### PR TITLE
Fix the content binding on the ActionLinkButton

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/Controls/ActionLinkButton.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/ActionLinkButton.xaml
@@ -47,7 +47,7 @@
                                         </Style.Triggers>
                                     </Style>
                                 </Hyperlink.Resources>
-                                <Run Text="{TemplateBinding Content}" />
+                                <Run Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}" />
                             </Hyperlink>
                     </TextBlock>
                 </ControlTemplate>


### PR DESCRIPTION
It's only working currently because the action link is not embedded in other bound controls, fails when used inside bound lists for eg.