### PR TITLE
Fix race condition when finishing ui flows

### DIFF
--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -156,7 +156,6 @@ namespace GitHub.Controllers
             completion?.OnNext(success);
             completion?.OnCompleted();
             transition.OnCompleted();
-            completion = null;
         }
 
         void RunView(UIViewType viewType)

--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -153,9 +153,9 @@ namespace GitHub.Controllers
         void End(bool success)
         {
             uiProvider.RemoveService(typeof(IConnection));
-            transition.OnCompleted();
             completion?.OnNext(success);
             completion?.OnCompleted();
+            transition.OnCompleted();
             completion = null;
         }
 

--- a/src/GitHub.Exports/Services/IUIProvider.cs
+++ b/src/GitHub.Exports/Services/IUIProvider.cs
@@ -24,5 +24,6 @@ namespace GitHub.Services
         IObservable<UserControl> SetupUI(UIControllerFlow controllerFlow, IConnection connection);
         void RunUI();
         void RunUI(UIControllerFlow controllerFlow, IConnection connection);
+        IObservable<bool> ListenToCompletionState();
     }
 }

--- a/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Connect/GitHubConnectSection.cs
@@ -323,14 +323,18 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
         {
             var uiProvider = ServiceProvider.GetExportedValue<IUIProvider>();
             uiProvider.GitServiceProvider = ServiceProvider;
-            var ret = uiProvider.SetupUI(controllerFlow, SectionConnection);
-            ret.Subscribe(_ => {}, () =>
-            {
-                if (controllerFlow == UIControllerFlow.Clone)
-                    isCloning = true;
-                else if (controllerFlow == UIControllerFlow.Create)
-                    isCreating = true;
-            });
+            uiProvider.SetupUI(controllerFlow, SectionConnection);
+            uiProvider.ListenToCompletionState()
+                .Subscribe(success =>
+                {
+                    if (success)
+                    {
+                        if (controllerFlow == UIControllerFlow.Clone)
+                            isCloning = true;
+                        else if (controllerFlow == UIControllerFlow.Create)
+                            isCreating = true;
+                    }
+                });
             uiProvider.RunUI();
         }
 

--- a/src/GitHub.VisualStudio/TeamExplorer/Sync/GitHubPublishSection.cs
+++ b/src/GitHub.VisualStudio/TeamExplorer/Sync/GitHubPublishSection.cs
@@ -118,19 +118,20 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             var ui = uiflow.Value;
             var creation = ui.SelectFlow(UIControllerFlow.Publish);
             bool success = false;
-            ui.ListenToCompletionState().Subscribe(s => success = s, () =>
-            {
-                // there's no real cancel button in the publish form, but if support a back button there, then we want to hide the form
-                IsVisible = false;
-                if (success)
-                    ServiceProvider.TryGetService<ITeamExplorer>()?.NavigateToPage(new Guid(TeamExplorerPageIds.Home), null);
-            });
+            ui.ListenToCompletionState().Subscribe(s => success = s);
 
             creation.Subscribe(c =>
             {
                 SectionContent = c;
                 c.DataContext = this;
                 ((IView)c).IsBusy.Subscribe(x => IsBusy = x);
+            },
+            () =>
+            {
+                // there's no real cancel button in the publish form, but if support a back button there, then we want to hide the form
+                IsVisible = false;
+                if (success)
+                    ServiceProvider.TryGetService<ITeamExplorer>()?.NavigateToPage(new Guid(TeamExplorerPageIds.Home), null);
             });
             ui.Start(null);
         }
@@ -142,9 +143,8 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             {
                 if (!disposed)
                 {
-                    if (disposable != null)
-                        disposable.Dispose();
                     disposed = true;
+                    disposable?.Dispose();
                 }
             }
             base.Dispose(disposing);

--- a/src/UnitTests/GitHub.App/Controllers/UIProviderTests.cs
+++ b/src/UnitTests/GitHub.App/Controllers/UIProviderTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.ComponentModel.Composition;
+using System.Reactive.Linq;
+using System.Windows.Controls;
+using GitHub.Controllers;
+using GitHub.Models;
+using GitHub.Services;
+using GitHub.UI;
+using NSubstitute;
+using Xunit;
+using UnitTests;
+using GitHub.ViewModels;
+using ReactiveUI;
+using System.Collections.Generic;
+using GitHub.Authentication;
+using System.Collections.ObjectModel;
+using GitHub.VisualStudio;
+
+public class UIProviderTests : TestBaseClass
+{
+    [Fact]
+    public void ListenToCompletionDoesNotThrowInRelease()
+    {
+        var provider = Substitutes.GetFullyMockedServiceProvider();
+
+        using (var p = new UIProvider(provider))
+        {
+#if DEBUG
+            Assert.ThrowsAny<InvalidOperationException>(() =>
+            {
+#endif
+                p.ListenToCompletionState();
+#if DEBUG
+            });
+#endif
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -139,6 +139,7 @@
     <Compile Include="GitHub.Api\SimpleApiClientTests.cs" />
     <Compile Include="GitHub.App\Caches\CredentialCacheTests.cs" />
     <Compile Include="GitHub.App\Caches\ImageCacheTests.cs" />
+    <Compile Include="GitHub.App\Controllers\UIProviderTests.cs" />
     <Compile Include="GitHub.App\Models\ModelServiceTests.cs" />
     <Compile Include="GitHub.App\Controllers\UIControllerTests.cs" />
     <Compile Include="GitHub.App\Models\PullRequestModelTests.cs" />


### PR DESCRIPTION
Let's decide that the `IUIController.ListenToCompletionState` observable finishes first, and then the `IUIController.SelectFlow` observable. Once the `SelectFlow` observable is completed, it's a fair bet that the `IUIController` is disposed and it isn't safe to access it for anything else.

Sanitize calls to `SelectFlow` and `ListenToCompletionState` so that UI navigation (which triggers `Dispose` to be called on everything) will only happen on completion of the observable returned by `SelectFlow`, as it is the last observable to be completed and things are safe to dispose after that.

Fixes #203 properly