### PR TITLE
Fix crash after publishing new repository

### DIFF
--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -152,7 +152,6 @@ namespace GitHub.Controllers
         {
             uiProvider.RemoveService(typeof(IConnection));
             transition.OnCompleted();
-            completion?.OnNext(success);
             completion?.OnCompleted();
             completion = null;
         }

--- a/src/GitHub.VisualStudio/TeamExplorer/Sync/GitHubPublishSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Sync/GitHubPublishSection.cs
@@ -117,7 +117,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             disposable = uiflow;
             var ui = uiflow.Value;
             var creation = ui.SelectFlow(UIControllerFlow.Publish);
-            ui.ListenToCompletionState().Subscribe(done =>
+            ui.ListenToCompletionState().Subscribe(_ => { }, () =>
             {
                 IsVisible = false;
                 ServiceProvider.TryGetService<ITeamExplorer>()?.NavigateToPage(new Guid(TeamExplorerPageIds.Home), null);


### PR DESCRIPTION
Visual Studio crashed after publishing, but the publishing process completed before the crash. The completion.OnNext() subscriber changes the active UI, which disposes the UIController. The subsequent completion?.OnCompleted() call threw an exception because completion is not null, but it is disposed. Since the OnNext subscriber is not evaluating the parameter, I changed the subscriber to respond to the OnCompleted() event instead. This appears to fix the issue.