### PR TITLE
Fix the build

### DIFF
--- a/src/GitHub.VisualStudio/Settings.cs
+++ b/src/GitHub.VisualStudio/Settings.cs
@@ -14,6 +14,8 @@ namespace GitHub.VisualStudio
 
         public static readonly Guid guidGitHubCmdSet = new Guid(guidGitHubCmdSetString);
         public static readonly Guid guidGitHubToolbarCmdSet = new Guid(guidGitHubToolbarCmdSetString);
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Already used in https://github.com/github/VisualStudio/pull/156")]
         public static readonly Guid guidContextMenuSet = new Guid(guidContextMenuSetString);
     }
 


### PR DESCRIPTION
Add SuppressMessage attribute for unused field GuidList.guidContextMenuSet.

This field breaks build of GitHub.VisualStudio project with error:

    >  Running Code Analysis...
    >MSBUILD : error CA1823: Microsoft.Performance : It appears that field 'GuidList.guidContextMenuSet' is never used or is only ever assigned to. Use this field or remove it.
    >  Code Analysis Complete -- 1 error(s), 0 warning(s)

This field is already used in another branch (PR https://github.com/github/VisualStudio/pull/156).