### PR TITLE
Add repository model tests

### DIFF
--- a/src/DesignTimeStyleHelper/MainWindow.xaml.cs
+++ b/src/DesignTimeStyleHelper/MainWindow.xaml.cs
@@ -3,7 +3,7 @@ using System.Windows;
 using GitHub.SampleData;
 using GitHub.Services;
 using GitHub.UI;
-using GitHub.VisualStudio;
+using GitHub.Extensions;
 using GitHub.Models;
 
 namespace DesignTimeStyleHelper

--- a/src/GitHub.App/Services/RepositoryPublishService.cs
+++ b/src/GitHub.App/Services/RepositoryPublishService.cs
@@ -13,7 +13,7 @@ namespace GitHub.Services
     public class RepositoryPublishService : IRepositoryPublishService
     {
         readonly IGitClient gitClient;
-        readonly Repository activeRepository;
+        readonly IRepository activeRepository;
 
         [ImportingConstructor]
         public RepositoryPublishService(IGitClient gitClient, IVSServices services)

--- a/src/GitHub.Exports/Extensions/SimpleRepositoryModelExtensions.cs
+++ b/src/GitHub.Exports/Extensions/SimpleRepositoryModelExtensions.cs
@@ -1,13 +1,11 @@
-﻿using GitHub.Models;
-using System;
+﻿using System;
 using System.Linq;
 using System.IO;
+using GitHub.Models;
 using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
 
 namespace GitHub.Extensions
 {
-    using Services;
-    using VisualStudio;
     public static class SimpleRepositoryModelExtensions
     {
         /// <summary>
@@ -15,14 +13,12 @@ namespace GitHub.Extensions
         /// </summary>
         public static ISimpleRepositoryModel ToModel(this IGitRepositoryInfo repo)
         {
-            if (repo == null)
-                return null;
-            return new SimpleRepositoryModel(repo.RepositoryPath);
+            return repo == null ? null : new SimpleRepositoryModel(repo.RepositoryPath);
         }
 
         public static bool HasCommits(this ISimpleRepositoryModel repository)
         {
-            var repo = Services.IGitService.GetRepo(repository.LocalPath);
+            var repo = VisualStudio.Services.IGitService.GetRepo(repository.LocalPath);
             return repo?.Commits.Any() ?? false;
         }
 

--- a/src/GitHub.Exports/Extensions/SimpleRepositoryModelExtensions.cs
+++ b/src/GitHub.Exports/Extensions/SimpleRepositoryModelExtensions.cs
@@ -6,6 +6,8 @@ using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
 
 namespace GitHub.Extensions
 {
+    using Services;
+    using VisualStudio;
     public static class SimpleRepositoryModelExtensions
     {
         /// <summary>
@@ -15,12 +17,12 @@ namespace GitHub.Extensions
         {
             if (repo == null)
                 return null;
-            return SimpleRepositoryModel.Create(repo.RepositoryPath);
+            return new SimpleRepositoryModel(repo.RepositoryPath);
         }
 
         public static bool HasCommits(this ISimpleRepositoryModel repository)
         {
-            var repo = GitHelpers.GetRepoFromPath(repository.LocalPath);
+            var repo = Services.IGitService.GetRepo(repository.LocalPath);
             return repo?.Commits.Any() ?? false;
         }
 

--- a/src/GitHub.Exports/Extensions/VSExtensions.cs
+++ b/src/GitHub.Exports/Extensions/VSExtensions.cs
@@ -1,12 +1,10 @@
-﻿using GitHub.Services;
-using Microsoft.TeamFoundation.Controls;
-using System;
+﻿using System;
 using System.Diagnostics;
+using GitHub.Services;
+using Microsoft.TeamFoundation.Controls;
 
 namespace GitHub.Extensions
 {
-    using VisualStudio;
-
     public static class VSExtensions
     {
         public static T TryGetService<T>(this IServiceProvider serviceProvider) where T : class
@@ -41,9 +39,9 @@ namespace GitHub.Extensions
         public static T GetExportedValue<T>(this IServiceProvider serviceProvider)
         {
             var ui = serviceProvider as IUIProvider;
-            if (ui != null)
-                return ui.GetService<T>();
-            return Services.ComponentModel.DefaultExportProvider.GetExportedValue<T>();
+            return ui != null
+                ? ui.GetService<T>()
+                : VisualStudio.Services.ComponentModel.DefaultExportProvider.GetExportedValue<T>();
         }
 
         public static ITeamExplorerSection GetSection(this IServiceProvider serviceProvider, Guid section)

--- a/src/GitHub.Exports/Extensions/VSExtensions.cs
+++ b/src/GitHub.Exports/Extensions/VSExtensions.cs
@@ -5,6 +5,8 @@ using System.Diagnostics;
 
 namespace GitHub.Extensions
 {
+    using VisualStudio;
+
     public static class VSExtensions
     {
         public static T TryGetService<T>(this IServiceProvider serviceProvider) where T : class
@@ -34,6 +36,14 @@ namespace GitHub.Extensions
         public static T GetService<T>(this IServiceProvider serviceProvider)
         {
             return (T)serviceProvider.GetService(typeof(T));
+        }
+
+        public static T GetExportedValue<T>(this IServiceProvider serviceProvider)
+        {
+            var ui = serviceProvider as IUIProvider;
+            if (ui != null)
+                return ui.GetService<T>();
+            return Services.ComponentModel.DefaultExportProvider.GetExportedValue<T>();
         }
 
         public static ITeamExplorerSection GetSection(this IServiceProvider serviceProvider, Guid section)

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Models\SimpleRepositoryModel.cs" />
     <Compile Include="Helpers\NotificationAwareObject.cs" />
     <Compile Include="Services\Connection.cs" />
+    <Compile Include="Services\GitService.cs" />
     <Compile Include="Services\ITeamExplorerServiceHolder.cs" />
     <Compile Include="Services\Logger.cs" />
     <Compile Include="Services\Services.cs" />

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Helpers\NotificationAwareObject.cs" />
     <Compile Include="Services\Connection.cs" />
     <Compile Include="Services\GitService.cs" />
+    <Compile Include="Services\IGitService.cs" />
     <Compile Include="Services\ITeamExplorerServiceHolder.cs" />
     <Compile Include="Services\Logger.cs" />
     <Compile Include="Services\Services.cs" />

--- a/src/GitHub.Exports/Models/SimpleRepositoryModel.cs
+++ b/src/GitHub.Exports/Models/SimpleRepositoryModel.cs
@@ -1,18 +1,13 @@
-﻿using GitHub.Extensions;
-using GitHub.Primitives;
-using GitHub.Services;
-using GitHub.UI;
-using GitHub.VisualStudio;
-using GitHub.VisualStudio.Helpers;
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using GitHub.Primitives;
+using GitHub.UI;
+using GitHub.VisualStudio.Helpers;
 
 namespace GitHub.Models
 {
-    using VisualStudio;
-
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SimpleRepositoryModel : NotificationAwareObject, ISimpleRepositoryModel, INotifyPropertySource, IEquatable<SimpleRepositoryModel>
     {
@@ -31,10 +26,8 @@ namespace GitHub.Models
             var dir = new DirectoryInfo(path);
             if (!dir.Exists)
                 throw new ArgumentException("Path does not exist", nameof(path));
-            var uri = Services.IGitService.GetUri(path);
-            var name = uri?.NameWithOwner;
-            if (name == null)
-                name = dir.Name;
+            var uri = VisualStudio.Services.IGitService.GetUri(path);
+            var name = uri?.NameWithOwner ?? dir.Name;
             Name = name;
             LocalPath = path;
             CloneUrl = uri;
@@ -54,15 +47,15 @@ namespace GitHub.Models
         {
             if (LocalPath == null)
                 return;
-            var uri = Services.IGitService.GetUri(LocalPath);
+            var uri = VisualStudio.Services.IGitService.GetUri(LocalPath);
             if (CloneUrl != uri)
                 CloneUrl = uri;
         }
 
-        public string Name { get; private set; }
+        public string Name { get; }
         UriString cloneUrl;
         public UriString CloneUrl { get { return cloneUrl; } set { cloneUrl = value; this.RaisePropertyChange(); } }
-        public string LocalPath { get; private set; }
+        public string LocalPath { get; }
         Octicon icon;
         public Octicon Icon { get { return icon; } set { icon = value; this.RaisePropertyChange(); } }
 
@@ -91,13 +84,12 @@ namespace GitHub.Models
             return other != null && String.Equals(Name, other.Name) && String.Equals(CloneUrl, other.CloneUrl) && String.Equals(LocalPath?.TrimEnd('\\'), other.LocalPath?.TrimEnd('\\'), StringComparison.CurrentCultureIgnoreCase);
         }
 
-        internal string DebuggerDisplay
-        {
-            get
-            {
-                return String.Format(CultureInfo.InvariantCulture,
-                    "{3}\tName: {0} CloneUrl: {1} LocalPath: {2}", Name, CloneUrl, LocalPath, GetHashCode());
-            }
-        }
+        internal string DebuggerDisplay => String.Format(
+            CultureInfo.InvariantCulture,
+            "{3}\tName: {0} CloneUrl: {1} LocalPath: {2}",
+            Name,
+            CloneUrl,
+            LocalPath,
+            GetHashCode());
     }
 }

--- a/src/GitHub.Exports/Models/SimpleRepositoryModel.cs
+++ b/src/GitHub.Exports/Models/SimpleRepositoryModel.cs
@@ -1,5 +1,6 @@
 ﻿using GitHub.Extensions;
 using GitHub.Primitives;
+using GitHub.Services;
 using GitHub.UI;
 using GitHub.VisualStudio;
 using GitHub.VisualStudio.Helpers;
@@ -10,6 +11,8 @@ using System.IO;
 
 namespace GitHub.Models
 {
+    using VisualStudio;
+
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class SimpleRepositoryModel : NotificationAwareObject, ISimpleRepositoryModel, INotifyPropertySource, IEquatable<SimpleRepositoryModel>
     {
@@ -28,7 +31,7 @@ namespace GitHub.Models
             var dir = new DirectoryInfo(path);
             if (!dir.Exists)
                 throw new ArgumentException("Path does not exist", nameof(path));
-            var uri = GitHelpers.GetRepoFromPath(path)?.GetUri();
+            var uri = Services.IGitService.GetUri(path);
             var name = uri?.NameWithOwner;
             if (name == null)
                 name = dir.Name;
@@ -36,15 +39,6 @@ namespace GitHub.Models
             LocalPath = path;
             CloneUrl = uri;
             Icon = Octicon.repo;
-        }
-
-        public static ISimpleRepositoryModel Create(string path)
-        {
-            if (path == null)
-                return null;
-            if (!Directory.Exists(path))
-                return null;
-            return new SimpleRepositoryModel(path);
         }
 
         public void SetIcon(bool isPrivate, bool isFork)
@@ -60,7 +54,7 @@ namespace GitHub.Models
         {
             if (LocalPath == null)
                 return;
-            var uri = GitHelpers.GetRepoFromPath(LocalPath)?.GetUri();
+            var uri = Services.IGitService.GetUri(LocalPath);
             if (CloneUrl != uri)
                 CloneUrl = uri;
         }

--- a/src/GitHub.Exports/Services/GitService.cs
+++ b/src/GitHub.Exports/Services/GitService.cs
@@ -1,0 +1,66 @@
+﻿using GitHub.Primitives;
+using LibGit2Sharp;
+using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitHub.Services
+{
+    public interface IGitService
+    {
+        UriString GetUri(string path);
+        UriString GetUri(IRepository repo);
+        UriString GetUri(IGitRepositoryInfo repoInfo);
+        IRepository GetRepo(IGitRepositoryInfo repoInfo);
+        IRepository GetRepo(string path);
+    }
+
+    [Export(typeof(IVSServices))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class GitService : IGitService
+    {
+        public UriString GetUri(IRepository repo)
+        {
+            return UriString.ToUriString(GetUriFromRepository(repo)?.ToRepositoryUrl());
+        }
+
+        public UriString GetUri(string path)
+        {
+            return GetUri(GetRepo(path));
+        }
+
+        public UriString GetUri(IGitRepositoryInfo repoInfo)
+        {
+            return GetUri(GetRepo(repoInfo));
+        }
+
+        public IRepository GetRepo(IGitRepositoryInfo repoInfo)
+        {
+            var repoPath = Repository.Discover(repoInfo?.RepositoryPath);
+            if (repoPath == null)
+                return null;
+            return new Repository(repoPath);
+        }
+
+        public IRepository GetRepo(string path)
+        {
+            var repoPath = Repository.Discover(path);
+            if (repoPath == null)
+                return null;
+            return new Repository(repoPath);
+        }
+
+        internal static UriString GetUriFromRepository(IRepository repo)
+        {
+            return repo
+                ?.Network
+                .Remotes
+                .FirstOrDefault(x => x.Name.Equals("origin", StringComparison.Ordinal))
+                ?.Url;
+        }
+    }
+}

--- a/src/GitHub.Exports/Services/IGitService.cs
+++ b/src/GitHub.Exports/Services/IGitService.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.ComponentModel.Composition;
-using System.Linq;
 using GitHub.Primitives;
 using LibGit2Sharp;
 using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
 
 namespace GitHub.Services
 {
-    [Export(typeof(IVSServices))]
-    [PartCreationPolicy(CreationPolicy.Shared)]
-    public class GitService : IGitService
+    public interface IGitService
     {
         /// <summary>
         /// Returns the URL of the remote named "origin" for the specified <see cref="repository"/>. If the repository
@@ -17,10 +12,7 @@ namespace GitHub.Services
         /// </summary>
         /// <param name="repository">The repository to look at for the remote.</param>
         /// <returns>A <see cref="UriString"/> representing the origin or null if none found.</returns>
-        public UriString GetUri(IRepository repository)
-        {
-            return UriString.ToUriString(GetUriFromRepository(repository)?.ToRepositoryUrl());
-        }
+        UriString GetUri(IRepository repository);
 
         /// <summary>
         /// Probes for a git repository and if one is found, returns a <see cref="UriString"/> for the repository's
@@ -32,11 +24,8 @@ namespace GitHub.Services
         /// </remarks>
         /// <param name="path">The path to start probing</param>
         /// <returns>A <see cref="UriString"/> representing the origin or null if none found.</returns>
-        public UriString GetUri(string path)
-        {
-            return GetUri(GetRepo(path));
-        }
-
+        UriString GetUri(string path);
+        
         /// <summary>
         /// Probes for a git repository and if one is found, returns a <see cref="UriString"/> for the repository's
         /// remote named "origin" if one is found
@@ -48,10 +37,7 @@ namespace GitHub.Services
         /// </remarks>
         /// <param name="repoInfo">The repository information containing the path to start probing</param>
         /// <returns>A <see cref="UriString"/> representing the origin or null if none found.</returns>
-        public UriString GetUri(IGitRepositoryInfo repoInfo)
-        {
-            return GetUri(GetRepo(repoInfo));
-        }
+        UriString GetUri(IGitRepositoryInfo repoInfo);
 
         /// <summary>
         /// Probes for a git repository and if one is found, returns a <see cref="IRepository"/> instance for the
@@ -65,10 +51,7 @@ namespace GitHub.Services
         /// <param name="repoInfo">The repository information containing the path to start probing</param>
         /// <returns>An instance of <see cref="IRepository"/> or null</returns>
 
-        public IRepository GetRepo(IGitRepositoryInfo repoInfo)
-        {
-            return GetRepo(repoInfo?.RepositoryPath);
-        }
+        IRepository GetRepo(IGitRepositoryInfo repoInfo);
 
         /// <summary>
         /// Probes for a git repository and if one is found, returns a <see cref="IRepository"/> instance for the
@@ -80,19 +63,6 @@ namespace GitHub.Services
         /// </remarks>
         /// <param name="path">The path to start probing</param>
         /// <returns>An instance of <see cref="IRepository"/> or null</returns>
-        public IRepository GetRepo(string path)
-        {
-            var repoPath = Repository.Discover(path);
-            return repoPath == null ? null : new Repository(repoPath);
-        }
-
-        internal static UriString GetUriFromRepository(IRepository repo)
-        {
-            return repo
-                ?.Network
-                .Remotes
-                .FirstOrDefault(x => x.Name.Equals("origin", StringComparison.Ordinal))
-                ?.Url;
-        }
+        IRepository GetRepo(string path);
     }
 }

--- a/src/GitHub.Exports/Services/Services.cs
+++ b/src/GitHub.Exports/Services/Services.cs
@@ -1,18 +1,17 @@
 ﻿using System;
 using EnvDTE;
 using EnvDTE80;
+using GitHub.Extensions;
+using GitHub.Info;
+using GitHub.Primitives;
 using GitHub.Services;
 using LibGit2Sharp;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell.Interop;
-using GitHub.Info;
-using GitHub.Primitives;
-using GitHub.Extensions;
 
 namespace GitHub.VisualStudio
 {
-
     public static class Services
     {
         public static IServiceProvider PackageServiceProvider { get; set; }
@@ -37,20 +36,14 @@ namespace GitHub.VisualStudio
             return PackageServiceProvider.GetService(typeof(T)) as Ret;
         }
 
-        public static IComponentModel ComponentModel
-        {
-            get { return GetGlobalService<SComponentModel, IComponentModel>(); }
-        }
+        public static IComponentModel ComponentModel => GetGlobalService<SComponentModel, IComponentModel>();
 
         public static IVsWebBrowsingService GetWebBrowsingService(this IServiceProvider provider)
         {
             return GetGlobalService<SVsWebBrowsingService, IVsWebBrowsingService>(provider);
         }
 
-        public static IVsOutputWindow OutputWindow
-        {
-            get { return GetGlobalService<SVsOutputWindow, IVsOutputWindow>(); }
-        }
+        public static IVsOutputWindow OutputWindow => GetGlobalService<SVsOutputWindow, IVsOutputWindow>();
 
         static IVsOutputWindowPane outputWindowPane = null;
         public static IVsOutputWindowPane OutputWindowPane
@@ -62,14 +55,14 @@ namespace GitHub.VisualStudio
                     // First make sure the output window is visible
                     var uiShell = GetGlobalService<SVsUIShell, IVsUIShell>();
                     // Get the frame of the output window
-                    Guid outputWindowGuid = new Guid("{34e76e81-ee4a-11d0-ae2e-00a0c90fffc3}");
+                    var outputWindowGuid = new Guid("{34e76e81-ee4a-11d0-ae2e-00a0c90fffc3}");
                     IVsWindowFrame outputWindowFrame = null;
                     ErrorHandler.ThrowOnFailure(uiShell.FindToolWindow((uint)__VSCREATETOOLWIN.CTW_fForceCreate, ref outputWindowGuid, out outputWindowFrame));
                     // Show the output window
                     if (outputWindowFrame != null)
                         ErrorHandler.ThrowOnFailure(outputWindowFrame.Show());
 
-                    Guid paneGuid = new Guid("E37A42B1-C1AE-475C-9982-7F49FE61918D");
+                    var paneGuid = new Guid("E37A42B1-C1AE-475C-9982-7F49FE61918D");
                     ErrorHandler.ThrowOnFailure(OutputWindow.CreatePane(ref paneGuid, ApplicationInfo.ApplicationSafeName, 1 /*visible=true*/, 0 /*clearWithSolution=false*/));
                     ErrorHandler.ThrowOnFailure(OutputWindow.GetPane(ref paneGuid, out outputWindowPane));
                 }
@@ -78,15 +71,9 @@ namespace GitHub.VisualStudio
             }
         }
 
-        public static DTE Dte
-        {
-            get { return GetGlobalService<DTE, DTE>(); }
-        }
+        public static DTE Dte => GetGlobalService<DTE, DTE>();
 
-        public static DTE2 Dte2
-        {
-            get { return Dte as DTE2; }
-        }
+        public static DTE2 Dte2 => Dte as DTE2;
 
         public static IVsActivityLog GetActivityLog(this IServiceProvider provider)
         {
@@ -130,6 +117,6 @@ namespace GitHub.VisualStudio
         {
             return UriString.ToUriString(GitService.GetUriFromRepository(repo)?.ToRepositoryUrl());
         }
-        public static IGitService IGitService { get { return PackageServiceProvider.GetService<IGitService>(); } }
+        public static IGitService IGitService => PackageServiceProvider.GetService<IGitService>();
     }
 }

--- a/src/GitHub.Exports/Services/VSServices.cs
+++ b/src/GitHub.Exports/Services/VSServices.cs
@@ -76,16 +76,15 @@ namespace GitHub.Services
         public LibGit2Sharp.IRepository GetActiveRepo()
         {
             var gitExt = serviceProvider.GetService<IGitExt>();
-            var gitService = serviceProvider.GetService<IGitService>();
-            if (gitExt.ActiveRepositories.Count > 0)
-                return gitService.GetRepo(gitExt.ActiveRepositories.First());
-            return serviceProvider.GetSolution().GetRepoFromSolution();
+            return gitExt.ActiveRepositories.Any()
+                ? serviceProvider.GetService<IGitService>().GetRepo(gitExt.ActiveRepositories.First())
+                : serviceProvider.GetSolution().GetRepoFromSolution();
         }
 
         public string GetActiveRepoPath()
         {
             var gitExt = serviceProvider.GetService<IGitExt>();
-            if (gitExt.ActiveRepositories.Count > 0)
+            if (gitExt.ActiveRepositories.Any())
                 return gitExt.ActiveRepositories.First().RepositoryPath;
             var repo = serviceProvider.GetSolution().GetRepoFromSolution();
             return repo?.Info?.Path ?? string.Empty;

--- a/src/GitHub.Exports/Services/VSServices.cs
+++ b/src/GitHub.Exports/Services/VSServices.cs
@@ -21,7 +21,7 @@ namespace GitHub.Services
         string GetLocalClonePathFromGitProvider();
         void Clone(string cloneUrl, string clonePath, bool recurseSubmodules);
         string GetActiveRepoPath();
-        LibGit2Sharp.Repository GetActiveRepo();
+        LibGit2Sharp.IRepository GetActiveRepo();
         IEnumerable<ISimpleRepositoryModel> GetKnownRepositories();
         string SetDefaultProjectPath(string path);
 
@@ -73,11 +73,12 @@ namespace GitHub.Services
             gitExt.Clone(cloneUrl, clonePath, recurseSubmodules ? CloneOptions.RecurseSubmodule : CloneOptions.None);
         }
 
-        public LibGit2Sharp.Repository GetActiveRepo()
+        public LibGit2Sharp.IRepository GetActiveRepo()
         {
             var gitExt = serviceProvider.GetService<IGitExt>();
+            var gitService = serviceProvider.GetService<IGitService>();
             if (gitExt.ActiveRepositories.Count > 0)
-                return gitExt.ActiveRepositories.First().GetRepoFromIGit();
+                return gitService.GetRepo(gitExt.ActiveRepositories.First());
             return serviceProvider.GetSolution().GetRepoFromSolution();
         }
 
@@ -117,16 +118,18 @@ namespace GitHub.Services
                 {
                     using (var subkey = key.OpenSubKey(x))
                     {
-                        var path = subkey?.GetValue("Path") as string;
-                        if (path != null)
+                        try
                         {
-                            var uri = GitHelpers.GetRepoFromPath(path)?.GetUri();
-                            var name = uri?.NameWithOwner;
-                            if (name != null)
-                                return new SimpleRepositoryModel(name, uri, path);
+                            var path = subkey?.GetValue("Path") as string;
+                            if (path != null)
+                                return new SimpleRepositoryModel(path);
                         }
+                        catch (Exception ex)
+                        {
+                            VsOutputLogger.WriteLine(string.Format(CultureInfo.CurrentCulture, "Error loading the repository from the registry '{0}'", ex));
+                        }
+                        return null;
                     }
-                    return null;
                 })
                 .Where(x => x != null)
                 .ToList();

--- a/src/UnitTests/GitHub.App/Models/RepositoryModelTests.cs
+++ b/src/UnitTests/GitHub.App/Models/RepositoryModelTests.cs
@@ -1,17 +1,15 @@
 ﻿using GitHub.Models;
 using GitHub.Primitives;
+using GitHub.Services;
+using GitHub.VisualStudio;
+using LibGit2Sharp;
 using NSubstitute;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnitTests;
 using Xunit;
 
-public class ComparisonTests
+public class RepositoryModelTests
 {
-    public class RepositoryModelTests : TestBaseClass
+    public class ComparisonTests : TestBaseClass
     {
         [Theory]
         [InlineData("a name", "https://github.com/github/VisualStudio", null, "a name", "https://github.com/github/VisualStudio", null)]
@@ -52,6 +50,37 @@ public class ComparisonTests
             Assert.NotEqual(a, b);
             Assert.False(a == b);
             Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
+        }
+    }
+
+    public class PathConstructorTests : TempFileBaseClass
+    {
+        [Fact]
+        public void NoRemoteUrl()
+        {
+            var provider = Substitutes.ServiceProvider;
+            Services.PackageServiceProvider = provider;
+            var gitservice = Substitutes.IGitService;
+            provider.GetService(typeof(IGitService)).Returns(gitservice);
+            var repo = Substitute.For<IRepository>();
+            var path = Directory.CreateSubdirectory("repo-name");
+            gitservice.GetUri(path.FullName).Returns((UriString)null);
+            var model = new SimpleRepositoryModel(path.FullName);
+            Assert.Equal("repo-name", model.Name);
+        }
+
+        [Fact]
+        public void WithRemoteUrl()
+        {
+            var provider = Substitutes.ServiceProvider;
+            Services.PackageServiceProvider = provider;
+            var gitservice = Substitutes.IGitService;
+            provider.GetService(typeof(IGitService)).Returns(gitservice);
+            var repo = Substitute.For<IRepository>();
+            var path = Directory.CreateSubdirectory("repo-name");
+            gitservice.GetUri(path.FullName).Returns(new UriString("https://github.com/user/repo-name"));
+            var model = new SimpleRepositoryModel(path.FullName);
+            Assert.Equal("user/repo-name", model.Name);
         }
     }
 

--- a/src/UnitTests/Helpers/TestBaseClass.cs
+++ b/src/UnitTests/Helpers/TestBaseClass.cs
@@ -1,4 +1,5 @@
 ﻿using EntryExitDecoratorInterfaces;
+using System.IO;
 
 /// <summary>
 /// This base class will get its methods called by the most-derived
@@ -7,14 +8,35 @@
 /// </summary>
 public class TestBaseClass : IEntryExitDecorator
 {
-    public void OnEntry()
+    public virtual void OnEntry()
     {
         // Ensure that every test has the InUnitTestRunner flag
         // set, so threading doesn't go nuts.
         Splat.ModeDetector.Current.SetInUnitTestRunner(true);
     }
 
-    public void OnExit()
+    public virtual void OnExit()
     {
+    }
+}
+
+public class TempFileBaseClass : TestBaseClass
+{
+    public DirectoryInfo Directory { get; set; }
+
+    public override void OnEntry()
+    {
+        var f = Path.GetTempFileName();
+        var name = Path.GetFileNameWithoutExtension(f);
+        File.Delete(f);
+        Directory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), name));
+        Directory.Create();
+        base.OnEntry();
+    }
+
+    public override void OnExit()
+    {
+        Directory.Delete(true);
+        base.OnExit();
     }
 }

--- a/src/UnitTests/Substitutes.cs
+++ b/src/UnitTests/Substitutes.cs
@@ -14,14 +14,8 @@ namespace UnitTests
 {
     internal static class Substitutes
     {
-        public static IGitRepositoriesExt IGitRepositoriesExt
-        {
-            get
-            {
-                var ret = Substitute.For<IGitRepositoriesExt>();
-                return ret;
-            }
-        }
+        public static IGitRepositoriesExt IGitRepositoriesExt { get { return Substitute.For<IGitRepositoriesExt>(); } }
+        public static IGitService IGitService { get { return Substitute.For<IGitService>(); } }
 
         public static IVSServices IVSServices
         {
@@ -89,27 +83,22 @@ namespace UnitTests
         {
             var ret = Substitute.For<IServiceProvider, IUIProvider>();
             var os = OperatingSystem;
-            var git = IGitRepositoriesExt;
             var vs = IVSServices;
             var clone = cloneService ?? new RepositoryCloneService(os, vs);
             var create = creationService ?? new RepositoryCreationService(clone);
-            var hosts = RepositoryHosts;
-            var exports = ExportFactoryProvider;
-            var connection = Connection;
-            var connectionManager = ConnectionManager;
-            var twoFactorChallengeHandler = TwoFactorChallengeHandler;
             avatarProvider = avatarProvider ?? Substitute.For<IAvatarProvider>();
-            ret.GetService(typeof(IGitRepositoriesExt)).Returns(git);
+            ret.GetService(typeof(IGitRepositoriesExt)).Returns(IGitRepositoriesExt);
+            ret.GetService(typeof(IGitService)).Returns(IGitService);
             ret.GetService(typeof(IVSServices)).Returns(vs);
             ret.GetService(typeof(IOperatingSystem)).Returns(os);
             ret.GetService(typeof(IRepositoryCloneService)).Returns(clone);
             ret.GetService(typeof(IRepositoryCreationService)).Returns(create);
-            ret.GetService(typeof(IRepositoryHosts)).Returns(hosts);
-            ret.GetService(typeof(IExportFactoryProvider)).Returns(exports);
-            ret.GetService(typeof(IConnection)).Returns(connection);
-            ret.GetService(typeof(IConnectionManager)).Returns(connectionManager);
+            ret.GetService(typeof(IRepositoryHosts)).Returns(RepositoryHosts);
+            ret.GetService(typeof(IExportFactoryProvider)).Returns(ExportFactoryProvider);
+            ret.GetService(typeof(IConnection)).Returns(Connection);
+            ret.GetService(typeof(IConnectionManager)).Returns(ConnectionManager);
             ret.GetService(typeof(IAvatarProvider)).Returns(avatarProvider);
-            ret.GetService(typeof(ITwoFactorChallengeHandler)).Returns(twoFactorChallengeHandler);
+            ret.GetService(typeof(ITwoFactorChallengeHandler)).Returns(TwoFactorChallengeHandler);
             return ret;
         }
 
@@ -121,6 +110,11 @@ namespace UnitTests
         public static IVSServices GetVSServices(this IServiceProvider provider)
         {
             return provider.GetService(typeof(IVSServices)) as IVSServices;
+        }
+
+        public static IGitService GetGitService(this IServiceProvider provider)
+        {
+            return provider.GetService(typeof(IGitService)) as IGitService;
         }
 
         public static IOperatingSystem GetOperatingSystem(this IServiceProvider provider)

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -145,7 +145,7 @@
     <Compile Include="GitHub.App\Models\ModelServiceTests.cs" />
     <Compile Include="GitHub.App\Controllers\UIControllerTests.cs" />
     <Compile Include="GitHub.App\Models\RepositoryHostTests.cs" />
-    <Compile Include="GitHub.App\Models\ComparisonTests.cs" />
+    <Compile Include="GitHub.App\Models\RepositoryModelTests.cs" />
     <Compile Include="GitHub.App\Services\AvatarProviderTests.cs" />
     <Compile Include="GitHub.App\Services\GitClientTests.cs" />
     <Compile Include="GitHub.App\Services\RepositoryCloneServiceTests.cs" />


### PR DESCRIPTION
This PR is based on #79, so that one should be merged first before looking at this.

Add repository model tests and support for testing things that rely on the GetUri and GetRepo extension methods that use libgit2#.

Testing RepositoryModel creation via the path constructor implies hitting libgit2sharp codepaths, and libgit2sharp doesn't expose nice interfaces for testing (why??). So, move things around and add a
GitService that replaces the extension methods that depend on libgit2sharp, so we can at least mock at a higher level.

The things that require this GitService are not created via mef, so expose it via the Services static class.