### PR TITLE
Fix a delay in loading the connect page

### DIFF
--- a/src/GitHub.Exports/Models/IConnectionManager.cs
+++ b/src/GitHub.Exports/Models/IConnectionManager.cs
@@ -2,7 +2,7 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using GitHub.Primitives;
-using GitHub.Services;
+using System.Threading.Tasks;
 
 namespace GitHub.Models
 {
@@ -19,6 +19,6 @@ namespace GitHub.Models
         // for telling IRepositoryHosts that we need to login from cache
         [SuppressMessage("Microsoft.Design", "CA1009:DeclareEventHandlersCorrectly")]
         event Func<IConnection, IObservable<IConnection>> DoLogin;
-        void RefreshRepositories();
+        Task RefreshRepositories();
     }
 }

--- a/src/GitHub.Exports/Services/VSServices.cs
+++ b/src/GitHub.Exports/Services/VSServices.cs
@@ -124,10 +124,9 @@ namespace GitHub.Services
                             if (path != null)
                                 return new SimpleRepositoryModel(path);
                         }
-                        // no sense spamming the log, the registry might have ton of stale things we don't care about
                         catch (Exception)
                         {
-                            //VsOutputLogger.WriteLine(string.Format(CultureInfo.CurrentCulture, "Error loading the repository from the registry '{0}'", ex));
+                            // no sense spamming the log, the registry might have ton of stale things we don't care about
                         }
                         return null;
                     }

--- a/src/GitHub.Exports/Services/VSServices.cs
+++ b/src/GitHub.Exports/Services/VSServices.cs
@@ -124,9 +124,10 @@ namespace GitHub.Services
                             if (path != null)
                                 return new SimpleRepositoryModel(path);
                         }
-                        catch (Exception ex)
+                        // no sense spamming the log, the registry might have ton of stale things we don't care about
+                        catch (Exception)
                         {
-                            VsOutputLogger.WriteLine(string.Format(CultureInfo.CurrentCulture, "Error loading the repository from the registry '{0}'", ex));
+                            //VsOutputLogger.WriteLine(string.Format(CultureInfo.CurrentCulture, "Error loading the repository from the registry '{0}'", ex));
                         }
                         return null;
                     }

--- a/src/GitHub.VisualStudio/Services/ConnectionManager.cs
+++ b/src/GitHub.VisualStudio/Services/ConnectionManager.cs
@@ -8,6 +8,7 @@ using System.Text;
 using GitHub.Models;
 using GitHub.Services;
 using GitHub.Primitives;
+using System.Threading.Tasks;
 
 namespace GitHub.VisualStudio
 {
@@ -126,9 +127,9 @@ namespace GitHub.VisualStudio
             Connections.Remove(connection);
         }
 
-        public void RefreshRepositories()
+        public async Task RefreshRepositories()
         {
-            var list = vsServices.GetKnownRepositories();
+            var list = await Task.Run(() => vsServices.GetKnownRepositories());
             list.GroupBy(r => Connections.FirstOrDefault(c => r.CloneUrl != null && c.HostAddress.Equals(HostAddress.Create(r.CloneUrl))))
                 .Where(g => g.Key != null)
                 .ForEach(g =>


### PR DESCRIPTION
Querying the registry for repositories so we can load the repository list in the Connect page is visibly delaying the UI, which is a no-no! Fixicate.