### PR TITLE
Fix the order of the connect section

### DIFF
--- a/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection1.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection1.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.Composition;
 
 namespace GitHub.VisualStudio.TeamExplorer.Connect
 {
-    [TeamExplorerSection(GitHubConnectSection1Id, TeamExplorerPageIds.Connect, 11)]
+    [TeamExplorerSection(GitHubConnectSection1Id, TeamExplorerPageIds.Connect, 10)]
     [PartCreationPolicy(CreationPolicy.NonShared)]
     public class GitHubConnectSection1 : GitHubConnectSection
     {


### PR DESCRIPTION
Make sure the second connection shows up above the hosted service providers section, when both are visible.