### PR TITLE
[wip] :art: Cleanup GetService and TryGetService some more.

### DIFF
--- a/src/GitHub.App/Models/ConnectionRepositoryHostMap.cs
+++ b/src/GitHub.App/Models/ConnectionRepositoryHostMap.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.Composition;
 using GitHub.Models;
 using GitHub.Services;
+using GitHub.Extensions;
 
 namespace GitHub.ViewModels
 {

--- a/src/GitHub.Exports/Services/IUIProvider.cs
+++ b/src/GitHub.Exports/Services/IUIProvider.cs
@@ -10,12 +10,8 @@ namespace GitHub.Services
     {
         ExportProvider ExportProvider { get; }
         IServiceProvider GitServiceProvider { get; set; }
-        T GetService<T>();
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
-        Ret GetService<T, Ret>() where Ret : class;
 
         object TryGetService(Type t);
-        T TryGetService<T>() where T : class;
 
         void AddService(Type t, object instance);
         void AddService<T>(T instance);


### PR DESCRIPTION
Cleanup some redundant and duplicated code. `UIProvider` should only use non-generic variants of GetService/TryGetService so that calls don't spill over to `ServiceProviderExtensions.cs` and potentially cause recursive calls. Everyone else goes through the extension methods.