### PR TITLE
Cleanup enterprise host detection code

### DIFF
--- a/src/GitHub.Api/SimpleApiClient.cs
+++ b/src/GitHub.Api/SimpleApiClient.cs
@@ -74,7 +74,7 @@ namespace GitHub.Api
             catch (ApiException apiex)
             {
                 if (!HostAddress.IsGitHubDotComUri(OriginalUrl.ToRepositoryUrl()))
-                    isEnterprise = apiex.HttpResponse?.Headers.ContainsKey("X-GitHub-Request-Id");
+                    isEnterprise = apiex.IsGitHubApiException();
             }
             catch {}
             finally

--- a/src/GitHub.Exports/ExceptionExtensions.cs
+++ b/src/GitHub.Exports/ExceptionExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Octokit;
+
+namespace GitHub.Extensions
+{
+    public static class ExceptionExtensions
+    {
+        const string GithubHeader = "X-GitHub-Request-Id";
+        public static bool IsGitHubApiException(this Exception ex)
+        {
+            var apiex = ex as ApiException;
+            return apiex?.HttpResponse?.Headers.ContainsKey(GithubHeader) ?? false;
+        }
+    }
+}

--- a/src/GitHub.Exports/ExceptionExtensions.cs
+++ b/src/GitHub.Exports/ExceptionExtensions.cs
@@ -3,7 +3,7 @@ using Octokit;
 
 namespace GitHub.Extensions
 {
-    public static class ExceptionExtensions
+    public static class ApiExceptionExtensions
     {
         const string GithubHeader = "X-GitHub-Request-Id";
         public static bool IsGitHubApiException(this Exception ex)

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -97,6 +97,7 @@
       <Link>Key.snk</Link>
     </None>
     <Compile Include="Collections\ICopyable.cs" />
+    <Compile Include="ExceptionExtensions.cs" />
     <Compile Include="Helpers\INotifyPropertySource.cs" />
     <Compile Include="Extensions\PropertyNotifierExtensions.cs" />
     <Compile Include="Extensions\SimpleRepositoryModelExtensions.cs" />

--- a/src/GitHub.Exports/Services/EnterpriseProbeTask.cs
+++ b/src/GitHub.Exports/Services/EnterpriseProbeTask.cs
@@ -41,9 +41,7 @@ namespace GitHub.Services
             var ret = await httpClient
                     .Send(request, CancellationToken.None)
                     .Catch(ex => {
-                        var apiex = ex as ApiException;
-                        if (apiex != null)
-                            success = apiex.HttpResponse?.Headers.ContainsKey("X-GitHub-Request-Id") ?? false;
+                        success = ex.IsGitHubApiException();
                         return null;
                     });
 


### PR DESCRIPTION
@Haacked I ended up cleaning the code up really quick. Feel free to play with it if you want! The extension class is in GitHub.Exports and not in GitHub.Extensions because the latter doesn't reference Octokit. No particular reason why it doesn't, it just never needed to before. Maybe other extensions should be moved there as well, or do we want to keep GitHub.Extensions a library that only extends .NET base classes and not other things?