### PR TITLE
Better login failed error tooltip

### DIFF
--- a/src/GitHub.App/ViewModels/LoginTabViewModel.cs
+++ b/src/GitHub.App/ViewModels/LoginTabViewModel.cs
@@ -13,6 +13,7 @@ using GitHub.Services;
 using GitHub.Validation;
 using NLog;
 using NullGuard;
+using Octokit;
 using ReactiveUI;
 
 namespace GitHub.ViewModels
@@ -72,13 +73,20 @@ namespace GitHub.ViewModels
                 return Observable.Return(Unit.Default);
             });
         }
-        protected IRepositoryHosts RepositoryHosts { get; private set; }
+        protected IRepositoryHosts RepositoryHosts { get; }
         protected abstract Uri BaseUri { get; }
-        public IReactiveCommand<Unit> SignUp { get; private set; }
+        public IReactiveCommand<Unit> SignUp { get; }
 
-        public IReactiveCommand<AuthenticationResult> Login { get; private set; }
-        public IReactiveCommand<Unit> Reset { get; private set; }
-        public IReactiveCommand<Unit> NavigateForgotPassword { get; private set; }
+        public IReactiveCommand<AuthenticationResult> Login { get; }
+        public IReactiveCommand<Unit> Reset { get; }
+        public IReactiveCommand<Unit> NavigateForgotPassword { get; }
+
+        string loginFailedMessage = "Check your username and password, then try again";
+        public string LoginFailedMessage
+        {
+            get { return loginFailedMessage; }
+            set { this.RaiseAndSetIfChanged(ref loginFailedMessage, value); }
+        }
 
         string usernameOrEmail;
         [AllowNull]

--- a/src/GitHub.App/ViewModels/LoginTabViewModel.cs
+++ b/src/GitHub.App/ViewModels/LoginTabViewModel.cs
@@ -13,7 +13,6 @@ using GitHub.Services;
 using GitHub.Validation;
 using NLog;
 using NullGuard;
-using Octokit;
 using ReactiveUI;
 
 namespace GitHub.ViewModels
@@ -46,7 +45,7 @@ namespace GitHub.ViewModels
 
                 log.Info(string.Format(CultureInfo.InvariantCulture, "Error logging into '{0}' as '{1}'", BaseUri,
                     UsernameOrEmail), ex);
-                if (ex is ForbiddenException)
+                if (ex is Octokit.ForbiddenException)
                 {
                     ShowLogInFailedError = true;
                     LoginFailedMessage = "Make sure to use your password and not a Personal Access token to log in.";

--- a/src/GitHub.App/ViewModels/LoginTabViewModel.cs
+++ b/src/GitHub.App/ViewModels/LoginTabViewModel.cs
@@ -41,9 +41,17 @@ namespace GitHub.ViewModels
 
             Login.ThrownExceptions.Subscribe(ex =>
             {
-                if (!ex.IsCriticalException())
+                if (ex.IsCriticalException()) return;
+
+                log.Info(string.Format(CultureInfo.InvariantCulture, "Error logging into '{0}' as '{1}'", BaseUri,
+                    UsernameOrEmail), ex);
+                if (ex is ForbiddenException)
                 {
-                    log.Info(string.Format(CultureInfo.InvariantCulture, "Error logging into '{0}' as '{1}'", BaseUri, UsernameOrEmail), ex);
+                    ShowLogInFailedError = true;
+                    LoginFailedMessage = "Make sure to use your password and not a Personal Access token to log in.";
+                }
+                else
+                {
                     ShowConnectingToHostFailed = true;
                 }
             });

--- a/src/GitHub.App/ViewModels/LoginToGitHubForEnterpriseViewModel.cs
+++ b/src/GitHub.App/ViewModels/LoginToGitHubForEnterpriseViewModel.cs
@@ -21,7 +21,7 @@ namespace GitHub.ViewModels
         [ImportingConstructor]
         public LoginToGitHubForEnterpriseViewModel(IRepositoryHosts hosts, IVisualStudioBrowser browser) : base(hosts, browser)
         {
-            enterpriseUrlValidator = ReactivePropertyValidator.For(this, x => x.EnterpriseUrl)
+            EnterpriseUrlValidator = ReactivePropertyValidator.For(this, x => x.EnterpriseUrl)
                 .IfNullOrEmpty("Please enter an Enterprise URL")
                 .IfNotUri("Please enter a valid Enterprise URL")
                 .IfGitHubDotComHost("Not an Enterprise server. Please enter an Enterprise URL");
@@ -55,24 +55,13 @@ namespace GitHub.ViewModels
             set { this.RaiseAndSetIfChanged(ref enterpriseUrl, value); }
         }
 
-        readonly ReactivePropertyValidator enterpriseUrlValidator;
-        public ReactivePropertyValidator EnterpriseUrlValidator
-        {
-            get { return enterpriseUrlValidator; }
-        }
+        public ReactivePropertyValidator EnterpriseUrlValidator { get; }
 
-        protected override Uri BaseUri
-        {
-            get
-            {
-                return new Uri(EnterpriseUrl);
-            }
-        }
+        protected override Uri BaseUri => new Uri(EnterpriseUrl);
 
         public IReactiveCommand<Unit> NavigateLearnMore
         {
             get;
-            private set;
         }
 
         protected override async Task ResetValidation()

--- a/src/GitHub.App/ViewModels/LoginToGitHubViewModel.cs
+++ b/src/GitHub.App/ViewModels/LoginToGitHubViewModel.cs
@@ -15,13 +15,11 @@ namespace GitHub.ViewModels
     [PartCreationPolicy(CreationPolicy.NonShared)]
     public class LoginToGitHubViewModel : LoginTabViewModel, ILoginToGitHubViewModel
     {
-        readonly Uri baseUri;
-
         [ImportingConstructor]
         public LoginToGitHubViewModel(IRepositoryHosts repositoryHosts, IVisualStudioBrowser browser)
             : base(repositoryHosts, browser)
         {
-            baseUri = HostAddress.GitHubDotComHostAddress.WebUri;
+            BaseUri = HostAddress.GitHubDotComHostAddress.WebUri;
 
             NavigatePricing = ReactiveCommand.CreateAsyncObservable(_ =>
             {
@@ -31,16 +29,13 @@ namespace GitHub.ViewModels
             });
         }
 
-        public IReactiveCommand<Unit> NavigatePricing { get; private set; }
+        public IReactiveCommand<Unit> NavigatePricing { get; }
 
-        protected override Uri BaseUri
-            {
-                get { return baseUri; }
-            }
+        protected override Uri BaseUri { get; }
 
-            protected override IObservable<AuthenticationResult> LogIn(object args)
-            {
-                return LogInToHost(HostAddress.GitHubDotComHostAddress);
-            }
+        protected override IObservable<AuthenticationResult> LogIn(object args)
+        {
+            return LogInToHost(HostAddress.GitHubDotComHostAddress);
         }
+    }
 }

--- a/src/GitHub.Exports.Reactive/ViewModels/ILoginToHostViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/ILoginToHostViewModel.cs
@@ -60,6 +60,11 @@ namespace GitHub.ViewModels
         bool ShowLogInFailedError { get; }
 
         /// <summary>
+        /// The message to show if login failed.
+        /// </summary>
+        string LoginFailedMessage { get; }
+
+        /// <summary>
         /// Gets a command which, when invoked, resets all properties 
         /// and validators.
         /// </summary>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/LoginControl.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/LoginControl.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Reactive.Linq;
 using System.Windows;
 using System.Windows.Input;
@@ -63,6 +62,7 @@ namespace GitHub.VisualStudio.UI.Views.Controls
             d(this.OneWayBind(ViewModel, vm => vm.GitHubLogin.NavigatePricing, v => v.pricingLink.Command));
 
             d(this.OneWayBind(ViewModel, vm => vm.GitHubLogin.ShowLogInFailedError, v => v.dotComLoginFailedMessage.Visibility));
+            d(this.OneWayBind(ViewModel, vm => vm.GitHubLogin.LoginFailedMessage, v => v.dotComLoginFailedMessage.Message));
             d(this.OneWayBind(ViewModel, vm => vm.GitHubLogin.ShowConnectingToHostFailed, v => v.dotComConnectionFailedMessage.Visibility));
         }
 
@@ -86,6 +86,7 @@ namespace GitHub.VisualStudio.UI.Views.Controls
             d(this.OneWayBind(ViewModel, vm => vm.EnterpriseLogin.NavigateLearnMore, v => v.learnMoreLink.Command));
 
             d(this.OneWayBind(ViewModel, vm => vm.EnterpriseLogin.ShowLogInFailedError, v => v.enterpriseLoginFailedMessage.Visibility));
+            d(this.OneWayBind(ViewModel, vm => vm.EnterpriseLogin.LoginFailedMessage, v => v.enterpriseLoginFailedMessage.Message));
             d(this.OneWayBind(ViewModel, vm => vm.EnterpriseLogin.ShowConnectingToHostFailed, v => v.enterpriseConnectingFailedMessage.Visibility));
         }
 

--- a/src/UnitTests/Helpers/TestBaseClass.cs
+++ b/src/UnitTests/Helpers/TestBaseClass.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using EntryExitDecoratorInterfaces;
-using GitHub.VisualStudio;
+﻿using EntryExitDecoratorInterfaces;
 
 /// <summary>
 /// This base class will get its methods called by the most-derived


### PR DESCRIPTION
When the user provides a personal access token instead of their password, the API responds with a 403. We now show a more helpful tooltip.

Fixes #14

![831](https://cloud.githubusercontent.com/assets/19977/9122356/6003f8f2-3c3d-11e5-9765-1e980c059065.png)
