### PR TITLE
Login in the sync page

### DIFF
--- a/src/GitHub.Api/SimpleApiClient.cs
+++ b/src/GitHub.Api/SimpleApiClient.cs
@@ -66,7 +66,12 @@ namespace GitHub.Api
                     }
                 }
             }
-            // it'll throw if it's private
+            // it'll throw if it's private or an enterprise instance requiring authentication
+            catch (ForbiddenException)
+            {
+                if (!HostAddress.IsGitHubDotComUri(OriginalUrl.ToRepositoryUrl()))
+                    isEnterprise = true;
+            }
             catch {}
             finally
             {

--- a/src/GitHub.Api/SimpleApiClient.cs
+++ b/src/GitHub.Api/SimpleApiClient.cs
@@ -71,7 +71,7 @@ namespace GitHub.Api
                 }
             }
             // it'll throw if it's private or an enterprise instance requiring authentication
-            catch (ForbiddenException)
+            catch (ApiException)
             {
                 if (!HostAddress.IsGitHubDotComUri(OriginalUrl.ToRepositoryUrl()))
                     isEnterprise = true;

--- a/src/GitHub.Api/SimpleApiClient.cs
+++ b/src/GitHub.Api/SimpleApiClient.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GitHub.Primitives;
 using GitHub.Services;
 using Octokit;
+using GitHub.Extensions;
 
 namespace GitHub.Api
 {
@@ -23,10 +24,13 @@ namespace GitHub.Api
         bool? isEnterprise;
         bool? hasWiki;
 
-        public SimpleApiClient(HostAddress hostAddress, UriString repoUrl, IGitHubClient githubClient,
+        public SimpleApiClient(UriString repoUrl, IGitHubClient githubClient,
             Lazy<IEnterpriseProbeTask> enterpriseProbe, Lazy<IWikiProbe> wikiProbe)
         {
-            HostAddress = hostAddress;
+            Guard.ArgumentNotNull(repoUrl, nameof(repoUrl));
+            Guard.ArgumentNotNull(githubClient, nameof(githubClient));
+
+            HostAddress = HostAddress.Create(repoUrl);
             OriginalUrl = repoUrl;
             client = githubClient;
             this.enterpriseProbe = enterpriseProbe;
@@ -48,7 +52,7 @@ namespace GitHub.Api
             await sem.WaitAsync();
             try
             {
-                if (owner == null && OriginalUrl != null)
+                if (owner == null)
                 {
                     var ownerLogin = OriginalUrl.Owner;
                     var repositoryName = OriginalUrl.RepositoryName;

--- a/src/GitHub.Api/SimpleApiClientFactory.cs
+++ b/src/GitHub.Api/SimpleApiClientFactory.cs
@@ -30,7 +30,7 @@ namespace GitHub.Api
         public ISimpleApiClient Create(UriString repositoryUrl)
         {
             var hostAddress = HostAddress.Create(repositoryUrl);
-            return cache.GetOrAdd(repositoryUrl, new SimpleApiClient(hostAddress, repositoryUrl,
+            return cache.GetOrAdd(repositoryUrl, new SimpleApiClient(repositoryUrl,
                 new GitHubClient(productHeader, new SimpleCredentialStore(hostAddress), hostAddress.ApiUri),
                 lazyEnterpriseProbe, lazyWikiProbe));
         }

--- a/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
@@ -12,7 +12,8 @@ namespace GitHub.Extensions
         {
             return cm.Connections.ToObservable()
                     .SelectMany(c => c.Login())
-                    .Select(c => hosts.LookupHost(c.HostAddress)).Any(h => h.IsLoggedIn);
+                    .Select(c => hosts.LookupHost(c.HostAddress))
+                    .Any(h => h.IsLoggedIn);
         }
 
         public static IObservable<bool> IsLoggedIn(this IConnectionManager cm, IRepositoryHosts hosts, HostAddress address)
@@ -20,7 +21,8 @@ namespace GitHub.Extensions
             return cm.Connections.ToObservable()
                     .Where(c => c.HostAddress.Equals(address))
                     .SelectMany(c => c.Login())
-                    .Select(c => hosts.LookupHost(c.HostAddress)).Any(h => h.IsLoggedIn);
+                    .Select(c => hosts.LookupHost(c.HostAddress))
+                    .Any(h => h.IsLoggedIn);
         }
     }
 }

--- a/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
@@ -2,6 +2,7 @@
 using GitHub.Models;
 using System;
 using ReactiveUI;
+using GitHub.Primitives;
 
 namespace GitHub.Extensions
 {
@@ -10,6 +11,14 @@ namespace GitHub.Extensions
         public static IObservable<bool> IsLoggedIn(this IConnectionManager cm, IRepositoryHosts hosts)
         {
             return cm.Connections.ToObservable()
+                    .SelectMany(c => c.Login())
+                    .Select(c => hosts.LookupHost(c.HostAddress)).Any(h => h.IsLoggedIn);
+        }
+
+        public static IObservable<bool> IsLoggedIn(this IConnectionManager cm, IRepositoryHosts hosts, HostAddress address)
+        {
+            return cm.Connections.ToObservable()
+                    .Where(c => c.HostAddress.Equals(address))
                     .SelectMany(c => c.Login())
                     .Select(c => hosts.LookupHost(c.HostAddress)).Any(h => h.IsLoggedIn);
         }

--- a/src/GitHub.Extensions/Guard.cs
+++ b/src/GitHub.Extensions/Guard.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NullGuard;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -8,6 +9,19 @@ namespace GitHub.Extensions
 {
     public static class Guard
     {
+        public static void ArgumentNotNull([AllowNull]object value, string name)
+        {
+            if (value != null) return;
+            string message = String.Format(CultureInfo.InvariantCulture, "Failed Null Check on '{0}'", name);
+#if DEBUG
+            if (!InUnitTestRunner())
+            {
+                Debug.Fail(message);
+            }
+#endif
+            throw new ArgumentNullException(name, message);
+        }
+
         public static void ArgumentNonNegative(int value, string name)
         {
             if (value > -1) return;
@@ -78,29 +92,7 @@ namespace GitHub.Extensions
         // Borrowed from Splat.
         static bool InUnitTestRunner()
         {
-            var testAssemblies = new[] {
-                "CSUNIT",
-                "NUNIT",
-                "XUNIT",
-                "MBUNIT",
-                "PEX.",
-                "NBEHAVE",
-            };
-
-            try
-            {
-                return SearchForAssembly(testAssemblies);
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
-
-        static bool SearchForAssembly(IEnumerable<string> assemblyList)
-        {
-            return AppDomain.CurrentDomain.GetAssemblies()
-                .Any(x => assemblyList.Any(name => x.FullName.ToUpperInvariant().Contains(name)));
+            return Splat.ModeDetector.InUnitTestRunner();
         }
     }
 }

--- a/src/GitHub.Extensions/TaskExtensions.cs
+++ b/src/GitHub.Extensions/TaskExtensions.cs
@@ -20,5 +20,8 @@ namespace GitHub.Extensions
                 return default(T);
             }
         }
+        public static void Forget(this Task task)
+        {
+        }
     }
 }

--- a/src/GitHub.VisualStudio/Base/EnsureLoggedInSection.cs
+++ b/src/GitHub.VisualStudio/Base/EnsureLoggedInSection.cs
@@ -9,6 +9,7 @@ using GitHub.VisualStudio.Base;
 using Microsoft.TeamFoundation.MVVM;
 using System.Globalization;
 using GitHub.Primitives;
+using System.Threading.Tasks;
 
 namespace GitHub.VisualStudio.TeamExplorer.Sync
 {
@@ -29,16 +30,16 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
         public override void Initialize(IServiceProvider serviceProvider)
         {
             base.Initialize(serviceProvider);
-            CheckLogin();
+            CheckLogin().Forget();
         }
 
         protected override void RepoChanged()
         {
             base.RepoChanged();
-            CheckLogin();
+            CheckLogin().Forget();
         }
 
-        async void CheckLogin()
+        async Task CheckLogin()
         {
             // this is not a github repo, or it hasn't been published yet
             if (ActiveRepo == null || ActiveRepoUri == null)
@@ -61,7 +62,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
         {
             var uiProvider = ServiceProvider.GetExportedValue<IUIProvider>();
             var ret = uiProvider.SetupUI(controllerFlow, null);
-            ret.Subscribe(c => { }, CheckLogin);
+            ret.Subscribe(c => { }, () => CheckLogin().Forget());
             uiProvider.RunUI();
         }
     }

--- a/src/GitHub.VisualStudio/Base/EnsureLoggedInSection.cs
+++ b/src/GitHub.VisualStudio/Base/EnsureLoggedInSection.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Reactive.Linq;
+using GitHub.Api;
+using GitHub.Extensions;
+using GitHub.Models;
+using GitHub.Services;
+using GitHub.UI;
+using GitHub.VisualStudio.Base;
+using Microsoft.TeamFoundation.MVVM;
+using System.Globalization;
+using GitHub.Primitives;
+
+namespace GitHub.VisualStudio.TeamExplorer.Sync
+{
+    public class EnsureLoggedInSection : TeamExplorerSectionBase
+    {
+        readonly IRepositoryHosts hosts;
+        readonly IVSServices vsServices;
+
+        public EnsureLoggedInSection(ISimpleApiClientFactory apiFactory, ITeamExplorerServiceHolder holder,
+            IConnectionManager cm, IRepositoryHosts hosts, IVSServices vsServices)
+            : base(apiFactory, holder, cm)
+        {
+            IsVisible = false;
+            this.hosts = hosts;
+            this.vsServices = vsServices;
+        }
+
+        public override void Initialize(IServiceProvider serviceProvider)
+        {
+            base.Initialize(serviceProvider);
+            CheckLogin();
+        }
+
+        protected override void RepoChanged()
+        {
+            base.RepoChanged();
+            CheckLogin();
+        }
+
+        async void CheckLogin()
+        {
+            // this is not a github repo, or it hasn't been published yet
+            if (ActiveRepo == null || ActiveRepoUri == null)
+                return;
+
+            vsServices.ClearNotifications();
+            var add = HostAddress.Create(ActiveRepoUri);
+            bool loggedIn = await connectionManager.IsLoggedIn(hosts, add);
+            if (!loggedIn)
+            {
+                var msg = string.Format(CultureInfo.CurrentUICulture, Resources.NotLoggedInMessage, add.Title, add.ApiUri);
+                vsServices.ShowMessage(
+                    msg,
+                    new RelayCommand(() => StartFlow(UIControllerFlow.Authentication))
+                );
+            }
+        }
+
+        void StartFlow(UIControllerFlow controllerFlow)
+        {
+            var uiProvider = ServiceProvider.GetExportedValue<IUIProvider>();
+            var ret = uiProvider.SetupUI(controllerFlow, null);
+            ret.Subscribe(c => { }, CheckLogin);
+            uiProvider.RunUI();
+        }
+    }
+}

--- a/src/GitHub.VisualStudio/Base/EnsureLoggedInSection.cs
+++ b/src/GitHub.VisualStudio/Base/EnsureLoggedInSection.cs
@@ -45,6 +45,10 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             if (ActiveRepo == null || ActiveRepoUri == null)
                 return;
 
+            var isgithub = await IsAGitHubRepo();
+            if (!isgithub)
+                return;
+
             vsServices.ClearNotifications();
             var add = HostAddress.Create(ActiveRepoUri);
             bool loggedIn = await connectionManager.IsLoggedIn(hosts, add);

--- a/src/GitHub.VisualStudio/Base/EnsureLoggedInSection.cs
+++ b/src/GitHub.VisualStudio/Base/EnsureLoggedInSection.cs
@@ -54,7 +54,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             bool loggedIn = await connectionManager.IsLoggedIn(hosts, add);
             if (!loggedIn)
             {
-                var msg = string.Format(CultureInfo.CurrentUICulture, Resources.NotLoggedInMessage, add.Title, add.ApiUri);
+                var msg = string.Format(CultureInfo.CurrentUICulture, Resources.NotLoggedInMessage, add.Title, add.Title);
                 vsServices.ShowMessage(
                     msg,
                     new RelayCommand(() => StartFlow(UIControllerFlow.Authentication))

--- a/src/GitHub.VisualStudio/Base/TeamExplorerItemBase.cs
+++ b/src/GitHub.VisualStudio/Base/TeamExplorerItemBase.cs
@@ -72,12 +72,13 @@ namespace GitHub.VisualStudio.Base
 
             SimpleApiClient = apiFactory.Create(uri);
 
-            if (!HostAddress.IsGitHubDotComUri(uri.ToRepositoryUrl()))
+            var isdotcom = HostAddress.IsGitHubDotComUri(uri.ToRepositoryUrl());
+            if (!isdotcom)
             {
                 var repo = await SimpleApiClient.GetRepository();
-                return repo.FullName == ActiveRepoName && SimpleApiClient.IsEnterprise();
+                return (repo.FullName == ActiveRepoName || repo.Id == 0) && SimpleApiClient.IsEnterprise();
             }
-            return true;
+            return isdotcom;
         }
 
         bool isEnabled;

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -247,7 +247,9 @@
     <Compile Include="TeamExplorer\Home\IssuesNavigationItem.cs" />
     <Compile Include="TeamExplorer\Home\WikiNavigationItem.cs" />
     <Compile Include="TeamExplorer\Home\PulseNavigationItem.cs" />
+    <Compile Include="TeamExplorer\Sync\EnsureLoggedInSectionSync.cs" />
     <Compile Include="TeamExplorer\Sync\GitHubPublishSection.cs" />
+    <Compile Include="Base\EnsureLoggedInSection.cs" />
     <Compile Include="UI\DrawingExtensions.cs" />
     <Compile Include="UI\GitHubPane.cs" />
     <Compile Include="UI\Views\Controls\RepositoryCloneControl.xaml.cs">

--- a/src/GitHub.VisualStudio/Resources.Designer.cs
+++ b/src/GitHub.VisualStudio/Resources.Designer.cs
@@ -385,6 +385,15 @@ namespace GitHub.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are not logged in to {0}, so certain git operations may fail. [Login now]({1}).
+        /// </summary>
+        public static string NotLoggedInMessage {
+            get {
+                return ResourceManager.GetString("NotLoggedInMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open the two-factor authentication app on your device to view your authentication code..
         /// </summary>
         public static string openTwoFactorAuthAppText {

--- a/src/GitHub.VisualStudio/Resources.resx
+++ b/src/GitHub.VisualStudio/Resources.resx
@@ -276,4 +276,7 @@
   <data name="WikiNavigationItemText" xml:space="preserve">
     <value>Wiki</value>
   </data>
+  <data name="NotLoggedInMessage" xml:space="preserve">
+    <value>You are not logged in to {0}, so certain git operations may fail. [Login now]({1})</value>
+  </data>
 </root>

--- a/src/GitHub.VisualStudio/TeamExplorer/Sync/EnsureLoggedInSectionSync.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Sync/EnsureLoggedInSectionSync.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.Composition;
+using GitHub.Api;
+using GitHub.Models;
+using GitHub.Services;
+using Microsoft.TeamFoundation.Controls;
+
+namespace GitHub.VisualStudio.TeamExplorer.Sync
+{
+    [TeamExplorerSection(SyncLoginSectionId, TeamExplorerPageIds.GitCommits, 10)]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public class EnsureLoggedInSectionSync : EnsureLoggedInSection
+    {
+        public const string SyncLoginSectionId = "C5975729-3CF1-47B4-AE92-C2934906CDDA";
+
+        [ImportingConstructor]
+        public EnsureLoggedInSectionSync(ISimpleApiClientFactory apiFactory, ITeamExplorerServiceHolder holder,
+            IConnectionManager cm, IRepositoryHosts hosts, IVSServices vsServices)
+            : base(apiFactory, holder, cm, hosts, vsServices)
+        {}
+    }
+}

--- a/src/UnitTests/GitHub.Api/SimpleApiClientTests.cs
+++ b/src/UnitTests/GitHub.Api/SimpleApiClientTests.cs
@@ -9,6 +9,15 @@ using Xunit;
 
 public class SimpleApiClientTests
 {
+    public class TheCtor : TestBaseClass
+    {
+        public void Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SimpleApiClient(null, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => new SimpleApiClient("https://github.com/github/visualstudio", null, null, null));
+        }
+    }
+
     public class TheGetRepositoryMethod
     {
         [Fact]

--- a/src/UnitTests/GitHub.Api/SimpleApiClientTests.cs
+++ b/src/UnitTests/GitHub.Api/SimpleApiClientTests.cs
@@ -21,7 +21,6 @@ public class SimpleApiClientTests
             var enterpriseProbe = Substitute.For<IEnterpriseProbeTask>();
             var wikiProbe = Substitute.For<IWikiProbe>();
             var client = new SimpleApiClient(
-                gitHubHost,
                 "https://github.com/github/visualstudio",
                 gitHubClient,
                 new Lazy<IEnterpriseProbeTask>(() => enterpriseProbe),
@@ -43,7 +42,6 @@ public class SimpleApiClientTests
             var enterpriseProbe = Substitute.For<IEnterpriseProbeTask>();
             var wikiProbe = Substitute.For<IWikiProbe>();
             var client = new SimpleApiClient(
-                gitHubHost,
                 "https://github.com/github/visualstudio",
                 gitHubClient,
                 new Lazy<IEnterpriseProbeTask>(() => enterpriseProbe),
@@ -73,7 +71,6 @@ public class SimpleApiClientTests
             wikiProbe.ProbeAsync(repository)
                 .Returns(_ => Task.FromResult(probeResult), _ => { throw new Exception("Only call it once"); });
             var client = new SimpleApiClient(
-                gitHubHost,
                 "https://github.com/github/visualstudio",
                 gitHubClient,
                 new Lazy<IEnterpriseProbeTask>(() => enterpriseProbe),
@@ -94,7 +91,6 @@ public class SimpleApiClientTests
             var enterpriseProbe = Substitute.For<IEnterpriseProbeTask>();
             var wikiProbe = Substitute.For<IWikiProbe>();
             var client = new SimpleApiClient(
-                gitHubHost,
                 "https://github.com/github/visualstudio",
                 gitHubClient,
                 new Lazy<IEnterpriseProbeTask>(() => enterpriseProbe),
@@ -123,7 +119,6 @@ public class SimpleApiClientTests
                 .Returns(_ => Task.FromResult(probeResult), _ => { throw new Exception("Only call it once"); });
             var wikiProbe = Substitute.For<IWikiProbe>();
             var client = new SimpleApiClient(
-                gitHubHost,
                 "https://github.com/github/visualstudio",
                 gitHubClient,
                 new Lazy<IEnterpriseProbeTask>(() => enterpriseProbe),
@@ -144,7 +139,6 @@ public class SimpleApiClientTests
             var enterpriseProbe = Substitute.For<IEnterpriseProbeTask>();
             var wikiProbe = Substitute.For<IWikiProbe>();
             var client = new SimpleApiClient(
-                gitHubHost,
                 "https://github.com/github/visualstudio",
                 gitHubClient,
                 new Lazy<IEnterpriseProbeTask>(() => enterpriseProbe),


### PR DESCRIPTION
Fixes #57

If the current repository is a github/github enterprise repo but the user isn't logged in to its instance, then network git operations might fail. Show a warning on the Sync page if this is the case, and allow the
user to login from there.