### PR TITLE
Make UIController connection handling safer

### DIFF
--- a/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
@@ -12,8 +12,7 @@ namespace GitHub.Extensions
         {
             return cm.Connections.ToObservable()
                     .SelectMany(c => c.Login())
-                    .Select(c => hosts.LookupHost(c.HostAddress))
-                    .Any(h => h.IsLoggedIn);
+                    .Any(c => hosts.LookupHost(c.HostAddress).IsLoggedIn);
         }
 
         public static IObservable<bool> IsLoggedIn(this IConnectionManager cm, IRepositoryHosts hosts, HostAddress address)
@@ -21,8 +20,14 @@ namespace GitHub.Extensions
             return cm.Connections.ToObservable()
                     .Where(c => c.HostAddress.Equals(address))
                     .SelectMany(c => c.Login())
-                    .Select(c => hosts.LookupHost(c.HostAddress))
-                    .Any(h => h.IsLoggedIn);
+                    .Any(c => hosts.LookupHost(c.HostAddress).IsLoggedIn);
+        }
+
+        public static IObservable<IConnection> GetLoggedInConnections(this IConnectionManager cm, IRepositoryHosts hosts)
+        {
+            return cm.Connections.ToObservable()
+                    .SelectMany(c => c.Login())
+                    .Where(c => hosts.LookupHost(c.HostAddress).IsLoggedIn);
         }
     }
 }


### PR DESCRIPTION
In case something changes in the extension methods that causes the assumption that the `Connections` list always has at least one entry
when we're logged in to not be true. Which shouldn't happen in the current setup. But I get the feeling we're going to be needing a handy method for getting logged in connections in the near future, so why not.