### PR TITLE
Unused field GuidList.guidContextMenuSet breaks build

### DIFF
--- a/src/GitHub.VisualStudio/Settings.cs
+++ b/src/GitHub.VisualStudio/Settings.cs
@@ -2,6 +2,7 @@
 // MUST match guids.h
 using Microsoft.TeamFoundation.Controls;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace GitHub.VisualStudio
 {
@@ -10,9 +11,12 @@ namespace GitHub.VisualStudio
         public const string guidGitHubPkgString = "c3d3dc68-c977-411f-b3e8-03b0dccf7dfc";
         public const string guidGitHubCmdSetString = "c4c91892-8881-4588-a5d9-b41e8f540f5a";
         public const string guidGitHubToolbarCmdSetString = "C5F1193E-F300-41B3-B4C4-5A703DD3C1C6";
+        public const string guidContextMenuSetString = "31057D08-8C3C-4C5B-9F91-8682EA08EC27";
 
         public static readonly Guid guidGitHubCmdSet = new Guid(guidGitHubCmdSetString);
         public static readonly Guid guidGitHubToolbarCmdSet = new Guid(guidGitHubToolbarCmdSetString);
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Already used in https://github.com/github/VisualStudio/pull/156")]
+        public static readonly Guid guidContextMenuSet = new Guid(guidContextMenuSetString);
     }
 
     static class NavigationItemPriority

--- a/src/GitHub.VisualStudio/Settings.cs
+++ b/src/GitHub.VisualStudio/Settings.cs
@@ -10,11 +10,9 @@ namespace GitHub.VisualStudio
         public const string guidGitHubPkgString = "c3d3dc68-c977-411f-b3e8-03b0dccf7dfc";
         public const string guidGitHubCmdSetString = "c4c91892-8881-4588-a5d9-b41e8f540f5a";
         public const string guidGitHubToolbarCmdSetString = "C5F1193E-F300-41B3-B4C4-5A703DD3C1C6";
-        public const string guidContextMenuSetString = "31057D08-8C3C-4C5B-9F91-8682EA08EC27";
 
         public static readonly Guid guidGitHubCmdSet = new Guid(guidGitHubCmdSetString);
         public static readonly Guid guidGitHubToolbarCmdSet = new Guid(guidGitHubToolbarCmdSetString);
-        public static readonly Guid guidContextMenuSet = new Guid(guidContextMenuSetString);
     }
 
     static class NavigationItemPriority


### PR DESCRIPTION
The field `GuidList.guidContextMenuSet` breaks build of GitHub.VisualStudio project with error:

    >  Running Code Analysis...
    >MSBUILD : error CA1823: Microsoft.Performance : It appears that field 'GuidList.guidContextMenuSet' is never used or is only ever assigned to. Use this field or remove it.
    >  Code Analysis Complete -- 1 error(s), 0 warning(s)

I tried `Build` and `Rebuild` on `GitHub.VisualStudio` project and both fails ([build output](https://github.com/github/VisualStudio/files/83306/unused-field-build-output.txt) and [error list](https://github.com/github/VisualStudio/files/83305/unused-field-error-list.txt)).

Removing this field fixes the build.  The GUID from this field is stored in GitHub.VisualStudio.vsct so it won't be lost.

