### PR TITLE
Fix regression. ActiveRepoUri is always http(s)

### DIFF
--- a/src/GitHub.Exports/Primitives/UriString.cs
+++ b/src/GitHub.Exports/Primitives/UriString.cs
@@ -51,7 +51,7 @@ namespace GitHub.Primitives
             }
         }
 
-        static UriString ToUriString(Uri uri)
+        public static UriString ToUriString(Uri uri)
         {
             return uri == null ? null : new UriString(uri.ToString());
         }

--- a/src/GitHub.Exports/Services/Services.cs
+++ b/src/GitHub.Exports/Services/Services.cs
@@ -116,7 +116,7 @@ namespace GitHub.VisualStudio
             }
         }
 
-        public static Uri GetRepoUrlFromSolution(IVsSolution solution)
+        public static UriString GetRepoUrlFromSolution(IVsSolution solution)
         {
             string solutionDir, solutionFile, userFile;
             if (!ErrorHandler.Succeeded(solution.GetSolutionInfo(out solutionDir, out solutionFile, out userFile)))
@@ -128,7 +128,7 @@ namespace GitHub.VisualStudio
                 return null;
             using (var repo = new Repository(repoPath))
             {
-                return GetUriFromRepository(repo)?.ToRepositoryUrl();
+                return repo.GetUri();
             }
         }
 
@@ -145,7 +145,12 @@ namespace GitHub.VisualStudio
             return new Repository(repoPath);
         }
 
-        public static UriString GetUriFromRepository(Repository repo)
+        public static UriString GetUri(this Repository repo)
+        {
+            return UriString.ToUriString(GetUriFromRepository(repo)?.ToRepositoryUrl());
+        }
+
+        static UriString GetUriFromRepository(Repository repo)
         {
             return repo
                 ?.Network

--- a/src/GitHub.VisualStudio/Base/TeamExplorerItemBase.cs
+++ b/src/GitHub.VisualStudio/Base/TeamExplorerItemBase.cs
@@ -48,8 +48,8 @@ namespace GitHub.VisualStudio.Base
             if (repo != null)
             {
                 var gitRepo = repo.GetRepoFromIGit();
-                var uri = Services.GetUriFromRepository(gitRepo);
-                var name = uri.RepositoryName;
+                var uri = gitRepo?.GetUri();
+                var name = uri?.RepositoryName;
                 if (name != null)
                 {
                     ActiveRepoUri = uri;


### PR DESCRIPTION
PR #21 broke things, the ActiveRepoUri needs to always be http(s). Fixicate.