### PR TITLE
workaround for checkbox not propagating changes to KeepPrivate property

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
@@ -31,11 +31,21 @@ namespace GitHub.VisualStudio.UI.Views.Controls
                 
                 d(this.Bind(ViewModel, vm => vm.Description, v => v.description.Text));
 
+                // BEGIN DANGER ZONE
+                //
+                // This replaces the default Bind behaviour as the Checkbox control
+                // does not raise an event here when it is hosted in the Team Explorer
+                // view.
+                //
+                // We've used this.Bind in other places (popups) so it's something
+                // we need to investigate further
+                //
                 d(Observable.FromEventPattern<RoutedEventArgs>(makePrivate, "Checked")
                     .Subscribe(_ => ViewModel.KeepPrivate = true));
-
                 d(Observable.FromEventPattern<RoutedEventArgs>(makePrivate, "Unchecked")
                     .Subscribe(_ => ViewModel.KeepPrivate = false));
+                // END DANGER ZONE
+
 
                 d(this.OneWayBind(ViewModel, vm => vm.CanKeepPrivate, v => v.makePrivate.IsEnabled));
 

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
@@ -31,6 +31,16 @@ namespace GitHub.VisualStudio.UI.Views.Controls
                 
                 d(this.Bind(ViewModel, vm => vm.Description, v => v.description.Text));
 
+                d(this.WhenAnyValue(x => x.ViewModel.KeepPrivate)
+                    .Subscribe(keepPrivate =>
+                    {
+                        // because we removed this.Bind, set this by hand
+                        if (keepPrivate != makePrivate.IsChecked)
+                        {
+                            makePrivate.IsChecked = keepPrivate;
+                        }
+                    }));
+
                 // BEGIN DANGER ZONE
                 //
                 // This replaces the default Bind behaviour as the Checkbox control

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
@@ -30,7 +30,13 @@ namespace GitHub.VisualStudio.UI.Views.Controls
                 d(this.Bind(ViewModel, vm => vm.RepositoryName, v => v.nameText.Text));
                 
                 d(this.Bind(ViewModel, vm => vm.Description, v => v.description.Text));
-                d(this.Bind(ViewModel, vm => vm.KeepPrivate, v => v.makePrivate.IsChecked));
+
+                d(Observable.FromEventPattern<RoutedEventArgs>(makePrivate, "Checked")
+                    .Subscribe(_ => ViewModel.KeepPrivate = true));
+
+                d(Observable.FromEventPattern<RoutedEventArgs>(makePrivate, "Unchecked")
+                    .Subscribe(_ => ViewModel.KeepPrivate = false));
+
                 d(this.OneWayBind(ViewModel, vm => vm.CanKeepPrivate, v => v.makePrivate.IsEnabled));
 
                 //d(this.OneWayBind(ViewModel, vm => vm.ShowUpgradeToMicroPlanWarning, v => v.upgradeToMicroPlanWarning.Visibility));


### PR DESCRIPTION
Proposed fix for #62 by observing the events directly

 - [x] still have to bind the property to the VM somehow.
 - [x] testing testing testing