### PR TITLE
:art: Remove rendundant null check

### DIFF
--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -272,8 +272,7 @@ namespace GitHub.Controllers
 
                 Debug.WriteLine("Disposing ({0})", GetHashCode());
                 disposables.Dispose();
-                if (transition != null)
-                    transition.Dispose();
+                transition?.Dispose();
                 disposed = true;
             }
         }

--- a/src/GitHub.App/Models/RepositoryHost.cs
+++ b/src/GitHub.App/Models/RepositoryHost.cs
@@ -104,7 +104,7 @@ namespace GitHub.Models
             // in multiple places in the chain below:
             var saveAuthorizationToken = new Func<ApplicationAuthorization, IObservable<Unit>>(authorization =>
             {
-                var token = authorization != null ? authorization.Token : null;
+                var token = authorization?.Token;
                 if (string.IsNullOrWhiteSpace(token))
                     return Observable.Return(Unit.Default);
 

--- a/src/GitHub.App/Services/AvatarProvider.cs
+++ b/src/GitHub.App/Services/AvatarProvider.cs
@@ -67,7 +67,7 @@ namespace GitHub.Services
             
         public IObservable<Unit> InvalidateAvatar([AllowNull] IAvatarContainer apiAccount)
         {
-            return apiAccount == null || String.IsNullOrWhiteSpace(apiAccount.Login)
+            return String.IsNullOrWhiteSpace(apiAccount?.Login)
                 ? Observable.Return(Unit.Default)
                 : cache.Invalidate(apiAccount.Login);
         }

--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -18,10 +18,7 @@ namespace GitHub.Services
 
             return Observable.Defer(() =>
             {
-                if (repository.Head != null
-                    && repository.Head != null
-                    && repository.Head.Commits != null
-                    && repository.Head.Commits.Any())
+                if (repository.Head?.Commits != null && repository.Head.Commits.Any())
                 {
                     var remote = repository.Network.Remotes[remoteName];
                     repository.Network.Push(remote, "HEAD", @"refs/heads/" + branchName);

--- a/src/GitHub.App/Services/Translation.cs
+++ b/src/GitHub.App/Services/Translation.cs
@@ -67,12 +67,9 @@ namespace GitHub.Services
             string exceptionMessage = exception.Message;
 
             var apiException = exception as ApiValidationException;
-            if (apiException != null && apiException.ApiError != null && apiException.ApiError.Errors != null)
-            {
-                var error = apiException.ApiError.Errors.FirstOrDefault();
-                if (error != null)
-                    exceptionMessage = error.Message ?? exceptionMessage;
-            }
+            var error = apiException?.ApiError?.Errors?.FirstOrDefault();
+            if (error != null)
+                exceptionMessage = error.Message ?? exceptionMessage;
 
             if (Original == exceptionMessage) return new Tuple<Translation, string>(this, null);
 

--- a/src/GitHub.App/ViewModels/RepositoryPublishViewModel.cs
+++ b/src/GitHub.App/ViewModels/RepositoryPublishViewModel.cs
@@ -191,7 +191,7 @@ namespace GitHub.ViewModels
 
             this.WhenAny(x => x.SafeRepositoryNameWarningValidator.ValidationResult, x => x.Value)
                 .WhereNotNull() // When this is instantiated, it sends a null result.
-                .Select(result => result == null ? null : result.Message)
+                .Select(result => result?.Message)
                 .Subscribe(message =>
                 {
                     if (!string.IsNullOrEmpty(message))


### PR DESCRIPTION
In `GitClient.cs` we checked whether `repository.Head == null` twice in
a row. I wanted to remove this redundancy and just ended up using the
fun null propagation operator where we could.