### PR TITLE
 Fixes Bug - GitHub section of Home page is cut when large font is used

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/GitHubHomeContent.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/GitHubHomeContent.xaml
@@ -9,7 +9,7 @@
              xmlns:cache="clr-namespace:GitHub.VisualStudio.Helpers"
              mc:Ignorable="d"
              d:DesignHeight="48"
-             Height="48"
+             Height="auto"
              d:DesignWidth="300"
              DataContext="{Binding ViewModel}"
              Background="{DynamicResource GitHubVsToolWindowBackground}"
@@ -34,28 +34,26 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Hidden">
-        <StackPanel Margin="8,0">
-            <Grid Margin="0,6,-4,6">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition ColumnDefinition.Width="Auto" />
-                    <ColumnDefinition ColumnDefinition.Width="*" />
-                </Grid.ColumnDefinitions>
-    
-            <ui:OcticonImage
-                    x:Name="repositoryIcon"
-                    Height="32"
-                    Width="32"
-                    VerticalAlignment="Center" 
-                    Margin="0,0,8,0"
-                    Icon="{Binding Path=Icon}"
-                    Foreground="{DynamicResource GitHubVsToolWindowText}" />
-    
-                <StackPanel Orientation="Vertical" Margin="0" Grid.Column="1">
-                    <Label Content="{Binding Path=RepoName}"  Foreground="{DynamicResource GitHubVsToolWindowText}"/>
-                    <Label Content="{Binding Path=RepoUrl}" Foreground="{DynamicResource GitHubVsGrayText}" />
-                </StackPanel>
-            </Grid>
-        </StackPanel>
-    </ScrollViewer>    
+    <StackPanel Margin="8,0">
+        <Grid Margin="0,6,-4,6">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition ColumnDefinition.Width="Auto" />
+                <ColumnDefinition ColumnDefinition.Width="*" />
+            </Grid.ColumnDefinitions>
+
+        <ui:OcticonImage
+                x:Name="repositoryIcon"
+                Height="32"
+                Width="32"
+                VerticalAlignment="Center" 
+                Margin="0,0,8,0"
+                Icon="{Binding Path=Icon}"
+                Foreground="{DynamicResource GitHubVsToolWindowText}" />
+
+            <StackPanel Orientation="Vertical" Margin="0" Grid.Column="1">
+                <Label Content="{Binding Path=RepoName}"  Foreground="{DynamicResource GitHubVsToolWindowText}"/>
+                <Label Content="{Binding Path=RepoUrl}" Foreground="{DynamicResource GitHubVsGrayText}" />
+            </StackPanel>
+        </Grid>
+    </StackPanel>
 </UserControl>

--- a/src/GitHub.VisualStudio/UI/Views/GitHubHomeContent.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/GitHubHomeContent.xaml
@@ -34,26 +34,28 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <StackPanel Margin="8,0">
-        <Grid Margin="0,6,-4,6">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition ColumnDefinition.Width="Auto" />
-                <ColumnDefinition ColumnDefinition.Width="*" />
-            </Grid.ColumnDefinitions>
-
-        <ui:OcticonImage
-                x:Name="repositoryIcon"
-                Height="32"
-                Width="32"
-                VerticalAlignment="Center" 
-                Margin="0,0,8,0"
-                Icon="{Binding Path=Icon}"
-                Foreground="{DynamicResource GitHubVsToolWindowText}" />
-
-            <StackPanel Orientation="Vertical" Margin="0" Grid.Column="1">
-                <Label Content="{Binding Path=RepoName}"  Foreground="{DynamicResource GitHubVsToolWindowText}"/>
-                <Label Content="{Binding Path=RepoUrl}" Foreground="{DynamicResource GitHubVsGrayText}" />
-            </StackPanel>
-        </Grid>
-    </StackPanel>
+    <ScrollViewer VerticalScrollBarVisibility="Hidden">
+        <StackPanel Margin="8,0">
+            <Grid Margin="0,6,-4,6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition ColumnDefinition.Width="Auto" />
+                    <ColumnDefinition ColumnDefinition.Width="*" />
+                </Grid.ColumnDefinitions>
+    
+            <ui:OcticonImage
+                    x:Name="repositoryIcon"
+                    Height="32"
+                    Width="32"
+                    VerticalAlignment="Center" 
+                    Margin="0,0,8,0"
+                    Icon="{Binding Path=Icon}"
+                    Foreground="{DynamicResource GitHubVsToolWindowText}" />
+    
+                <StackPanel Orientation="Vertical" Margin="0" Grid.Column="1">
+                    <Label Content="{Binding Path=RepoName}"  Foreground="{DynamicResource GitHubVsToolWindowText}"/>
+                    <Label Content="{Binding Path=RepoUrl}" Foreground="{DynamicResource GitHubVsGrayText}" />
+                </StackPanel>
+            </Grid>
+        </StackPanel>
+    </ScrollViewer>    
 </UserControl>


### PR DESCRIPTION
Bug link :- https://github.com/github/VisualStudio/issues/159 
This PR provides a ScrollViewer (hidden) so that all of the content can be seen just by scrolling. This is useful when the size of the font is increased large enough to fit the complete text inside StackPanel.