### PR TITLE
Fix connections not being passed on to view models

### DIFF
--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -18,6 +18,7 @@ using NullGuard;
 using ReactiveUI;
 using Stateless;
 using System.Collections.Specialized;
+using System.Linq;
 
 namespace GitHub.Controllers
 {
@@ -226,7 +227,11 @@ namespace GitHub.Controllers
         {
             if (connection != null)
             {
-                uiProvider.AddService(typeof(IConnection), connection);
+                if (currentFlow != UIControllerFlow.Authentication)
+                    uiProvider.AddService(connection);
+                else // sanity check: it makes zero sense to pass a connection in when calling the auth flow
+                    Debug.Assert(false, "Calling the auth flow with a connection makes no sense!");
+
                 connection.Login()
                     .Select(c => hosts.LookupHost(connection.HostAddress))
                     .Do(host =>
@@ -253,13 +258,21 @@ namespace GitHub.Controllers
                     .IsLoggedIn(hosts)
                     .Do(loggedin =>
                     {
-                        if (!loggedin && currentFlow != UIControllerFlow.Authentication)
+                        if (currentFlow != UIControllerFlow.Authentication)
                         {
-                            connectionAdded = (s, e) => {
-                                if (e.Action == NotifyCollectionChangedAction.Add)
-                                    uiProvider.AddService(typeof(IConnection), e.NewItems[0]);
-                            };
-                            connectionManager.Connections.CollectionChanged += connectionAdded;
+                            if (loggedin) // register the first available connection so the viewmodel can use it
+                                uiProvider.AddService(connectionManager.Connections.First(c => hosts.LookupHost(c.HostAddress).IsLoggedIn));
+                            else
+                            {
+                                // a connection will be added to the list when auth is done, register it so the next
+                                // viewmodel can use it
+                                connectionAdded = (s, e) =>
+                                {
+                                    if (e.Action == NotifyCollectionChangedAction.Add)
+                                        uiProvider.AddService(typeof(IConnection), e.NewItems[0]);
+                                };
+                                connectionManager.Connections.CollectionChanged += connectionAdded;
+                            }
                         }
 
                         machine.Configure(UIViewType.None)

--- a/src/GitHub.App/Models/ConnectionRepositoryHostMap.cs
+++ b/src/GitHub.App/Models/ConnectionRepositoryHostMap.cs
@@ -10,7 +10,7 @@ namespace GitHub.ViewModels
     {
         [ImportingConstructor]
         public ConnectionRepositoryHostMap(IUIProvider provider, IRepositoryHosts hosts)
-            : this(provider.GetService<IConnection>(), hosts)
+            : this(provider.TryGetService<IConnection>(), hosts)
         {
         }
 

--- a/src/GitHub.Exports/Services/IUIProvider.cs
+++ b/src/GitHub.Exports/Services/IUIProvider.cs
@@ -18,6 +18,7 @@ namespace GitHub.Services
         T TryGetService<T>() where T : class;
 
         void AddService(Type t, object instance);
+        void AddService<T>(T instance);
         void RemoveService(Type t);
 
         IObservable<UserControl> SetupUI(UIControllerFlow controllerFlow, IConnection connection);

--- a/src/GitHub.VisualStudio/Services/UIProvider.cs
+++ b/src/GitHub.VisualStudio/Services/UIProvider.cs
@@ -144,6 +144,11 @@ namespace GitHub.VisualStudio
             return GetService<T>() as Ret;
         }
 
+        public void AddService<T>(T instance)
+        {
+            AddService(typeof(T), instance);
+        }
+
         public void AddService(Type t, object instance)
         {
             if (!Initialized)

--- a/src/UnitTests/GitHub.Exports/VSServicesTests.cs
+++ b/src/UnitTests/GitHub.Exports/VSServicesTests.cs
@@ -16,6 +16,7 @@ public class VSServicesTests
             var provider = Substitute.For<IUIProvider>();
             var gitRepositoriesExt = Substitute.For<IGitRepositoriesExt>();
             provider.GetService(typeof(IGitRepositoriesExt)).Returns(gitRepositoriesExt);
+            provider.TryGetService(typeof(IGitRepositoriesExt)).Returns(gitRepositoriesExt);
             var vsServices = new VSServices(provider);
 
             vsServices.Clone("https://github.com/github/visualstudio", @"c:\fake\ghfvs", recurseSubmodules);


### PR DESCRIPTION
Fix a bug where if we're logged in but don't pass a connection to Start, no connection object would be passed along to whatever viewmodel we're loading, which is a Bad Thing(tm).

If we're logged in but no connection object is passed in, we should retrieve the first available logged-in connection from the connections list and pass that one in, so that viewmodels *always* get a connection.