### PR TITLE
Make sure we don't crash when VS's git service returns bogus data

### DIFF
--- a/src/GitHub.VisualStudio/Base/TeamExplorerServiceHolder.cs
+++ b/src/GitHub.VisualStudio/Base/TeamExplorerServiceHolder.cs
@@ -125,7 +125,19 @@ namespace GitHub.VisualStudio.Base
             {
                 GitService = GitService ?? ServiceProvider.GetService<IGitExt>();
                 if (ActiveRepo == null)
-                    ActiveRepo = await System.Threading.Tasks.Task.Run(() => GitService.ActiveRepositories.FirstOrDefault());
+                    ActiveRepo = await System.Threading.Tasks.Task.Run(() =>
+                    {
+                        var repos = GitService?.ActiveRepositories;
+                        // Looks like this might return null after a while, for some unknown reason
+                        // if it does, let's refresh the GitService instance in case something got wonky
+                        // and try again. See issue #23
+                        if (repos == null)
+                        {
+                            GitService = ServiceProvider?.GetService<IGitExt>();
+                            repos = GitService?.ActiveRepositories;
+                        }
+                        return repos?.FirstOrDefault();
+                    });
             }
             else
                 ActiveRepo = null;


### PR DESCRIPTION
Fixes #23

I'm going on a bit of a hunch because I can't repro the crash, but the stacktrace clearly shows it's line 128 and there's only two accesses that can be throwing there, so protecting them both.