### PR TITLE
Fixes to the repo list in the connect page

### DIFF
--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -236,6 +236,14 @@ namespace GitHub.Controllers
                     .IsLoggedIn(hosts)
                     .Do(loggedin =>
                     {
+                        if (!loggedin && currentFlow != UIControllerFlow.Authentication)
+                        {
+                            connectionManager.Connections.CollectionChanged += (s, e) => {
+                                if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add)
+                                    uiProvider.AddService(typeof(IConnection), e.NewItems[0]);
+                            };
+                        }
+
                         machine.Configure(UIViewType.None)
                             .Permit(Trigger.Auth, UIViewType.Login)
                             .PermitIf(Trigger.Create, UIViewType.Create, () => loggedin)

--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Windows;
 using System.Windows.Controls;
 using GitHub.Authentication;
 using GitHub.Exports;
@@ -15,8 +17,6 @@ using GitHub.ViewModels;
 using NullGuard;
 using ReactiveUI;
 using Stateless;
-using System.Windows;
-using System.Reactive.Concurrency;
 
 namespace GitHub.Controllers
 {
@@ -265,10 +265,7 @@ namespace GitHub.Controllers
         public void Stop()
         {
             Debug.WriteLine("Stop ({0})", GetHashCode());
-            if (machine.IsInState(UIViewType.End))
-                Fire(Trigger.Next);
-            else
-                Fire(Trigger.Cancel);
+            Fire(machine.IsInState(UIViewType.End) ? Trigger.Next : Trigger.Cancel);
         }
 
         bool disposed; // To detect redundant calls
@@ -291,6 +288,6 @@ namespace GitHub.Controllers
             GC.SuppressFinalize(this);
         }
 
-        public bool IsStopped { get { return machine.IsInState(UIViewType.Finished); } }
+        public bool IsStopped => machine.IsInState(UIViewType.Finished);
     }
 }

--- a/src/GitHub.Exports/Exports/ExportMetadata.cs
+++ b/src/GitHub.Exports/Exports/ExportMetadata.cs
@@ -5,6 +5,7 @@ using GitHub.ViewModels;
 using System.Windows.Controls;
 using System.Linq;
 using System.Diagnostics;
+using System.Reflection;
 
 namespace GitHub.Exports {
 
@@ -50,8 +51,14 @@ namespace GitHub.Exports {
     {
         public static bool IsViewType(this UserControl c, UIViewType type)
         {
-            Debug.Assert(c.GetType().GetCustomAttributesData().Any(x => x.AttributeType == typeof(ExportViewAttribute) && x.NamedArguments.Any() && x.NamedArguments[0].TypedValue.ArgumentType == typeof(UIViewType)), "Someone broke the ExportViewAttribute contract...");
-            return c.GetType().GetCustomAttributesData().Any(x => x.AttributeType == typeof(ExportViewAttribute) && (UIViewType)x.NamedArguments[0].TypedValue.Value == type);
+            return c.GetType().GetCustomAttributesData().Any(attr => IsViewType(attr, type));
+        }
+
+        private static bool IsViewType(CustomAttributeData attributeData, UIViewType viewType)
+        {
+            Debug.Assert(attributeData.NamedArguments != null);
+            return attributeData.AttributeType == typeof(ExportViewAttribute)
+                && (UIViewType)attributeData.NamedArguments[0].TypedValue.Value == viewType;
         }
     }
 }

--- a/src/GitHub.Exports/Exports/ExportMetadata.cs
+++ b/src/GitHub.Exports/Exports/ExportMetadata.cs
@@ -4,6 +4,7 @@ using GitHub.UI;
 using GitHub.ViewModels;
 using System.Windows.Controls;
 using System.Linq;
+using System.Diagnostics;
 
 namespace GitHub.Exports {
 
@@ -49,7 +50,8 @@ namespace GitHub.Exports {
     {
         public static bool IsViewType(this UserControl c, UIViewType type)
         {
-            return c.GetType().GetCustomAttributesData().Any(x => x.AttributeType.Equals(typeof(ExportViewAttribute)) && (UIViewType)x.NamedArguments[0].TypedValue.Value == type);
+            Debug.Assert(c.GetType().GetCustomAttributesData().Any(x => x.AttributeType == typeof(ExportViewAttribute) && x.NamedArguments.Any() && x.NamedArguments[0].TypedValue.ArgumentType == typeof(UIViewType)), "Someone broke the ExportViewAttribute contract...");
+            return c.GetType().GetCustomAttributesData().Any(x => x.AttributeType == typeof(ExportViewAttribute) && (UIViewType)x.NamedArguments[0].TypedValue.Value == type);
         }
     }
 }

--- a/src/GitHub.Exports/Exports/ExportMetadata.cs
+++ b/src/GitHub.Exports/Exports/ExportMetadata.cs
@@ -2,6 +2,8 @@ using System;
 using System.ComponentModel.Composition;
 using GitHub.UI;
 using GitHub.ViewModels;
+using System.Windows.Controls;
+using System.Linq;
 
 namespace GitHub.Exports {
 
@@ -41,5 +43,13 @@ namespace GitHub.Exports {
     public interface IViewModelMetadata
     {
         UIViewType ViewType { get; }
+    }
+
+    public static class ExportViewAttributeExtensions
+    {
+        public static bool IsViewType(this UserControl c, UIViewType type)
+        {
+            return c.GetType().GetCustomAttributesData().Any(x => x.AttributeType.Equals(typeof(ExportViewAttribute)) && (UIViewType)x.NamedArguments[0].TypedValue.Value == type);
+        }
     }
 }

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -101,6 +101,7 @@
     </None>
     <Compile Include="Helpers\INotifyPropertySource.cs" />
     <Compile Include="Helpers\PropertyNotifierExtensions.cs" />
+    <Compile Include="Helpers\SimpleRepositoryModelExtensions.cs" />
     <Compile Include="Info\ApplicationInfo.cs" />
     <Compile Include="Models\IAccount.cs" />
     <Compile Include="Models\IConnectionManager.cs" />

--- a/src/GitHub.Exports/Helpers/SimpleRepositoryModelExtensions.cs
+++ b/src/GitHub.Exports/Helpers/SimpleRepositoryModelExtensions.cs
@@ -1,0 +1,25 @@
+﻿using GitHub.Models;
+using System;
+using System.Linq;
+using System.IO;
+
+namespace GitHub.Extensions
+{
+    using VisualStudio;
+
+    public static class SimpleRepositoryModelExtensions
+    {
+        public static bool HasCommits(this ISimpleRepositoryModel repository)
+        {
+            var repo = Services.GetRepoFromPath(repository.LocalPath);
+            return repo?.Commits.Count() > 0;
+        }
+        public static bool HasContent(this ISimpleRepositoryModel repository)
+        {
+            var dir = new DirectoryInfo(repository.LocalPath);
+            return dir.EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly)
+                      .Any(x => ((x.Attributes.HasFlag(FileAttributes.Directory) || x.Attributes.HasFlag(FileAttributes.Normal)) &&
+                                !x.Name.StartsWith(".", StringComparison.Ordinal) && !x.Name.StartsWith("readme", StringComparison.Ordinal)));
+        }
+    }
+}

--- a/src/GitHub.Exports/Helpers/SimpleRepositoryModelExtensions.cs
+++ b/src/GitHub.Exports/Helpers/SimpleRepositoryModelExtensions.cs
@@ -19,7 +19,7 @@ namespace GitHub.Extensions
             var dir = new DirectoryInfo(repository.LocalPath);
             return dir.EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly)
                       .Any(x => ((x.Attributes.HasFlag(FileAttributes.Directory) || x.Attributes.HasFlag(FileAttributes.Normal)) &&
-                                !x.Name.StartsWith(".", StringComparison.Ordinal) && !x.Name.StartsWith("readme", StringComparison.Ordinal)));
+                                !x.Name.StartsWith(".", StringComparison.Ordinal) && !x.Name.StartsWith("readme", StringComparison.OrdinalIgnoreCase)));
         }
     }
 }

--- a/src/GitHub.Exports/Helpers/SimpleRepositoryModelExtensions.cs
+++ b/src/GitHub.Exports/Helpers/SimpleRepositoryModelExtensions.cs
@@ -12,7 +12,7 @@ namespace GitHub.Extensions
         public static bool HasCommits(this ISimpleRepositoryModel repository)
         {
             var repo = Services.GetRepoFromPath(repository.LocalPath);
-            return repo?.Commits.Count() > 0;
+            return repo?.Commits.Any() ?? false;
         }
         public static bool MightContainSolution(this ISimpleRepositoryModel repository)
         {

--- a/src/GitHub.Exports/Helpers/SimpleRepositoryModelExtensions.cs
+++ b/src/GitHub.Exports/Helpers/SimpleRepositoryModelExtensions.cs
@@ -14,7 +14,7 @@ namespace GitHub.Extensions
             var repo = Services.GetRepoFromPath(repository.LocalPath);
             return repo?.Commits.Count() > 0;
         }
-        public static bool HasContent(this ISimpleRepositoryModel repository)
+        public static bool MightContainSolution(this ISimpleRepositoryModel repository)
         {
             var dir = new DirectoryInfo(repository.LocalPath);
             return dir.EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly)

--- a/src/GitHub.Exports/Services/IUIProvider.cs
+++ b/src/GitHub.Exports/Services/IUIProvider.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.Composition.Hosting;
 using GitHub.Models;
 using GitHub.UI;
+using System.Windows.Controls;
 
 namespace GitHub.Services
 {
@@ -20,7 +21,7 @@ namespace GitHub.Services
         void AddService(Type t, object instance);
         void RemoveService(Type t);
 
-        IObservable<object> SetupUI(UIControllerFlow controllerFlow, IConnection connection);
+        IObservable<UserControl> SetupUI(UIControllerFlow controllerFlow, IConnection connection);
         void RunUI();
         void RunUI(UIControllerFlow controllerFlow, IConnection connection);
     }

--- a/src/GitHub.Exports/Services/Services.cs
+++ b/src/GitHub.Exports/Services/Services.cs
@@ -180,5 +180,11 @@ namespace GitHub.VisualStudio
         {
             return repoInfo.GetRepoFromIGit()?.GetUri();
         }
+
+        public static bool HasCommits(this ISimpleRepositoryModel repository)
+        {
+            var repo = GetRepoFromPath(repository.LocalPath);
+            return repo?.Commits.Count() > 0;
+        }
     }
 }

--- a/src/GitHub.Exports/Services/Services.cs
+++ b/src/GitHub.Exports/Services/Services.cs
@@ -8,11 +8,8 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
-using GitHub.Models;
 using GitHub.Info;
-using GitHub.Extensions;
 using GitHub.Primitives;
 
 namespace GitHub.VisualStudio
@@ -179,12 +176,6 @@ namespace GitHub.VisualStudio
         public static UriString GetUriFromRepository(this IGitRepositoryInfo repoInfo)
         {
             return repoInfo.GetRepoFromIGit()?.GetUri();
-        }
-
-        public static bool HasCommits(this ISimpleRepositoryModel repository)
-        {
-            var repo = GetRepoFromPath(repository.LocalPath);
-            return repo?.Commits.Count() > 0;
         }
     }
 }

--- a/src/GitHub.Exports/Services/VSServices.cs
+++ b/src/GitHub.Exports/Services/VSServices.cs
@@ -1,18 +1,18 @@
-﻿using Microsoft.TeamFoundation.Git.Controls.Extensibility;
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
 using System.Linq;
+using System.Windows.Input;
 using GitHub.Extensions;
-using Microsoft.Win32;
-using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
+using GitHub.Models;
 using GitHub.VisualStudio;
 using Microsoft.TeamFoundation.Controls;
+using Microsoft.TeamFoundation.Git.Controls.Extensibility;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
-using System.Collections.Generic;
-using GitHub.Models;
-using System.Windows.Input;
+using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
+using Microsoft.Win32;
 
 namespace GitHub.Services
 {
@@ -181,41 +181,36 @@ namespace GitHub.Services
         public void ShowMessage(string message)
         {
             var manager = serviceProvider.TryGetService<ITeamExplorer>() as ITeamExplorerNotificationManager;
-            if (manager != null)
-                manager.ShowNotification(message, NotificationType.Information, NotificationFlags.None, null, default(Guid));
+            manager?.ShowNotification(message, NotificationType.Information, NotificationFlags.None, null, default(Guid));
         }
 
         public void ShowMessage(string message, ICommand command)
         {
             var manager = serviceProvider.TryGetService<ITeamExplorer>() as ITeamExplorerNotificationManager;
-            if (manager != null)
-                manager.ShowNotification(message, NotificationType.Information, NotificationFlags.None, command, default(Guid));
+            manager?.ShowNotification(message, NotificationType.Information, NotificationFlags.None, command, default(Guid));
         }
 
         public void ShowWarning(string message)
         {
             var manager = serviceProvider.TryGetService<ITeamExplorer>() as ITeamExplorerNotificationManager;
-            if (manager != null)
-                manager.ShowNotification(message, NotificationType.Warning, NotificationFlags.None, null, default(Guid));
+            manager?.ShowNotification(message, NotificationType.Warning, NotificationFlags.None, null, default(Guid));
         }
 
         public void ShowError(string message)
         {
             var manager = serviceProvider.TryGetService<ITeamExplorer>() as ITeamExplorerNotificationManager;
-            if (manager != null)
-                manager.ShowNotification(message, NotificationType.Error, NotificationFlags.None, null, default(Guid));
+            manager?.ShowNotification(message, NotificationType.Error, NotificationFlags.None, null, default(Guid));
         }
 
         public void ClearNotifications()
         {
             var manager = serviceProvider.TryGetService<ITeamExplorer>() as ITeamExplorerNotificationManager;
-            if (manager != null)
-                manager.ClearNotifications();
-		}
+            manager?.ClearNotifications();
+        }
 
         public void ActivityLogMessage(string message)
         {
-            var log = VisualStudio.Services.GetActivityLog(serviceProvider);
+            var log = serviceProvider.GetActivityLog();
             if (log != null)
             {
                 if (!ErrorHandler.Succeeded(log.LogEntry((UInt32)__ACTIVITYLOG_ENTRYTYPE.ALE_INFORMATION,
@@ -226,7 +221,7 @@ namespace GitHub.Services
 
         public void ActivityLogError(string message)
         {
-            var log = VisualStudio.Services.GetActivityLog(serviceProvider);
+            var log = serviceProvider.GetActivityLog();
             if (log != null)
             {
 
@@ -238,7 +233,7 @@ namespace GitHub.Services
 
         public void ActivityLogWarning(string message)
         {
-            var log = VisualStudio.Services.GetActivityLog(serviceProvider);
+            var log = serviceProvider.GetActivityLog();
             if (log != null)
             {
                 if (!ErrorHandler.Succeeded(log.LogEntry((UInt32)__ACTIVITYLOG_ENTRYTYPE.ALE_WARNING,

--- a/src/GitHub.VisualStudio/Base/TeamExplorerBase.cs
+++ b/src/GitHub.VisualStudio/Base/TeamExplorerBase.cs
@@ -44,12 +44,12 @@ namespace GitHub.VisualStudio.Base
             return GetService<T>() as Ret;
         }
 
-        protected void OpenInBrowser(Lazy<IVisualStudioBrowser> browser, Uri uri)
+        protected static void OpenInBrowser(Lazy<IVisualStudioBrowser> browser, Uri uri)
         {
             OpenInBrowser(browser.Value, uri);
         }
 
-        protected void OpenInBrowser(IVisualStudioBrowser browser, Uri uri)
+        protected static void OpenInBrowser(IVisualStudioBrowser browser, Uri uri)
         {
             Debug.Assert(browser != null, "Could not create a browser helper instance.");
             browser?.OpenUrl(uri);

--- a/src/GitHub.VisualStudio/Base/TeamExplorerBase.cs
+++ b/src/GitHub.VisualStudio/Base/TeamExplorerBase.cs
@@ -44,11 +44,15 @@ namespace GitHub.VisualStudio.Base
             return GetService<T>() as Ret;
         }
 
-        protected virtual void OpenInBrowser(Lazy<IVisualStudioBrowser> browser, Uri uri)
+        protected void OpenInBrowser(Lazy<IVisualStudioBrowser> browser, Uri uri)
         {
-            var b = browser.Value;
-            Debug.Assert(b != null, "Could not create a browser helper instance.");
-            b?.OpenUrl(uri);
+            OpenInBrowser(browser.Value, uri);
+        }
+
+        protected void OpenInBrowser(IVisualStudioBrowser browser, Uri uri)
+        {
+            Debug.Assert(browser != null, "Could not create a browser helper instance.");
+            browser?.OpenUrl(uri);
         }
     }
 }

--- a/src/GitHub.VisualStudio/Helpers/Constants.cs
+++ b/src/GitHub.VisualStudio/Helpers/Constants.cs
@@ -9,7 +9,7 @@
 
         public const string Notification_RepoCreated = "[{0}](u:{1}) has been successfully created.";
         public const string Notification_RepoCloned = "[{0}](u:{1}) has been successfully cloned.";
-        public const string Notification_CreateNewProject = "[Create a new project or solution](c:{0})";
-        public const string Notification_OpenProject = "[Open an existing project or solution](o:{0})";
+        public const string Notification_CreateNewProject = "[Create a new project or solution](c:{0}).";
+        public const string Notification_OpenProject = "[Open an existing project or solution](o:{0}).";
     }
 }

--- a/src/GitHub.VisualStudio/Helpers/Constants.cs
+++ b/src/GitHub.VisualStudio/Helpers/Constants.cs
@@ -1,10 +1,15 @@
 ﻿namespace GitHub.VisualStudio.Helpers
 {
-    public static class Constants
+    internal static class Constants
     {
         public const string NoAngleBracketsErrorMessage = "Failed to parse signature - Neither `name` nor `email` should contain angle brackets chars.";
         public const int MaxRepositoryNameLength = 100;
         public const int MaxDirectoryLength = 200; // Windows allows 248, but we need to allow room for subdirectories.
         public const int MaxFilePathLength = 260;
+
+        public const string Notification_RepoCreated = "[{0}](u:{1}) has been successfully created.";
+        public const string Notification_RepoCloned = "[{0}](u:{1}) has been successfully cloned.";
+        public const string Notification_CreateNewProject = "[Create a new project or solution](c:{0})";
+        public const string Notification_OpenProject = "[Open an existing project or solution](o:{0})";
     }
 }

--- a/src/GitHub.VisualStudio/Services/UIProvider.cs
+++ b/src/GitHub.VisualStudio/Services/UIProvider.cs
@@ -17,6 +17,7 @@ using NullGuard;
 using NLog;
 using System.Reactive.Linq;
 using GitHub.Infrastructure;
+using System.Windows.Controls;
 
 namespace GitHub.VisualStudio
 {
@@ -184,12 +185,12 @@ namespace GitHub.VisualStudio
         }
 
         UI.WindowController windowController;
-        public IObservable<object> SetupUI(UIControllerFlow controllerFlow, [AllowNull] IConnection connection)
+        public IObservable<UserControl> SetupUI(UIControllerFlow controllerFlow, [AllowNull] IConnection connection)
         {
             if (!Initialized)
             {
                 log.Error("ExportProvider is not initialized, cannot setup UI.");
-                return Observable.Return<object>(null);
+                return Observable.Return<UserControl>(null);
             }
 
             StopUI();

--- a/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
@@ -1,4 +1,11 @@
-﻿using GitHub.Api;
+﻿using System;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using GitHub.Api;
+using GitHub.Exports;
+using GitHub.Extensions;
 using GitHub.Models;
 using GitHub.Services;
 using GitHub.UI;
@@ -6,20 +13,10 @@ using GitHub.VisualStudio.Base;
 using GitHub.VisualStudio.Helpers;
 using GitHub.VisualStudio.UI.Views;
 using Microsoft.TeamFoundation.Controls;
-using System.Linq;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using GitHub.Extensions;
-using NullGuard;
-using Microsoft.VisualStudio;
-using System;
-using System.Windows.Data;
-using System.ComponentModel;
-using ReactiveUI;
-using GitHub.Exports;
-using System.Globalization;
 using Microsoft.TeamFoundation.MVVM;
-using GitHub.Primitives;
+using Microsoft.VisualStudio;
+using NullGuard;
+using ReactiveUI;
 
 namespace GitHub.VisualStudio.TeamExplorer.Connect
 {
@@ -109,10 +106,9 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                         Refresh(connectionManager.Connections[sectionIndex]);
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    if (connectionManager.Connections.Count <= sectionIndex)
-                        Refresh(null);
-                    else
-                        Refresh(connectionManager.Connections[sectionIndex]);
+                    Refresh(connectionManager.Connections.Count <= sectionIndex
+                        ? null
+                        : connectionManager.Connections[sectionIndex]);
                     break;
             }
         }
@@ -176,10 +172,9 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
         void UpdateConnection()
         {
-            if (connectionManager.Connections.Count > sectionIndex)
-                Refresh(connectionManager.Connections[sectionIndex]);
-            else
-                Refresh(SectionConnection);
+            Refresh(connectionManager.Connections.Count > sectionIndex
+                ? connectionManager.Connections[sectionIndex]
+                : SectionConnection);
         }
 
         void OnPropertyChange(object sender, PropertyChangedEventArgs e)
@@ -246,7 +241,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             vsservices.ClearNotifications();
             vsservices.ShowMessage(
                 msg,
-                new RelayCommand((o) =>
+                new RelayCommand(o =>
                 {
                     var str = o.ToString();
                     /* the prefix is the action to perform:

--- a/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
@@ -232,7 +232,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
         void HandleClonedRepo(ISimpleRepositoryModel newrepo)
         {
-            
             var msg = string.Format(CultureInfo.CurrentUICulture, Constants.Notification_RepoCloned, newrepo.Name, newrepo.CloneUrl);
             if (newrepo.HasCommits() && newrepo.HasContent())
                 msg += " " + string.Format(CultureInfo.CurrentUICulture, Constants.Notification_OpenProject, newrepo.LocalPath);

--- a/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
@@ -232,8 +232,9 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
         void HandleClonedRepo(ISimpleRepositoryModel newrepo)
         {
+            
             var msg = string.Format(CultureInfo.CurrentUICulture, Constants.Notification_RepoCloned, newrepo.Name, newrepo.CloneUrl);
-            if (newrepo.HasCommits())
+            if (newrepo.HasCommits() && newrepo.HasContent())
                 msg += " " + string.Format(CultureInfo.CurrentUICulture, Constants.Notification_OpenProject, newrepo.LocalPath);
             else
                 msg += " " + string.Format(CultureInfo.CurrentUICulture, Constants.Notification_CreateNewProject, newrepo.LocalPath);

--- a/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
@@ -344,6 +344,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             {
                 if (!disposed)
                 {
+                    connectionManager.Connections.CollectionChanged -= RefreshConnections;
                     if (Repositories != null)
                         Repositories.CollectionChanged -= UpdateRepositoryList;
                     disposed = true;

--- a/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
@@ -16,6 +16,7 @@ using System;
 using System.Windows.Data;
 using System.ComponentModel;
 using ReactiveUI;
+using GitHub.Exports;
 
 namespace GitHub.VisualStudio.TeamExplorer.Connect
 {
@@ -227,13 +228,11 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
         public void DoCreate()
         {
-            isCreating = true;
             StartFlow(UIControllerFlow.Create);
         }
 
         public void DoClone()
         {
-            isCloning = true;
             StartFlow(UIControllerFlow.Clone);
         }
 
@@ -272,7 +271,15 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
         {
             var uiProvider = ServiceProvider.GetExportedValue<IUIProvider>();
             uiProvider.GitServiceProvider = ServiceProvider;
-            uiProvider.RunUI(controllerFlow, SectionConnection);
+            var ret = uiProvider.SetupUI(controllerFlow, SectionConnection);
+            ret.Subscribe((c) =>
+            {
+                if (c.IsViewType(UIViewType.Clone))
+                    isCloning = true;
+                else if (c.IsViewType(UIViewType.Create))
+                    isCreating = true;
+            });
+            uiProvider.RunUI();
         }
 
         bool disposed;

--- a/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
@@ -233,7 +233,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
         void HandleClonedRepo(ISimpleRepositoryModel newrepo)
         {
             var msg = string.Format(CultureInfo.CurrentUICulture, Constants.Notification_RepoCloned, newrepo.Name, newrepo.CloneUrl);
-            if (newrepo.HasCommits() && newrepo.HasContent())
+            if (newrepo.HasCommits() && newrepo.MightContainSolution())
                 msg += " " + string.Format(CultureInfo.CurrentUICulture, Constants.Notification_OpenProject, newrepo.LocalPath);
             else
                 msg += " " + string.Format(CultureInfo.CurrentUICulture, Constants.Notification_CreateNewProject, newrepo.LocalPath);

--- a/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
@@ -327,7 +327,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             var uiProvider = ServiceProvider.GetExportedValue<IUIProvider>();
             uiProvider.GitServiceProvider = ServiceProvider;
             var ret = uiProvider.SetupUI(controllerFlow, SectionConnection);
-            ret.Subscribe((c) =>
+            ret.Subscribe(c =>
             {
                 if (c.IsViewType(UIViewType.Clone))
                     isCloning = true;

--- a/src/GitHub.VisualStudio/TeamExplorer/Sync/GitHubPublishSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Sync/GitHubPublishSection.cs
@@ -135,7 +135,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             disposable = uiflow;
             var ui = uiflow.Value;
             var creation = ui.SelectFlow(UIControllerFlow.Publish);
-            creation.Subscribe((c) =>
+            creation.Subscribe(c =>
             {
                 SectionContent = c;
                 c.DataContext = this;


### PR DESCRIPTION
Found a few bugs that needed fixing.

- Cloning or creating when logged out was throwing a NRE
- Cloning or creating when logged out would trigger multiple "Open Solution" dialogs.

I didn't like the open solution thing popping up automatically, so I changed the notifications to show links to the Open/Create project dialogs when the cloning/creating process is done.
Now it checks whether a cloned repo has commits and content (files or directories) to decide whether to link to the Create or the Open project dialog. It's not too smart, but it should work well for most cases.