### PR TITLE
Simplify inotify code

### DIFF
--- a/src/GitHub.Exports/Helpers/NotificationAwareObject.cs
+++ b/src/GitHub.Exports/Helpers/NotificationAwareObject.cs
@@ -1,8 +1,9 @@
 using System.ComponentModel;
+using GitHub.VisualStudio.Helpers;
 
 namespace GitHub.Primitives
 {
-    public abstract class NotificationAwareObject : INotifyPropertyChanged
+    public abstract class NotificationAwareObject : INotifyPropertyChanged, INotifyPropertySource
     {
         public event PropertyChangedEventHandler PropertyChanged;
 

--- a/src/GitHub.VisualStudio/Base/TeamExplorerItemBase.cs
+++ b/src/GitHub.VisualStudio/Base/TeamExplorerItemBase.cs
@@ -11,7 +11,7 @@ using GitHub.Extensions;
 
 namespace GitHub.VisualStudio.Base
 {
-    public class TeamExplorerItemBase : TeamExplorerGitRepoInfo, INotifyPropertySource
+    public class TeamExplorerItemBase : TeamExplorerGitRepoInfo
     {
         readonly ISimpleApiClientFactory apiFactory;
         protected ITeamExplorerServiceHolder holder;

--- a/src/GitHub.VisualStudio/Base/TeamExplorerNavigationItemBase.cs
+++ b/src/GitHub.VisualStudio/Base/TeamExplorerNavigationItemBase.cs
@@ -8,13 +8,12 @@ using GitHub.UI;
 using GitHub.VisualStudio.Helpers;
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.VisualStudio.PlatformUI;
-using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
 using NullGuard;
 using GitHub.Models;
 
 namespace GitHub.VisualStudio.Base
 {
-    public class TeamExplorerNavigationItemBase : TeamExplorerItemBase, ITeamExplorerNavigationItem2, INotifyPropertySource
+    public class TeamExplorerNavigationItemBase : TeamExplorerItemBase, ITeamExplorerNavigationItem2
     {
         readonly Octicon octicon;
 

--- a/src/GitHub.VisualStudio/Base/TeamExplorerSectionBase.cs
+++ b/src/GitHub.VisualStudio/Base/TeamExplorerSectionBase.cs
@@ -12,7 +12,7 @@ using GitHub.Models;
 
 namespace GitHub.VisualStudio.Base
 {
-    public class TeamExplorerSectionBase : TeamExplorerItemBase, ITeamExplorerSection, INotifyPropertySource
+    public class TeamExplorerSectionBase : TeamExplorerItemBase, ITeamExplorerSection
     {
         protected IConnectionManager connectionManager;
 


### PR DESCRIPTION
Anything inheriting from `NotificationAwareObject` also needs functionality from `INotifyPropertySource`, so might as well put that in `NotificationAwareObject`