### PR TITLE
[wip] Error handling from viewmodels to views

### DIFF
--- a/src/GitHub.Exports/UI/IView.cs
+++ b/src/GitHub.Exports/UI/IView.cs
@@ -8,5 +8,6 @@ namespace GitHub.UI
         IObservable<object> Done { get; }
         IObservable<object> Cancel { get; }
         IObservable<bool> IsBusy { get; }
+        IObservable<object> Error { get; }
     }
 }

--- a/src/GitHub.UI.Reactive/Controls/SimpleViewUserControl.cs
+++ b/src/GitHub.UI.Reactive/Controls/SimpleViewUserControl.cs
@@ -18,6 +18,7 @@ namespace GitHub.UI
     {
         readonly Subject<object> close = new Subject<object>();
         readonly Subject<object> cancel = new Subject<object>();
+        readonly Subject<object> error = new Subject<object>();
         readonly Subject<bool> isBusy = new Subject<bool>();
 
         public SimpleViewUserControl()
@@ -39,6 +40,8 @@ namespace GitHub.UI
 
         public IObservable<object> Cancel { get { return cancel; } }
 
+        public IObservable<object> Error { get { return error; } }
+
         public IObservable<bool> IsBusy{ get { return isBusy; } }
 
         protected void NotifyDone()
@@ -51,6 +54,12 @@ namespace GitHub.UI
         {
             cancel.OnNext(null);
             cancel.OnCompleted();
+        }
+
+        protected void NotifyError(string message)
+        {
+            error.OnNext(message);
+            error.OnCompleted();
         }
 
         protected void NotifyIsBusy(bool busy)
@@ -66,6 +75,7 @@ namespace GitHub.UI
                 if (disposed) return;
 
                 close.Dispose();
+                error.Dispose();
                 disposed = true;
             }
         }

--- a/src/GitHub.VisualStudio/TeamExplorer/Sync/GitHubPublishSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Sync/GitHubPublishSection.cs
@@ -52,7 +52,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             view.DataContext = this;
         }
 
-        async void RTMSetup()
+        async void Setup()
         {
             if (ActiveRepo != null && ActiveRepoUri == null)
             {
@@ -66,39 +66,23 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
                 IsVisible = false;
         }
 
-        async void PreRTMSetup()
-        {
-            if (ActiveRepo != null && ActiveRepoUri == null)
-            {
-                IsVisible = true;
-                loggedIn = await connectionManager.IsLoggedIn(hosts);
-                if (loggedIn)
-                    ShowPublish();
-                else
-                {
-                    ShowGetStarted = true;
-                    ShowSignup = true;
-                }
-            }
-            else
-                IsVisible = false;
-        }
-
         public override void Initialize(object sender, SectionInitializeEventArgs e)
         {
             base.Initialize(sender, e);
-            RTMSetup();
+            Setup();
         }
 
         protected override void RepoChanged()
         {
             base.RepoChanged();
-            RTMSetup();
+            Setup();
         }
 
         public async void Connect()
         {
             loggedIn = await connectionManager.IsLoggedIn(hosts);
+            // we run the login on a separate UI flow because the login
+            // dialog is a modal dialog while the publish dialog is inlined in Team Explorer
             if (loggedIn)
                 ShowPublish();
             else
@@ -130,7 +114,9 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
 
         void ShowPublish()
         {
+            // set the loading indicator while we prep the form
             IsBusy = true;
+
             var uiProvider = ServiceProvider.GetExportedValue<IUIProvider>();
             var factory = uiProvider.GetService<IExportFactoryProvider>();
             var uiflow = factory.UIControllerFactory.CreateExport();

--- a/src/GitHub.VisualStudio/TeamExplorer/Sync/GitHubPublishSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Sync/GitHubPublishSection.cs
@@ -13,6 +13,8 @@ using System.Reactive.Linq;
 using GitHub.Extensions;
 using GitHub.Api;
 using GitHub.VisualStudio.TeamExplorer;
+using System.Reactive.Disposables;
+using System.Windows.Controls;
 
 namespace GitHub.VisualStudio.TeamExplorer.Sync
 {
@@ -24,7 +26,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
 
         readonly Lazy<IVisualStudioBrowser> lazyBrowser;
         readonly IRepositoryHosts hosts;
-        IDisposable disposable;
+        readonly CompositeDisposable disposables = new CompositeDisposable();
         bool loggedIn;
 
         [ImportingConstructor]
@@ -132,7 +134,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             var uiProvider = ServiceProvider.GetExportedValue<IUIProvider>();
             var factory = uiProvider.GetService<IExportFactoryProvider>();
             var uiflow = factory.UIControllerFactory.CreateExport();
-            disposable = uiflow;
+            disposables.Add(uiflow);
             var ui = uiflow.Value;
             var creation = ui.SelectFlow(UIControllerFlow.Publish);
             creation.Subscribe(c =>
@@ -151,8 +153,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             {
                 if (!disposed)
                 {
-                    if (disposable != null)
-                        disposable.Dispose();
+                    disposables.Dispose();
                     disposed = true;
                 }
             }

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
@@ -42,10 +42,17 @@ namespace GitHub.VisualStudio.UI.Views.Controls
                 d(this.OneWayBind(ViewModel, vm => vm.IsPublishing, v => v.description.IsEnabled, x => x == false));
                 d(this.OneWayBind(ViewModel, vm => vm.IsPublishing, v => v.accountsComboBox.IsEnabled, x => x == false));
 
-                ViewModel.PublishRepository.Subscribe(_ => NotifyDone());
+                d(ViewModel.PublishRepository.Subscribe(_ => NotifyDone()));
+                d(ViewModel.PublishRepository.ThrownExceptions.Subscribe(ex =>
+                {
+                    var error = ex as UnhandledUserErrorException;
+                    if (error == null)
+                        NotifyError("Error publishing repository." + Environment.NewLine + ex.Message);
+                    else
+                        NotifyError((error.ReportedError.ErrorMessage + Environment.NewLine + error.ReportedError.ErrorCauseOrResolution).TrimEnd());
+                }));
 
-                d(this.WhenAny(x => x.ViewModel.IsPublishing, x => x.Value)
-                .Subscribe(x => NotifyIsBusy(x)));
+                d(this.WhenAny(x => x.ViewModel.IsPublishing, x => x.Value).Subscribe(x => NotifyIsBusy(x)));
 
                 nameText.Text = ViewModel.DefaultRepositoryName;
             });

--- a/src/UnitTests/GitHub.App/ViewModels/RepositoryPublishViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/RepositoryPublishViewModelTests.cs
@@ -339,10 +339,10 @@ public class RepositoryPublishViewModelTests
 
             vm.RepositoryName = "repo-name";
 
+            var obs = Substitute.For<IObserver<Exception>>();
+            vm.PublishRepository.ThrownExceptions.Subscribe(obs);
             await vm.PublishRepository.ExecuteAsync().Catch(Observable.Return(Unit.Default));
-
-            vsServices.Received().ShowMessage("Repository published successfully.");
-            vsServices.DidNotReceive().ShowError(Args.String);
+            obs.DidNotReceiveWithAnyArgs().OnNext(null);
         }
 
         [Fact]
@@ -358,10 +358,11 @@ public class RepositoryPublishViewModelTests
             var vm = Helpers.SetupConnectionsAndViewModel(hosts, repositoryPublishService, vsServices, cm);
             vm.RepositoryName = "repo-name";
 
+            var obs = Substitute.For<IObserver<Exception>>();
+            vm.PublishRepository.ThrownExceptions.Subscribe(obs);
             await vm.PublishRepository.ExecuteAsync().Catch(Observable.Return(Unit.Default));
-
-            vsServices.DidNotReceive().ShowMessage(Args.String);
-            vsServices.Received().ShowError("There is already a repository named 'repo-name' for the current account.");
+            obs.ReceivedWithAnyArgs().OnNext(null);
+            Assert.True(obs.ReceivedCalls().Any(x => ((UnhandledUserErrorException)x.GetArguments()[0]).Message == "There is already a repository named 'repo-name' for the current account."));
         }
 
         [Fact]
@@ -391,6 +392,7 @@ public class RepositoryPublishViewModelTests
 
             vm.RepositoryName = "repo-name";
 
+            vm.PublishRepository.ThrownExceptions.Subscribe();
             await vm.PublishRepository.ExecuteAsync().Catch(Observable.Return(Unit.Default));
 
             vm.SelectedConnection = conns.First(x => x != vm.SelectedConnection);
@@ -422,6 +424,7 @@ public class RepositoryPublishViewModelTests
 
             vm.RepositoryName = "repo-name";
 
+            vm.PublishRepository.ThrownExceptions.Subscribe();
             await vm.PublishRepository.ExecuteAsync().Catch(Observable.Return(Unit.Default));
 
             vm.SelectedAccount = accounts[1];


### PR DESCRIPTION
Adds a way to surface errors from the view model to the view so that view hosts can get to them. 

ViewModels are responsible for handling the UI on the view they control, but they shouldn't be handling UI for things outside of the view. In this case, we're showing errors in VS outside the view, and that should be handled by the section that is hosting the view.

This requires that errors be propagated from the viewmodel to the view and from there to the host via the IView interface, since hosts don't usually know what they're hosting.