### PR TITLE
Add code of conduct to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,9 @@
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
+This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
+[code-of-conduct]: http://todogroup.org/opencodeofconduct/#VisualStudio/opensource@github.com
+
 ## Submitting a pull request
 
 0. [Fork][] and clone the repository.


### PR DESCRIPTION
We are adopting the [Open Code of Conduct](http://todogroup.org/opencodeofconduct) for all @github projects. This adds it to the contributing guidelines. Let me know if you have any questions or concerns.

/cc @shana 