### PR TITLE
Add a tooltip for the repository name validator

### DIFF
--- a/src/GitHub.UI.Reactive/Assets/Controls/Validation/ValidationMessage.xaml
+++ b/src/GitHub.UI.Reactive/Assets/Controls/Validation/ValidationMessage.xaml
@@ -20,7 +20,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type local:ValidationMessage}">
-                    <Grid x:Name="grid" Visibility="Collapsed" Margin="{TemplateBinding Padding}">
+                    <Grid x:Name="grid" Visibility="Collapsed" Margin="{TemplateBinding Padding}" ToolTip="{TemplateBinding Text}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
I added a tooltip to fix this.

![876](https://cloud.githubusercontent.com/assets/19977/9921174/a4968ad0-5c8f-11e5-856f-8e38414853de.png)

We don't want to add wrapping because it could push the button off the dialog.

Fixes #84