### PR TITLE
Experimental feature: synchronize forks

### DIFF
--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -189,6 +189,7 @@
     <Compile Include="UserErrors\PrivateRepositoryQuotaExceededUserError.cs" />
     <Compile Include="ViewModels\BaseViewModel.cs" />
     <Compile Include="Models\ConnectionRepositoryHostMap.cs" />
+    <Compile Include="ViewModels\CloneSyncViewModel.cs" />
     <Compile Include="ViewModels\RepositoryCreationViewModel.cs" />
     <Compile Include="ViewModels\RepositoryCloneViewModel.cs" />
     <Compile Include="ViewModels\LoginControlViewModel.cs" />

--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -39,6 +39,18 @@ namespace GitHub.Services
             });
         }
 
+        public IObservable<Unit> Fetch(IRepository repository, string remoteName, string refSpec)
+        {
+            Guard.ArgumentNotEmptyString(remoteName, nameof(remoteName));
+
+            return Observable.Defer(() =>
+            {
+                var remote = repository.Network.Remotes[remoteName];
+                repository.Network.Fetch(remote, new string[] { refSpec });
+                return Observable.Return(Unit.Default);
+            });
+        }
+
         public IObservable<Unit> SetRemote(IRepository repository, string remoteName, Uri url)
         {
             Guard.ArgumentNotEmptyString(remoteName, nameof(remoteName));

--- a/src/GitHub.App/ViewModels/CloneSyncViewModel.cs
+++ b/src/GitHub.App/ViewModels/CloneSyncViewModel.cs
@@ -1,0 +1,62 @@
+﻿using GitHub.Models;
+using GitHub.Services;
+using LibGit2Sharp;
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Globalization;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitHub.ViewModels
+{
+    [Export(typeof(ICloneSyncViewModel))]
+    public class CloneSyncViewModel : ICloneSyncViewModel
+    {
+        static readonly Logger log = LogManager.GetCurrentClassLogger();
+        readonly Lazy<IGitClient> gitClient;
+
+        [ImportingConstructor]
+        CloneSyncViewModel(Lazy<IGitClient> gitClient)
+        {
+            this.gitClient = gitClient;
+        }
+
+        public IObservable<bool> Sync(ISimpleRepositoryModel repo)
+        {
+            var gitRepo = GitService.GetRepoFromPath(repo.LocalPath);
+            var upstream = gitRepo.Network.Remotes["upstream"];
+            if (upstream == null)
+                return Observable.Return(false);
+
+            var upstreamBranches = gitRepo.Branches.Where(x => x.IsRemote && x.Remote == upstream);
+            foreach (var branch in gitRepo.Branches
+                .Where(x => !x.IsRemote  &&
+                            x.IsTracking &&
+                            x.Remote.Name == "origin" &&
+                            upstreamBranches.Any(r => r.Name == upstream.Name + "/" + x.Name) &&
+                            !Equals(x, gitRepo.Head)
+                            ))
+            {
+                var upstreamBranch = upstreamBranches.FirstOrDefault(x => x.Name == upstream.Name + "/" + branch.Name);
+                var history = gitRepo.ObjectDatabase.CalculateHistoryDivergence(branch.Tip, upstreamBranch.Tip);
+                if (history.AheadBy.HasValue && history.BehindBy.HasValue &&
+                    history.AheadBy.Value == 0 && history.BehindBy.Value > 0)
+                {
+                    // we can sync!
+                    log.Debug("Fetching and merging " + history.BehindBy.Value + " commits to branch " + branch.Name + " from remote " + upstream.Name);
+                    var refspec = string.Format(CultureInfo.InvariantCulture, "{0}:{0}", branch.Name);
+                    return gitClient.Value.Fetch(gitRepo, upstream.Name, refspec)
+                        .Select(x => gitClient.Value.Push(gitRepo, branch.Name, branch.Remote.Name))
+                        .Select(x => true);
+                }
+            }
+
+
+            return Observable.Return(true);
+        }
+    }
+}

--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -24,6 +24,15 @@ namespace GitHub.Services
         IObservable<Unit> Fetch(IRepository repository, string remoteName);
 
         /// <summary>
+        /// Fetches the remote with a specific refspec.
+        /// </summary>
+        /// <param name="repository">The repository to pull</param>
+        /// <param name="remoteName">The name of the remote</param>
+        /// <param name="refSpec">The refspec to use</param>
+        /// <returns></returns>
+        IObservable<Unit> Fetch(IRepository repository, string remoteName, string refSpec);
+
+        /// <summary>
         /// Sets the specified remote to the specified URL.
         /// </summary>
         /// <param name="repository">The repository to set</param>

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -129,6 +129,7 @@
     <Compile Include="ViewModels\IServiceProviderAware.cs" />
     <Compile Include="UI\IView.cs" />
     <Compile Include="UI\Octicon.cs" />
+    <Compile Include="ViewModels\ICloneSyncViewModel.cs" />
     <Compile Include="ViewModels\IGitHubConnectSection.cs" />
     <Compile Include="ViewModels\IGitHubInvitationSection.cs" />
     <Compile Include="ViewModels\IGitHubHomeSection.cs" />

--- a/src/GitHub.Exports/ViewModels/ICloneSyncViewModel.cs
+++ b/src/GitHub.Exports/ViewModels/ICloneSyncViewModel.cs
@@ -1,0 +1,14 @@
+﻿using GitHub.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitHub.ViewModels
+{
+    public interface ICloneSyncViewModel
+    {
+        IObservable<bool> Sync(ISimpleRepositoryModel repo);
+    }
+}

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -247,6 +247,7 @@
     <Compile Include="TeamExplorer\Home\IssuesNavigationItem.cs" />
     <Compile Include="TeamExplorer\Home\WikiNavigationItem.cs" />
     <Compile Include="TeamExplorer\Home\PulseNavigationItem.cs" />
+    <Compile Include="TeamExplorer\Sync\CloneSync.cs" />
     <Compile Include="TeamExplorer\Sync\GitHubPublishSection.cs" />
     <Compile Include="UI\DrawingExtensions.cs" />
     <Compile Include="UI\GitHubPane.cs" />

--- a/src/GitHub.VisualStudio/Resources.Designer.cs
+++ b/src/GitHub.VisualStudio/Resources.Designer.cs
@@ -502,6 +502,15 @@ namespace GitHub.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Synchronize Clone.
+        /// </summary>
+        public static string SynchronizeCloneText {
+            get {
+                return ResourceManager.GetString("SynchronizeCloneText", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Two-factor authentication.
         /// </summary>
         public static string twoFactorAuthText {

--- a/src/GitHub.VisualStudio/Resources.resx
+++ b/src/GitHub.VisualStudio/Resources.resx
@@ -276,4 +276,7 @@
   <data name="WikiNavigationItemText" xml:space="preserve">
     <value>Wiki</value>
   </data>
+  <data name="SynchronizeCloneText" xml:space="preserve">
+    <value>Synchronize Clone</value>
+  </data>
 </root>

--- a/src/GitHub.VisualStudio/TeamExplorer/Sync/CloneSync.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Sync/CloneSync.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using GitHub.VisualStudio.Base;
+using Microsoft.TeamFoundation.Controls;
+using GitHub.Api;
+using GitHub.VisualStudio.Helpers;
+using GitHub.Services;
+using GitHub.UI;
+using GitHub.ViewModels;
+using GitHub.Models;
+using GitHub.Extensions;
+using System.Reactive.Linq;
+
+namespace GitHub.VisualStudio.TeamExplorer.Sync
+{
+    [TeamExplorerNavigationItem(CloneSyncId, NavigationItemPriority.Graphs, TargetPageId=TeamExplorerPageIds.GitCommits)]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public class CloneSync : TeamExplorerNavigationItemBase
+    {
+        public const string CloneSyncId = "92655B52-360D-4BF5-95C5-D9E9E596AC77";
+        readonly Lazy<ICloneSyncViewModel> vm;
+
+        [ImportingConstructor]
+        public CloneSync(ISimpleApiClientFactory apiFactory, ITeamExplorerServiceHolder holder,
+            Lazy<ICloneSyncViewModel> vm)
+            : base(apiFactory, holder, Octicon.repo_clone)
+        {
+            Text = Resources.SynchronizeCloneText;
+            ArgbColor = Colors.LightBlueNavigationItem.ToInt32();
+            this.vm = vm;
+        }
+
+        public async override void Execute()
+        {
+            await Task.Run(() =>
+            {
+                var obs = vm.Value.Sync(ActiveRepo);
+                obs.Subscribe();
+                return true;
+            });
+            base.Execute();
+        }
+    }
+}


### PR DESCRIPTION
When you fork a repo, it's hard to keep it in sync with the upstream
repository. This experimental feature goes through all the remote
branches of a configured "upstream" remote, grab all local branches
which match by name, have not diverged in history but are behind the
upstream remote branch, updates the local branches via a fast forward
fetch, and pushes the updated local branches to the "origin" remote, so
that the fork is synchronized on the server with upstream.