### PR TITLE
Checkbox styling fix for #62

### DIFF
--- a/src/GitHub.VisualStudio/SharedDictionary.xaml
+++ b/src/GitHub.VisualStudio/SharedDictionary.xaml
@@ -10,25 +10,14 @@
 
   <Style x:Key="VSStyledButton" TargetType="{x:Type Button}" BasedOn="{StaticResource VsButtonStyleKey}">
   </Style>
-  <Style x:Key="VSStyledCheckBox" TargetType="{x:Type CheckBox}">
-    <Setter Property="Control.Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="{x:Type CheckBox}">
-          <CheckBox Foreground="{DynamicResource VsBrush.ToolWindowText}" Background="{DynamicResource VsBrush.ToolWindowBackground}">
-              <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource VsBrush.ToolWindowText}" Background="{DynamicResource VsBrush.ToolWindowBackground}">
-                <TextBlock.Inlines>
-                    <Run Text="{TemplateBinding Content}" />
-                </TextBlock.Inlines>
-              </TextBlock>
-            </CheckBox>
-            <ControlTemplate.Triggers>
-              <Trigger Property="UIElement.IsMouseOver" Value="true">
-                <Setter Property="Background" Value="{DynamicResource VsBrush.ToolWindowBackground}"/>
-              </Trigger>
-            </ControlTemplate.Triggers>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
+  <Style x:Key="VSStyledCheckBox" BasedOn="{StaticResource VsCheckBoxStyleKey}" TargetType="{x:Type CheckBox}">
+    <Setter Property="Foreground" Value="{DynamicResource VsBrush.ToolWindowText}" />
+    <Setter Property="Background" Value="{DynamicResource VsBrush.ToolWindowBackground}" />
+    <Style.Triggers>
+      <Trigger Property="UIElement.IsMouseOver" Value="true">
+        <Setter Property="Background" Value="{DynamicResource VsBrush.ToolWindowBackground}"/>
+      </Trigger>
+    </Style.Triggers>
   </Style>
   <Style x:Key="VSStyledComboBox" TargetType="{x:Type ComboBox}" BasedOn="{StaticResource VsComboBoxStyleKey}">
   </Style>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml
@@ -123,7 +123,24 @@
 
         <CheckBox x:Name="makePrivate"
                   Margin="0,8,0,0"
-                  Style="{StaticResource VSStyledCheckBox}">Private Repository</CheckBox>
+                  Style="{StaticResource VSStyledCheckBox}">
+          <TextBlock TextWrapping="Wrap"
+                     Foreground="{DynamicResource VsBrush.ToolWindowText}"
+                     Background="{DynamicResource VsBrush.ToolWindowBackground}">
+            <TextBlock.Resources>
+              <Style TargetType="{x:Type TextBlock}">
+                <Style.Triggers>
+                  <Trigger Property="IsEnabled" Value="False">
+                    <Setter Property="Opacity" Value="0.5" />
+                  </Trigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Resources>
+            <TextBlock.Inlines>
+              <Run>Private Repository</Run>
+            </TextBlock.Inlines>
+          </TextBlock>
+        </CheckBox>
         
         <Label x:Name="upgradeToMicroPlanWarning" HorizontalAlignment="Left" Visibility="Collapsed">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
@@ -30,33 +30,7 @@ namespace GitHub.VisualStudio.UI.Views.Controls
                 d(this.Bind(ViewModel, vm => vm.RepositoryName, v => v.nameText.Text));
                 
                 d(this.Bind(ViewModel, vm => vm.Description, v => v.description.Text));
-
-                d(this.WhenAnyValue(x => x.ViewModel.KeepPrivate)
-                    .Subscribe(keepPrivate =>
-                    {
-                        // because we removed this.Bind, set this by hand
-                        if (keepPrivate != makePrivate.IsChecked)
-                        {
-                            makePrivate.IsChecked = keepPrivate;
-                        }
-                    }));
-
-                // BEGIN DANGER ZONE
-                //
-                // This replaces the default Bind behaviour as the Checkbox control
-                // does not raise an event here when it is hosted in the Team Explorer
-                // view.
-                //
-                // We've used this.Bind in other places (popups) so it's something
-                // we need to investigate further
-                //
-                d(Observable.FromEventPattern<RoutedEventArgs>(makePrivate, "Checked")
-                    .Subscribe(_ => ViewModel.KeepPrivate = true));
-                d(Observable.FromEventPattern<RoutedEventArgs>(makePrivate, "Unchecked")
-                    .Subscribe(_ => ViewModel.KeepPrivate = false));
-                // END DANGER ZONE
-
-
+                d(this.Bind(ViewModel, vm => vm.KeepPrivate, v => v.makePrivate.IsChecked));
                 d(this.OneWayBind(ViewModel, vm => vm.CanKeepPrivate, v => v.makePrivate.IsEnabled));
 
                 //d(this.OneWayBind(ViewModel, vm => vm.ShowUpgradeToMicroPlanWarning, v => v.upgradeToMicroPlanWarning.Visibility));


### PR DESCRIPTION
Fixes #62

This fixes the checkbox styling so it still matches Team Explorer but doesn't break our reactive bindings.

The previous style was using an inner checkbox for the rendering, and when reactiveui binds the view to the viewmodel, it likely looks for changed properties in the RoutedEventArgs Source or possibly the sender object that goes along with the event, and both of these represent the outer checkbox, which is not the originator of the Checked event, so it doesn't actually have the IsChecked property set.

This caused the UI to appear correct (inner checkbox is set), but the binding to not pick up the change (outer checkbox not set).