### PR TITLE
Allow the Account property to return null.

### DIFF
--- a/src/GitHub.App/ViewModels/GistCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/GistCreationViewModel.cs
@@ -67,7 +67,12 @@ namespace GitHub.ViewModels
         }
 
         public IReactiveCommand<Gist> CreateGist { get; }
-        public IAccount Account { get { return account.Value; } }
+
+        public IAccount Account
+        {
+            [return: AllowNull]
+            get { return account.Value; }
+        }
 
         bool isPrivate;
         public bool IsPrivate


### PR DESCRIPTION
@shana, because we get the [account asynchronously](https://github.com/georgebearden/VisualStudio/blob/092fc5b6cb6adcc57a137bbb45bb10dba32f439b/src/GitHub.App/ViewModels/GistCreationViewModel.cs#L45-L49) when instantiating the `GistCreationViewModel`, it can be null when we try to Bind it to the Gist popup which causes a fody nullguard assertion error like this one
![nullguard_assertion](https://cloud.githubusercontent.com/assets/7898345/12385084/8edbb88e-bd86-11e5-8cf0-5ca4de29e5c5.PNG).

Allowing the `Account` property to return null fixes the issue and I verified that everything works as expected as eventually the async call returns with our account and we have our nice avatar and username in the view.
