### PR TITLE
Add combobox UI

### DIFF
--- a/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
+++ b/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
@@ -63,7 +63,7 @@
                                  VerticalAlignment="Top">
                                 <TextBlock 
                                     Text="{TemplateBinding PromptText}" 
-                                    Opacity="0.3"
+                                    Opacity="0.5"
                                     TextTrimming="CharacterEllipsis" />
                             </Label>
                         </Grid>

--- a/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
+++ b/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
@@ -61,11 +61,6 @@
                                  IsHitTestVisible="False"
                                  HorizontalAlignment="Stretch"
                                  VerticalAlignment="Top">
-                                <Label.Style>
-                                    <Style TargetType="{x:Type Label}">
-                                        <Setter Property="Foreground" Value="{DynamicResource GitHubForegroundBrush}" />
-                                    </Style>
-                                </Label.Style>
                                 <TextBlock 
                                     Text="{TemplateBinding PromptText}" 
                                     Opacity="0.3"

--- a/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
+++ b/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
@@ -61,6 +61,11 @@
                                  IsHitTestVisible="False"
                                  HorizontalAlignment="Stretch"
                                  VerticalAlignment="Top">
+                                <Label.Style>
+                                    <Style TargetType="{x:Type Label}">
+                                        <Setter Property="Foreground" Value="{DynamicResource GitHubForegroundBrush}" />
+                                    </Style>
+                                </Label.Style>
                                 <TextBlock 
                                     Text="{TemplateBinding PromptText}" 
                                     Opacity="0.3"

--- a/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
+++ b/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
@@ -123,7 +123,6 @@
                         </Trigger>
                         <DataTrigger Binding="{Binding Text.Length, RelativeSource={RelativeSource Self}}" Value="0">
                             <Setter Property="Opacity" TargetName="PromptLabel" Value="0.7" />
-                            <Setter Property="Foreground" Value="Transparent" />
                             <Setter Property="Visibility" TargetName="clearButton" Value="Collapsed" />
                         </DataTrigger>
                     </ControlTemplate.Triggers>

--- a/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
+++ b/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
@@ -51,7 +51,7 @@
                                 Margin="0"/>
                             <Label x:Name="PromptLabel"
                                  FontSize="{TemplateBinding FontSize}" 
-                                 Foreground="{DynamicResource GitHubForegroundBrush}"
+                                 Foreground="{TemplateBinding Foreground}"
                                  Margin="2,0,0,0" 
                                  Padding="{TemplateBinding Padding}"
                                  Opacity="0"
@@ -63,6 +63,7 @@
                                  VerticalAlignment="Top">
                                 <TextBlock 
                                     Text="{TemplateBinding PromptText}" 
+                                    Opacity="0.3"
                                     TextTrimming="CharacterEllipsis" />
                             </Label>
                         </Grid>

--- a/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
+++ b/src/GitHub.UI/Assets/Controls/FilterTextBox.xaml
@@ -40,7 +40,7 @@
                             </Border>
                         </Border>
 
-                        <Grid Margin="1,0,0,0">
+                        <Grid Margin="1,1,0,0">
                             <ScrollViewer
                                 x:Name="PART_ContentHost"
                                 Padding="{TemplateBinding Padding}"

--- a/src/GitHub.UI/Assets/TextBlocks.xaml
+++ b/src/GitHub.UI/Assets/TextBlocks.xaml
@@ -71,7 +71,7 @@
                             </Border>
                         </Border>
 
-                        <Grid Margin="1,0,0,0">
+                        <Grid Margin="1,2,0,0">
                             <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" VerticalAlignment="Top" Margin="0"/>
                             <Label x:Name="PromptLabel" HorizontalAlignment="Left"
                                  Foreground="{DynamicResource GHTextBrush}"

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -358,6 +358,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Styles\GitHubComboBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Styles\ThemeBlue.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/GitHub.VisualStudio/SharedDictionary.xaml
+++ b/src/GitHub.VisualStudio/SharedDictionary.xaml
@@ -7,6 +7,7 @@
   <ResourceDictionary.MergedDictionaries>
     <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/ThemeDesignTime.xaml"/>
     <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/ActionLinkButton.xaml" />
+    <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/GitHubComboBox.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
   <Style x:Key="VSStyledButton" BasedOn="{StaticResource VsButtonStyleKey}" TargetType="{x:Type Button}" />

--- a/src/GitHub.VisualStudio/Styles/GitHubComboBox.xaml
+++ b/src/GitHub.VisualStudio/Styles/GitHubComboBox.xaml
@@ -1,0 +1,56 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
+                    xmlns:local="clr-namespace:GitHub.VisualStudio.Styles">
+    
+    <Style x:Key="GitHubComboBoxBorder" TargetType="{x:Type Border}">
+        <Setter Property="Margin" Value="10" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="BorderBrush" Value="{DynamicResource GitHubComboBoxBorderBrush}" />
+        <Setter Property="Effect">
+            <Setter.Value>
+                <DropShadowEffect Direction="315" ShadowDepth="5" BlurRadius="5" Opacity="0.25" />
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="GitHubComboBoxContainer" TargetType="{x:Type Grid}">
+        <Setter Property="Background" Value="{DynamicResource GitHubComboBoxBackgroundBrush}" />
+
+        <Style.Resources>
+            <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                <Setter Property="Foreground" Value="{DynamicResource GitHubVsToolWindowText}" />
+            </Style>
+
+            <Style TargetType="{x:Type ui:OcticonImage}" BasedOn="{StaticResource {x:Type ui:OcticonImage}}">
+                <Setter Property="Foreground" Value="{DynamicResource GitHubVsToolWindowText}" />
+            </Style>
+            
+            <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
+                <Setter Property="Background" Value="{DynamicResource GitHubComboBoxBorderBrush}" />
+                <Setter Property="Margin" Value="0" />
+            </Style>
+
+            <Style TargetType="{x:Type ui:FilterTextBox}" BasedOn="{StaticResource {x:Type ui:FilterTextBox}}">
+                <Setter Property="BorderBrush" Value="{DynamicResource GitHubComboBoxBorderBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource GitHubVsWindowText}" />
+                <Setter Property="Background" Value="{DynamicResource GitHubVsBrandedUIBackground}" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Height" Value="25" />
+            </Style>
+
+            <Style TargetType="{x:Type ListBox}" BasedOn="{StaticResource {x:Type ListBox}}">
+                <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="MaxHeight" Value="100" />
+            </Style>
+
+            <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                <Setter Property="Padding" Value="3" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            </Style>
+        </Style.Resources>
+    </Style>
+
+</ResourceDictionary>

--- a/src/GitHub.VisualStudio/Styles/GitHubComboBox.xaml
+++ b/src/GitHub.VisualStudio/Styles/GitHubComboBox.xaml
@@ -1,6 +1,11 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:cache="clr-namespace:GitHub.VisualStudio.Helpers"
                     xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI">
+
+    <ResourceDictionary.MergedDictionaries>
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+    </ResourceDictionary.MergedDictionaries>
     
     <Style x:Key="GitHubComboBoxBorder" TargetType="{x:Type Border}">
         <Setter Property="Margin" Value="10" />
@@ -25,7 +30,6 @@
                 <Setter Property="Foreground" Value="{DynamicResource GitHubVsToolWindowText}" />
             </Style>
 
-            
             <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
                 <Setter Property="Background" Value="{DynamicResource GitHubComboBoxBorderBrush}" />
                 <Setter Property="Margin" Value="0" />

--- a/src/GitHub.VisualStudio/Styles/GitHubComboBox.xaml
+++ b/src/GitHub.VisualStudio/Styles/GitHubComboBox.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
-                    xmlns:local="clr-namespace:GitHub.VisualStudio.Styles">
+                    xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI">
     
     <Style x:Key="GitHubComboBoxBorder" TargetType="{x:Type Border}">
         <Setter Property="Margin" Value="10" />
@@ -25,6 +24,7 @@
             <Style TargetType="{x:Type ui:OcticonImage}" BasedOn="{StaticResource {x:Type ui:OcticonImage}}">
                 <Setter Property="Foreground" Value="{DynamicResource GitHubVsToolWindowText}" />
             </Style>
+
             
             <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
                 <Setter Property="Background" Value="{DynamicResource GitHubComboBoxBorderBrush}" />

--- a/src/GitHub.VisualStudio/Styles/ThemeBlue.xaml
+++ b/src/GitHub.VisualStudio/Styles/ThemeBlue.xaml
@@ -36,4 +36,7 @@
   <SolidColorBrush x:Key="GitHubPrimaryButtonBorderBrush" Color="#FF599942" />
   <SolidColorBrush x:Key="GitHubPrimaryButtonBorderMouseOverBrush" Color="#FF68B34D" />
   <SolidColorBrush x:Key="GitHubPrimaryButtonBorderPressedBrush" Color="#FF599942" />
+
+  <SolidColorBrush x:Key="GitHubComboBoxBackgroundBrush" Color="#FFF6F6F6" />
+  <SolidColorBrush x:Key="GitHubComboBoxBorderBrush" Color="#FFCCCEDC" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/Styles/ThemeDark.xaml
+++ b/src/GitHub.VisualStudio/Styles/ThemeDark.xaml
@@ -41,4 +41,7 @@
   <SolidColorBrush x:Key="GitHubPrimaryButtonBorderBrush" Color="#FF7BA84D" />
   <SolidColorBrush x:Key="GitHubPrimaryButtonBorderMouseOverBrush" Color="#FF95CC5E" />
   <SolidColorBrush x:Key="GitHubPrimaryButtonBorderPressedBrush" Color="#FF7BA84D" />
+
+  <SolidColorBrush x:Key="GitHubComboBoxBackgroundBrush" Color="#FF1B1B1C" />
+  <SolidColorBrush x:Key="GitHubComboBoxBorderBrush" Color="#FF434346" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
+++ b/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
@@ -16,8 +16,6 @@
   <SolidColorBrush x:Key="GitHubVsSearchBoxBackground" Color="#FF333337" />
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FFF1F1F1" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FF3F3F46" />
-  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FF333337" />
-  <SolidColorBrush x:Key="GitHubVsMenu" Color="#FF1B1B1C" />
   -->
 
   <!-- Design time colors taken from the VS light theme
@@ -30,8 +28,6 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FF1E1E1E" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FFCCCEBD" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FFEEEEF2" />
-  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FFCCCEDB" />
-  <SolidColorBrush x:Key="GitHubVsMenu" Color="#FFF6F6F6" />
   -->
 
   <!-- Design time colors taken from the VS blue theme
@@ -45,6 +41,4 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FF000000" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FF8591A2" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FFFFFFFF" />
-  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FFCCCEDB" />
-  <SolidColorBrush x:Key="GitHubVsMenu" Color="#FFF6F6F6" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
+++ b/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
@@ -4,10 +4,11 @@
   xmlns:PresentationOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
 
   <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/ThemeLight.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/ThemeDark.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
   <!-- Design time colors taken from the VS dark theme
+  -->
   <SolidColorBrush x:Key="GitHubVsToolWindowText" Color="#FFFFFFFF" />
   <SolidColorBrush x:Key="GitHubVsToolWindowBackground" Color="#FF252526" />
   <SolidColorBrush x:Key="GitHubVsGrayText" Color="#FF999999" />
@@ -16,12 +17,10 @@
   <SolidColorBrush x:Key="GitHubVsSearchBoxBackground" Color="#FF333337" />
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FFF1F1F1" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FF3F3F46" />
-  <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FF2D2D30" />
-
-  -->
+  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBackgroundBegin" Color="#FFF6F6F6" />
+  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FFCCCEDB" />
 
   <!-- Design time colors taken from the VS light theme
-  -->
   <SolidColorBrush x:Key="GitHubVsToolWindowText" Color="#FF1E1E1E" />
   <SolidColorBrush x:Key="GitHubVsToolWindowBackground" Color="#FFF5F5F5" />
   <SolidColorBrush x:Key="GitHubVsGrayText" Color="#FF717171" />
@@ -31,6 +30,7 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FF1E1E1E" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FFCCCEBD" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FFEEEEF2" />
+  -->
 
   <!-- Design time colors taken from the VS blue theme
   <SolidColorBrush x:Key="GitHubVsToolWindowText" Color="#FF000000" />

--- a/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
+++ b/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
@@ -4,11 +4,10 @@
   xmlns:PresentationOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
 
   <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/ThemeDark.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/ThemeBlue.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
   <!-- Design time colors taken from the VS dark theme
-  -->
   <SolidColorBrush x:Key="GitHubVsToolWindowText" Color="#FFFFFFFF" />
   <SolidColorBrush x:Key="GitHubVsToolWindowBackground" Color="#FF252526" />
   <SolidColorBrush x:Key="GitHubVsGrayText" Color="#FF999999" />
@@ -17,8 +16,9 @@
   <SolidColorBrush x:Key="GitHubVsSearchBoxBackground" Color="#FF333337" />
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FFF1F1F1" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FF3F3F46" />
-  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBackgroundBegin" Color="#FF1B1B1C" />
   <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FF333337" />
+  <SolidColorBrush x:Key="GitHubVsMenu" Color="#FF1B1B1C" />
+  -->
 
   <!-- Design time colors taken from the VS light theme
   <SolidColorBrush x:Key="GitHubVsToolWindowText" Color="#FF1E1E1E" />
@@ -30,11 +30,12 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FF1E1E1E" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FFCCCEBD" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FFEEEEF2" />
-  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBackgroundBegin" Color="#FFF6F6F6" />
   <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FFCCCEDB" />
+  <SolidColorBrush x:Key="GitHubVsMenu" Color="#FFF6F6F6" />
   -->
 
   <!-- Design time colors taken from the VS blue theme
+  -->
   <SolidColorBrush x:Key="GitHubVsToolWindowText" Color="#FF000000" />
   <SolidColorBrush x:Key="GitHubVsToolWindowBackground" Color="#FFFFFFFF" />
   <SolidColorBrush x:Key="GitHubVsGrayText" Color="#FF6d6d6d" />
@@ -44,7 +45,6 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FF000000" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FF8591A2" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FFFFFFFF" />
-  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBackgroundBegin" Color="#FFEFEFEF" />
   <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FFCCCEDB" />
-  -->
+  <SolidColorBrush x:Key="GitHubVsMenu" Color="#FFF6F6F6" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
+++ b/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
@@ -4,7 +4,7 @@
   xmlns:PresentationOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
 
   <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/ThemeDark.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/ThemeLight.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
   <!-- Design time colors taken from the VS dark theme

--- a/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
+++ b/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
@@ -17,8 +17,8 @@
   <SolidColorBrush x:Key="GitHubVsSearchBoxBackground" Color="#FF333337" />
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FFF1F1F1" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FF3F3F46" />
-  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBackgroundBegin" Color="#FFF6F6F6" />
-  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FFCCCEDB" />
+  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBackgroundBegin" Color="#FF1B1B1C" />
+  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FF333337" />
 
   <!-- Design time colors taken from the VS light theme
   <SolidColorBrush x:Key="GitHubVsToolWindowText" Color="#FF1E1E1E" />
@@ -30,6 +30,8 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FF1E1E1E" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FFCCCEBD" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FFEEEEF2" />
+  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBackgroundBegin" Color="#FFF6F6F6" />
+  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FFCCCEDB" />
   -->
 
   <!-- Design time colors taken from the VS blue theme
@@ -42,5 +44,7 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FF000000" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FF8591A2" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FFFFFFFF" />
+  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBackgroundBegin" Color="#FFEFEFEF" />
+  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="#FFCCCEDB" />
   -->
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
+++ b/src/GitHub.VisualStudio/Styles/ThemeDesignTime.xaml
@@ -4,7 +4,7 @@
   xmlns:PresentationOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
 
   <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/ThemeLight.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/ThemeDark.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
   <!-- Design time colors taken from the VS dark theme

--- a/src/GitHub.VisualStudio/Styles/ThemeLight.xaml
+++ b/src/GitHub.VisualStudio/Styles/ThemeLight.xaml
@@ -41,4 +41,7 @@
   <SolidColorBrush x:Key="GitHubPrimaryButtonBorderBrush" Color="#FF599942" />
   <SolidColorBrush x:Key="GitHubPrimaryButtonBorderMouseOverBrush" Color="#FF68B34D" />
   <SolidColorBrush x:Key="GitHubPrimaryButtonBorderPressedBrush" Color="#FF599942" />
+
+  <SolidColorBrush x:Key="GitHubComboBoxBackgroundBrush" Color="#FFF6F6F6" />
+  <SolidColorBrush x:Key="GitHubComboBoxBorderBrush" Color="#FFCCCEDC" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/Styles/VsBrush.xaml
+++ b/src/GitHub.VisualStudio/Styles/VsBrush.xaml
@@ -13,5 +13,4 @@
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="{DynamicResource VsColor.BrandedUIBorder}" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="{DynamicResource VsColor.BrandedUIBackground}" />
   <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="{DynamicResource VsColor.ComboBoxPopupBorder}" />
-  <SolidColorBrush x:Key="GitHubVsMenu" Color="{DynamicResource VsColor.Menu}" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/Styles/VsBrush.xaml
+++ b/src/GitHub.VisualStudio/Styles/VsBrush.xaml
@@ -12,6 +12,6 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="{DynamicResource VsColor.WindowText}" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="{DynamicResource VsColor.BrandedUIBorder}" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="{DynamicResource VsColor.BrandedUIBackground}" />
-  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBackgroundBegin" Color="{DynamicResource VsColor.ComboBoxPopupBackgroundBegin}" />
   <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="{DynamicResource VsColor.ComboBoxPopupBorder}" />
+  <SolidColorBrush x:Key="GitHubVsMenu" Color="{DynamicResource VsColor.Menu}" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/Styles/VsBrush.xaml
+++ b/src/GitHub.VisualStudio/Styles/VsBrush.xaml
@@ -12,4 +12,6 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="{DynamicResource VsColor.WindowText}" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="{DynamicResource VsColor.BrandedUIBorder}" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="{DynamicResource VsColor.BrandedUIBackground}" />
+  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBackgroundBegin" Color="{DynamicResource VsColor.ComboBoxPopupBackgroundBegin}" />
+  <SolidColorBrush x:Key="GitHubVsComboBoxPopupBorder" Color="{DynamicResource VsColor.ComboBoxPopupBorder}" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -31,56 +31,6 @@
                 <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/GitHubActionLink.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
-            <Style x:Key="GitHubComboBoxBorder" TargetType="{x:Type Border}">
-                <Setter Property="Margin" Value="10" />
-                <Setter Property="BorderThickness" Value="1" />
-                <Setter Property="BorderBrush" Value="{DynamicResource GitHubComboBoxBorderBrush}" />
-                <Setter Property="Effect">
-                    <Setter.Value>
-                        <DropShadowEffect Direction="315" ShadowDepth="5" BlurRadius="5" Opacity="0.25" />
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-            <Style x:Key="GitHubComboBoxContainer" TargetType="{x:Type Grid}">
-                <Setter Property="Background" Value="{DynamicResource GitHubComboBoxBackgroundBrush}" />
-
-                <Style.Resources>
-                    <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
-                        <Setter Property="Foreground" Value="{DynamicResource GitHubVsToolWindowText}" />
-                    </Style>
-
-                    <Style TargetType="{x:Type ui:OcticonImage}" BasedOn="{StaticResource {x:Type ui:OcticonImage}}">
-                        <Setter Property="Foreground" Value="{DynamicResource GitHubVsToolWindowText}" />
-                    </Style>
-                    
-                    <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
-                        <Setter Property="Background" Value="{DynamicResource GitHubComboBoxBorderBrush}" />
-                        <Setter Property="Margin" Value="0" />
-                    </Style>
-
-                    <Style TargetType="{x:Type ui:FilterTextBox}" BasedOn="{StaticResource {x:Type ui:FilterTextBox}}">
-                        <Setter Property="BorderBrush" Value="{DynamicResource GitHubComboBoxBorderBrush}" />
-                        <Setter Property="Foreground" Value="{DynamicResource GitHubVsWindowText}" />
-                        <Setter Property="Background" Value="{DynamicResource GitHubVsBrandedUIBackground}" />
-                        <Setter Property="Margin" Value="5" />
-                        <Setter Property="Height" Value="25" />
-                    </Style>
-
-                    <Style TargetType="{x:Type ListBox}" BasedOn="{StaticResource {x:Type ListBox}}">
-                        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
-                        <Setter Property="BorderThickness" Value="0" />
-                        <Setter Property="Background" Value="Transparent" />
-                        <Setter Property="MaxHeight" Value="100" />
-                    </Style>
-
-                    <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
-                        <Setter Property="Padding" Value="3" />
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                    </Style>
-                </Style.Resources>
-            </Style>
-
             <!--
             <Style x:Key="GitHubPRDetailsTabControl" TargetType="{x:Type TabControl}">
                 <Setter Property="Padding" Value="2"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -42,8 +42,7 @@
                 </Setter>
             </Style>
 
-            <Style x:Key="GitHubComboBoxContainer"
-                   TargetType="{x:Type Grid}">
+            <Style x:Key="GitHubComboBoxContainer" TargetType="{x:Type Grid}">
                 <Setter Property="Background" Value="{DynamicResource GitHubVsComboBoxPopupBackgroundBegin}" />
 
                 <Style.Resources>
@@ -453,6 +452,7 @@
                             <ui:FilterTextBox
                                 x:Name="filterBranch"
                                 Grid.Row="0"
+                                Foreground="{DynamicResource GitHubVsWindowText}"
                                 PromptText="Filter branches" />
                             <Separator Grid.Row="1" Margin="0" />
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -45,6 +45,7 @@
             <Style x:Key="GitHubComboBoxContainer"
                    TargetType="{x:Type Grid}">
                 <Setter Property="Background" Value="#FFF6F6F6" />
+
                 <Style.Resources>
                     <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
                         <Setter Property="BorderBrush" Value="#FFD7D9E3" />
@@ -55,6 +56,17 @@
                         <Setter Property="BorderBrush" Value="#FFCCCEDC" />
                         <Setter Property="Margin" Value="5" />
                         <Setter Property="Height" Value="25" />
+                    </Style>
+
+                    <Style TargetType="{x:Type ListBox}" BasedOn="{StaticResource {x:Type ListBox}}">
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="Background" Value="Transparent" />
+                        <Setter Property="MaxHeight" Value="100" />
+                    </Style>
+
+                    <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                        <Setter Property="Padding" Value="3" />
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                     </Style>
                 </Style.Resources>
             </Style>
@@ -434,8 +446,8 @@
                                 PromptText="Filter branches" />
                             <Separator Grid.Row="1" Margin="0" BorderBrush="#FFD7D9E3" />
 
-                            <ListBox BorderThickness="0" Background="Transparent" Grid.Row="2" MaxHeight="100">
-                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                            <ListBox Grid.Row="2">
+                                <ListBoxItem>
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
@@ -446,7 +458,8 @@
                                         <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right" />
                                     </Grid>
                                 </ListBoxItem>
-                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+
+                                <ListBoxItem>
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -154,7 +154,7 @@
                                     </Border>
                                 </Border>
 
-                                <Grid Margin="1,0,0,0">
+                                <Grid Margin="1,2,0,0">
                                     <ScrollViewer x:Name="PART_ContentHost" Padding="{TemplateBinding Padding}" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" VerticalAlignment="Top" Margin="0"/>
                                     <Label x:Name="PromptLabel" HorizontalAlignment="Left"
                                          Foreground="{DynamicResource GitHubVsGrayText}"
@@ -182,9 +182,7 @@
                                     <Setter Property="Foreground" Value="Transparent" />
                                 </DataTrigger>
                             </ControlTemplate.Triggers>
-
                         </ControlTemplate>
-
                     </Setter.Value>
                 </Setter>
             </Style>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -47,6 +47,10 @@
                 <Setter Property="Background" Value="{DynamicResource GitHubVsComboBoxPopupBackgroundBegin}" />
 
                 <Style.Resources>
+                    <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
+                        <Setter Property="Foreground" Value="{DynamicResource GitHubVsToolWindowText}" />
+                    </Style>
+                    
                     <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
                         <Setter Property="Background" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
                         <Setter Property="Margin" Value="0" />
@@ -533,8 +537,8 @@
                                             VerticalAlignment="Top"
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
-                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">Haacked</TextBlock>
-                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Phil Haack</TextBlock>
+                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">Haacked</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Phil Haack</TextBlock>
                                         <ui:OcticonImage Foreground="{DynamicResource GitHubVsToolWindowText}" Icon="check" Grid.Column="3" HorizontalAlignment="Right" Opacity="0.3" />
                                     </Grid>
                                 </ListBoxItem>
@@ -552,8 +556,8 @@
                                             VerticalAlignment="Top"
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
-                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
-                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
+                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
 
@@ -570,8 +574,8 @@
                                             VerticalAlignment="Top"
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
-                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">shiftkey</TextBlock>
-                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Brendan Forster</TextBlock>
+                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">shiftkey</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Brendan Forster</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
 
@@ -588,8 +592,8 @@
                                             VerticalAlignment="Top"
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
-                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">paladique</TextBlock>
-                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Jasmine Greenaway</TextBlock>
+                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">paladique</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Jasmine Greenaway</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -34,7 +34,7 @@
             <Style x:Key="GitHubComboBoxBorder" TargetType="{x:Type Border}">
                 <Setter Property="Margin" Value="10" />
                 <Setter Property="BorderThickness" Value="1" />
-                <Setter Property="BorderBrush" Value="#FF959595" />
+                <Setter Property="BorderBrush" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
                 <Setter Property="Effect">
                     <Setter.Value>
                         <DropShadowEffect Direction="315" ShadowDepth="5" BlurRadius="5" Opacity="0.25" />
@@ -44,15 +44,19 @@
 
             <Style x:Key="GitHubComboBoxContainer"
                    TargetType="{x:Type Grid}">
-                <Setter Property="Background" Value="#FFF6F6F6" />
+                <Setter Property="Background" Value="{DynamicResource GitHubVsComboBoxPopupBackgroundBegin}" />
 
                 <Style.Resources>
                     <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
-                        <Setter Property="BorderBrush" Value="#FFD7D9E3" />
+                        <!--
+                        <Setter Property="BorderBrush" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
+                        -->
+                        <Setter Property="Background" Value="Red" />
+                        <Setter Property="Margin" Value="0" />
                     </Style>
 
                     <Style TargetType="{x:Type ui:FilterTextBox}" BasedOn="{StaticResource {x:Type ui:FilterTextBox}}">
-                        <Setter Property="BorderBrush" Value="#FFCCCEDC" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
                         <Setter Property="Margin" Value="5" />
                         <Setter Property="Height" Value="25" />
                     </Style>
@@ -444,7 +448,7 @@
                                 x:Name="filterBranch"
                                 Grid.Row="0"
                                 PromptText="Filter branches" />
-                            <Separator Grid.Row="1" Margin="0" BorderBrush="#FFD7D9E3" />
+                            <Separator Grid.Row="1" Margin="0" />
 
                             <ListBox Grid.Row="2">
                                 <ListBoxItem>
@@ -455,7 +459,7 @@
                                         </Grid.ColumnDefinitions>
 
                                         <TextBlock Grid.Column="0">master</TextBlock>
-                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right" />
+                                        <ui:OcticonImage Icon="check" Grid.Column="1" HorizontalAlignment="Right" />
                                     </Grid>
                                 </ListBoxItem>
 
@@ -504,7 +508,7 @@
                     <Border Style="{DynamicResource GitHubComboBoxBorder}">
                         <Grid Style="{DynamicResource GitHubComboBoxContainer}"
                             MinWidth="150"
-                            MaxWidth="300" >
+                            MaxWidth="300">
                             
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="*" />
@@ -532,9 +536,9 @@
                                             VerticalAlignment="Top"
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
-                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">Haacked</TextBlock>
-                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Phil Haack</TextBlock>
-                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="3" HorizontalAlignment="Right" />
+                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">Haacked</TextBlock>
+                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Phil Haack</TextBlock>
+                                        <ui:OcticonImage Foreground="{DynamicResource GitHubVsToolWindowText}" Icon="check" Grid.Column="3" HorizontalAlignment="Right" />
                                     </Grid>
                                 </ListBoxItem>
 
@@ -551,8 +555,8 @@
                                             VerticalAlignment="Top"
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
-                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
-                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
+                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
+                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
 
@@ -569,8 +573,8 @@
                                             VerticalAlignment="Top"
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
-                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">shiftkey</TextBlock>
-                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Brendan Forster</TextBlock>
+                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">shiftkey</TextBlock>
+                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Brendan Forster</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
 
@@ -587,8 +591,8 @@
                                             VerticalAlignment="Top"
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
-                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">paladique</TextBlock>
-                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Jasmine Greenaway</TextBlock>
+                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">paladique</TextBlock>
+                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Jasmine Greenaway</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
 
@@ -604,8 +608,8 @@
                                             VerticalAlignment="Top"
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
-                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
-                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
+                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
+                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
                             </ListBox>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -61,6 +61,7 @@
 
                     <Style TargetType="{x:Type ui:FilterTextBox}" BasedOn="{StaticResource {x:Type ui:FilterTextBox}}">
                         <Setter Property="BorderBrush" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
+                        <Setter Property="Foreground" Value="{DynamicResource GitHubVsWindowText}" />
                         <Setter Property="Background" Value="{DynamicResource GitHubVsBrandedUIBackground}" />
                         <Setter Property="Margin" Value="5" />
                         <Setter Property="Height" Value="25" />
@@ -452,7 +453,6 @@
                             <ui:FilterTextBox
                                 x:Name="filterBranch"
                                 Grid.Row="0"
-                                Foreground="{DynamicResource GitHubVsWindowText}"
                                 PromptText="Filter branches" />
                             <Separator Grid.Row="1" Margin="0" />
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -49,7 +49,6 @@
                 <Style.Resources>
                     <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
                         <Setter Property="BorderBrush" Value="#FFD7D9E3" />
-                        <Setter Property="Margin" Value="5" />
                     </Style>
 
                     <Style TargetType="{x:Type ui:FilterTextBox}" BasedOn="{StaticResource {x:Type ui:FilterTextBox}}">
@@ -59,6 +58,7 @@
                     </Style>
 
                     <Style TargetType="{x:Type ListBox}" BasedOn="{StaticResource {x:Type ListBox}}">
+                        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
                         <Setter Property="BorderThickness" Value="0" />
                         <Setter Property="Background" Value="Transparent" />
                         <Setter Property="MaxHeight" Value="100" />
@@ -494,15 +494,10 @@
                     StaysOpen="False"
                     PlacementTarget="{Binding ElementName=assigneePopupButton}"
                     Placement="Bottom">
-                    <Border Margin="10" BorderThickness="1" BorderBrush="#FF959595">
-                        <Border.Effect>
-                            <DropShadowEffect Direction="315" ShadowDepth="5" BlurRadius="5" Opacity="0.25" />
-                        </Border.Effect>
-
-                        <Grid
+                    <Border Style="{DynamicResource GitHubComboBoxBorder}">
+                        <Grid Style="{DynamicResource GitHubComboBoxContainer}"
                             MinWidth="150"
-                            MaxWidth="300"
-                            Background="#FFF6F6F6">
+                            MaxWidth="300" >
                             
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="*" />
@@ -513,17 +508,11 @@
                             <ui:FilterTextBox
                                 x:Name="filterAssignee"
                                 Grid.Row="0"
-                                BorderBrush="#FFCCCEDC"
-                                Margin="5"
-                                Height="25"
                                 PromptText="Filter people" />
-                            <Separator Grid.Row="1" Margin="0" BorderBrush="#FFD7D9E3" />
+                            <Separator Grid.Row="1" />
 
-                            <ListBox 
-                                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                BorderThickness="0"
-                                Background="Transparent" Grid.Row="2" MaxHeight="100">
-                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                            <ListBox Grid.Row="2">
+                                <ListBoxItem>
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="16" />
@@ -542,7 +531,7 @@
                                     </Grid>
                                 </ListBoxItem>
 
-                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                <ListBoxItem>
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="16" />
@@ -561,7 +550,7 @@
                                     </Grid>
                                 </ListBoxItem>
 
-                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                <ListBoxItem>
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="16" />
@@ -580,7 +569,7 @@
                                     </Grid>
                                 </ListBoxItem>
 
-                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                <ListBoxItem>
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="16" />

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -43,7 +43,7 @@
             </Style>
 
             <Style x:Key="GitHubComboBoxContainer" TargetType="{x:Type Grid}">
-                <Setter Property="Background" Value="{DynamicResource GitHubVsComboBoxPopupBackgroundBegin}" />
+                <Setter Property="Background" Value="{DynamicResource GitHubVsMenu}" />
 
                 <Style.Resources>
                     <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -1,7 +1,6 @@
 ﻿<local:GenericPullRequestCreationView x:Class="GitHub.VisualStudio.UI.Views.PullRequestCreationView"
                                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                      xmlns:cache="clr-namespace:GitHub.VisualStudio.Helpers"
                                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                                       xmlns:helpers="clr-namespace:GitHub.VisualStudio.Helpers"
                                       xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
@@ -28,7 +27,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <helpers:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/SharedDictionary.xaml" />
                 <helpers:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
-                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/GitHubActionLink.xaml" />
+                <helpers:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/GitHubActionLink.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <!--

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -31,6 +31,34 @@
                 <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/GitHubActionLink.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
+            <Style x:Key="GitHubComboBoxBorder" TargetType="{x:Type Border}">
+                <Setter Property="Margin" Value="10" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="BorderBrush" Value="#FF959595" />
+                <Setter Property="Effect">
+                    <Setter.Value>
+                        <DropShadowEffect Direction="315" ShadowDepth="5" BlurRadius="5" Opacity="0.25" />
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style x:Key="GitHubComboBoxContainer"
+                   TargetType="{x:Type Grid}">
+                <Setter Property="Background" Value="#FFF6F6F6" />
+                <Style.Resources>
+                    <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
+                        <Setter Property="BorderBrush" Value="#FFD7D9E3" />
+                        <Setter Property="Margin" Value="5" />
+                    </Style>
+
+                    <Style TargetType="{x:Type ui:FilterTextBox}" BasedOn="{StaticResource {x:Type ui:FilterTextBox}}">
+                        <Setter Property="BorderBrush" Value="#FFCCCEDC" />
+                        <Setter Property="Margin" Value="5" />
+                        <Setter Property="Height" Value="25" />
+                    </Style>
+                </Style.Resources>
+            </Style>
+
             <!--
             <Style x:Key="GitHubPRDetailsTabControl" TargetType="{x:Type TabControl}">
                 <Setter Property="Padding" Value="2"/>
@@ -389,13 +417,10 @@
                     StaysOpen="False"
                     PlacementTarget="{Binding ElementName=branchSelectionButton}"
                     Placement="Bottom">
-                    <Border Margin="10" BorderThickness="1" BorderBrush="#FF959595">
-                        <Border.Effect>
-                            <DropShadowEffect Direction="315" ShadowDepth="5" BlurRadius="5" Opacity="0.25" />
-                        </Border.Effect>
-
-                        <Grid Width="200"
-                            Background="#FFF6F6F6">
+                    <Border Style="{DynamicResource GitHubComboBoxBorder}">
+                        <Grid 
+                            Style="{DynamicResource GitHubComboBoxContainer}"
+                            Width="200" >
                             
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="*" />
@@ -406,13 +431,21 @@
                             <ui:FilterTextBox
                                 x:Name="filterBranch"
                                 Grid.Row="0"
-                                BorderBrush="#FFCCCEDC"
-                                Margin="5"
-                                Height="25"
                                 PromptText="Filter branches" />
                             <Separator Grid.Row="1" Margin="0" BorderBrush="#FFD7D9E3" />
 
                             <ListBox BorderThickness="0" Background="Transparent" Grid.Row="2" MaxHeight="100">
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBlock Grid.Column="0">master</TextBlock>
+                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right" />
+                                    </Grid>
+                                </ListBoxItem>
                                 <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
                                     <Grid>
                                         <Grid.ColumnDefinitions>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -467,6 +467,7 @@
                                         </Grid.ColumnDefinitions>
 
                                         <TextBlock Grid.Column="0">not-master</TextBlock>
+                                        <TextBlock Grid.Column="1" Opacity="0.3" HorizontalAlignment="Right">March 1</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
                             </ListBox>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -424,54 +424,6 @@
                                         <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right" />
                                     </Grid>
                                 </ListBoxItem>
-
-                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-
-                                        <TextBlock Grid.Column="0">fix-everything</TextBlock>
-                                        <TextBlock Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right">Mar 1</TextBlock>
-                                    </Grid>
-                                </ListBoxItem>
-
-                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-
-                                        <TextBlock Grid.Column="0">fix-everything</TextBlock>
-                                        <TextBlock Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right">Mar 1</TextBlock>
-                                    </Grid>
-                                </ListBoxItem>
-
-                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-
-                                        <TextBlock Grid.Column="0">fix-everything</TextBlock>
-                                        <TextBlock Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right">Mar 1</TextBlock>
-                                    </Grid>
-                                </ListBoxItem>
-
-                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-
-                                        <TextBlock Grid.Column="0">fix-everything</TextBlock>
-                                        <TextBlock Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right">Mar 1</TextBlock>
-                                    </Grid>
-                                </ListBoxItem>
                             </ListBox>
                         </Grid>
                     </Border>
@@ -488,18 +440,139 @@
                 </Grid.ColumnDefinitions>
 
                 <Label Grid.Column="0" Content="Assignee" VerticalAlignment="Center" Foreground="{DynamicResource GitHubVsGrayText}" />
-                <ui:GitHubActionLink Grid.Column="1" Content="Haacked" HasDropDown="True" VerticalAlignment="Center" HorizontalAlignment="Left">
-                    <i:Interaction.Behaviors>
-                        <ui:DropDownActionLinkBehaviour />
-                    </i:Interaction.Behaviors>
+                <ui:GitHubActionLink x:Name="assigneePopupButton" Grid.Column="1" Content="Haacked" HasDropDown="True" VerticalAlignment="Center" HorizontalAlignment="Left" Click="assigneePopupButton_Click" />
 
-                    <ui:GitHubActionLink.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem Header="Haacked" />
-                            <MenuItem Header="NotHaacked" />
-                        </ContextMenu>
-                    </ui:GitHubActionLink.ContextMenu>
-                </ui:GitHubActionLink>
+                <Popup
+                    x:Name="assigneePopup"
+                    AllowsTransparency="True"
+                    StaysOpen="False"
+                    PlacementTarget="{Binding ElementName=assigneePopupButton}"
+                    Placement="Bottom">
+                    <Border Margin="10" BorderThickness="1" BorderBrush="#FF959595">
+                        <Border.Effect>
+                            <DropShadowEffect Direction="315" ShadowDepth="5" BlurRadius="5" Opacity="0.25" />
+                        </Border.Effect>
+
+                        <Grid
+                            MinWidth="150"
+                            MaxWidth="300"
+                            Background="#FFF6F6F6">
+                            
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
+                            <ui:FilterTextBox
+                                x:Name="filterAssignee"
+                                Grid.Row="0"
+                                BorderBrush="#FFCCCEDC"
+                                Margin="5"
+                                Height="25"
+                                PromptText="Filter people" />
+                            <Separator Grid.Row="1" Margin="0" BorderBrush="#FFD7D9E3" />
+
+                            <ListBox 
+                                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                BorderThickness="0"
+                                Background="Transparent" Grid.Row="2" MaxHeight="100">
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="16" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <Image
+                                            VerticalAlignment="Top"
+                                            Grid.Column="0"
+                                            Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
+                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">Haacked</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Phil Haack</TextBlock>
+                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="3" HorizontalAlignment="Right" />
+                                    </Grid>
+                                </ListBoxItem>
+
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="16" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <Image
+                                            VerticalAlignment="Top"
+                                            Grid.Column="0"
+                                            Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
+                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
+                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="3" HorizontalAlignment="Right" />
+                                    </Grid>
+                                </ListBoxItem>
+
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="16" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <Image
+                                            VerticalAlignment="Top"
+                                            Grid.Column="0"
+                                            Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
+                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">shiftkey</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Brendan Forster</TextBlock>
+                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="3" HorizontalAlignment="Right" />
+                                    </Grid>
+                                </ListBoxItem>
+
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="16" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <Image
+                                            VerticalAlignment="Top"
+                                            Grid.Column="0"
+                                            Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
+                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">paladique</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Jasmine Greenaway</TextBlock>
+                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="3" HorizontalAlignment="Right" />
+                                    </Grid>
+                                </ListBoxItem>
+
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="16" />
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <Image
+                                            VerticalAlignment="Top"
+                                            Grid.Column="0"
+                                            Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
+                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
+                                    </Grid>
+                                </ListBoxItem>
+                            </ListBox>
+                        </Grid>
+                    </Border>
+                </Popup>
 
                 <ui:GitHubActionLink Grid.Column="2" Content="Clear assignee" HorizontalAlignment="Right"  VerticalAlignment="Center" />
             </Grid>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -381,17 +381,101 @@
                 <TextBlock VerticalAlignment="Center" Text="From" Foreground="{DynamicResource GitHubVsGrayText}" />
                 <Label Content="{Binding CurrentBranchName}" Foreground="{DynamicResource GitHubVsToolWindowText}"/>
                 <TextBlock VerticalAlignment="Center" Text="into" Foreground="{DynamicResource GitHubVsGrayText}" />
-                <ui:GitHubActionLink Content="master" HasDropDown="True" Margin="5,0,0,0" VerticalAlignment="Center">
-                    <i:Interaction.Behaviors>
-                        <ui:DropDownActionLinkBehaviour />
-                    </i:Interaction.Behaviors>
-                    <ui:GitHubActionLink.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem Header="master" />
-                            <MenuItem Header="not-master" />
-                        </ContextMenu>
-                    </ui:GitHubActionLink.ContextMenu>
-                </ui:GitHubActionLink>
+                <ui:GitHubActionLink x:Name="branchSelectionButton" Content="master" HasDropDown="True" Margin="5,0,0,0" VerticalAlignment="Center" Click="branchSelectionButton_Click" />
+
+                <Popup
+                    x:Name="branchPopup"
+                    AllowsTransparency="True"
+                    StaysOpen="False"
+                    PlacementTarget="{Binding ElementName=branchSelectionButton}"
+                    Placement="Bottom">
+                    <Border Margin="10" BorderThickness="1" BorderBrush="#FF959595">
+                        <Border.Effect>
+                            <DropShadowEffect Direction="315" ShadowDepth="5" BlurRadius="5" Opacity="0.25" />
+                        </Border.Effect>
+
+                        <Grid Width="200"
+                            Background="#FFF6F6F6">
+                            
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
+                            <ui:FilterTextBox
+                                x:Name="filterBranch"
+                                Grid.Row="0"
+                                BorderBrush="#FFCCCEDC"
+                                Margin="5"
+                                Height="25"
+                                PromptText="Filter branches" />
+                            <Separator Grid.Row="1" Margin="0" BorderBrush="#FFD7D9E3" />
+
+                            <ListBox BorderThickness="0" Background="Transparent" Grid.Row="2" MaxHeight="100">
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBlock Grid.Column="0">master</TextBlock>
+                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right" />
+                                    </Grid>
+                                </ListBoxItem>
+
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBlock Grid.Column="0">fix-everything</TextBlock>
+                                        <TextBlock Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right">Mar 1</TextBlock>
+                                    </Grid>
+                                </ListBoxItem>
+
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBlock Grid.Column="0">fix-everything</TextBlock>
+                                        <TextBlock Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right">Mar 1</TextBlock>
+                                    </Grid>
+                                </ListBoxItem>
+
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBlock Grid.Column="0">fix-everything</TextBlock>
+                                        <TextBlock Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right">Mar 1</TextBlock>
+                                    </Grid>
+                                </ListBoxItem>
+
+                                <ListBoxItem Padding="3" HorizontalContentAlignment="Stretch">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <TextBlock Grid.Column="0">fix-everything</TextBlock>
+                                        <TextBlock Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right">Mar 1</TextBlock>
+                                    </Grid>
+                                </ListBoxItem>
+                            </ListBox>
+                        </Grid>
+                    </Border>
+                </Popup>
             </StackPanel>
 
             <ui:PromptTextBox Margin="10,5" PromptText="Title" Style="{StaticResource GitHubVsPromptTextBox}" />
@@ -400,11 +484,11 @@
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
                 <Label Grid.Column="0" Content="Assignee" VerticalAlignment="Center" Foreground="{DynamicResource GitHubVsGrayText}" />
-                <ui:GitHubActionLink Grid.Column="1" Content="{Binding SelectedAssignee}" HasDropDown="True" VerticalAlignment="Center" HorizontalAlignment="Left">
+                <ui:GitHubActionLink Grid.Column="1" Content="Haacked" HasDropDown="True" VerticalAlignment="Center" HorizontalAlignment="Left">
                     <i:Interaction.Behaviors>
                         <ui:DropDownActionLinkBehaviour />
                     </i:Interaction.Behaviors>
@@ -417,7 +501,7 @@
                     </ui:GitHubActionLink.ContextMenu>
                 </ui:GitHubActionLink>
 
-                <ui:GitHubActionLink Grid.Column="2" Content="Clear Assignee" VerticalAlignment="Center" />
+                <ui:GitHubActionLink Grid.Column="2" Content="Clear assignee" HorizontalAlignment="Right"  VerticalAlignment="Center" />
             </Grid>
 
             <Grid Margin="10,5,10,10" HorizontalAlignment="Stretch">

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -50,6 +50,10 @@
                     <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
                         <Setter Property="Foreground" Value="{DynamicResource GitHubVsToolWindowText}" />
                     </Style>
+
+                    <Style TargetType="{x:Type ui:OcticonImage}" BasedOn="{StaticResource {x:Type ui:OcticonImage}}">
+                        <Setter Property="Foreground" Value="{DynamicResource GitHubVsToolWindowText}" />
+                    </Style>
                     
                     <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
                         <Setter Property="Background" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
@@ -58,6 +62,7 @@
 
                     <Style TargetType="{x:Type ui:FilterTextBox}" BasedOn="{StaticResource {x:Type ui:FilterTextBox}}">
                         <Setter Property="BorderBrush" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
+                        <Setter Property="Background" Value="{DynamicResource GitHubVsBrandedUIBackground}" />
                         <Setter Property="Margin" Value="5" />
                         <Setter Property="Height" Value="25" />
                     </Style>
@@ -520,6 +525,7 @@
                             <ui:FilterTextBox
                                 x:Name="filterAssignee"
                                 Grid.Row="0"
+                                Foreground="{DynamicResource GitHubVsWindowText}"
                                 PromptText="Filter people" />
                             <Separator Grid.Row="1" />
 
@@ -609,8 +615,8 @@
                                             VerticalAlignment="Top"
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
-                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
-                                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
+                                        <TextBlock Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
                             </ListBox>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -466,8 +466,7 @@
                                             <ColumnDefinition Width="*" />
                                         </Grid.ColumnDefinitions>
 
-                                        <TextBlock Grid.Column="0">master</TextBlock>
-                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="1" HorizontalAlignment="Right" />
+                                        <TextBlock Grid.Column="0">not-master</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
                             </ListBox>
@@ -481,12 +480,19 @@
             <Grid Margin="10,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
                 <Label Grid.Column="0" Content="Assignee" VerticalAlignment="Center" Foreground="{DynamicResource GitHubVsGrayText}" />
-                <ui:GitHubActionLink x:Name="assigneePopupButton" Grid.Column="1" Content="Haacked" HasDropDown="True" VerticalAlignment="Center" HorizontalAlignment="Left" Click="assigneePopupButton_Click" />
+                <ui:GitHubActionLink
+                    x:Name="assigneePopupButton" 
+                    Grid.Column="1"
+                    Content="Haacked (Phil Haack)"
+                    HasDropDown="True"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Left"
+                    Click="assigneePopupButton_Click" />
 
                 <Popup
                     x:Name="assigneePopup"
@@ -546,7 +552,6 @@
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
                                         <TextBlock Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
                                         <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
-                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="3" HorizontalAlignment="Right" />
                                     </Grid>
                                 </ListBoxItem>
 
@@ -565,7 +570,6 @@
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
                                         <TextBlock Grid.Column="1" Margin="5,0,0,0">shiftkey</TextBlock>
                                         <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Brendan Forster</TextBlock>
-                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="3" HorizontalAlignment="Right" />
                                     </Grid>
                                 </ListBoxItem>
 
@@ -584,7 +588,6 @@
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
                                         <TextBlock Grid.Column="1" Margin="5,0,0,0">paladique</TextBlock>
                                         <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Jasmine Greenaway</TextBlock>
-                                        <ui:OcticonImage Icon="check" Opacity="0.3" Grid.Column="3" HorizontalAlignment="Right" />
                                     </Grid>
                                 </ListBoxItem>
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -48,10 +48,7 @@
 
                 <Style.Resources>
                     <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
-                        <!--
-                        <Setter Property="BorderBrush" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
-                        -->
-                        <Setter Property="Background" Value="Red" />
+                        <Setter Property="Background" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
                         <Setter Property="Margin" Value="0" />
                     </Style>
 
@@ -459,7 +456,7 @@
                                         </Grid.ColumnDefinitions>
 
                                         <TextBlock Grid.Column="0">master</TextBlock>
-                                        <ui:OcticonImage Icon="check" Grid.Column="1" HorizontalAlignment="Right" />
+                                        <ui:OcticonImage Icon="check" Grid.Column="1" HorizontalAlignment="Right" Opacity="0.3" />
                                     </Grid>
                                 </ListBoxItem>
 
@@ -538,7 +535,7 @@
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
                                         <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="1" Margin="5,0,0,0">Haacked</TextBlock>
                                         <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Phil Haack</TextBlock>
-                                        <ui:OcticonImage Foreground="{DynamicResource GitHubVsToolWindowText}" Icon="check" Grid.Column="3" HorizontalAlignment="Right" />
+                                        <ui:OcticonImage Foreground="{DynamicResource GitHubVsToolWindowText}" Icon="check" Grid.Column="3" HorizontalAlignment="Right" Opacity="0.3" />
                                     </Grid>
                                 </ListBoxItem>
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -34,7 +34,7 @@
             <Style x:Key="GitHubComboBoxBorder" TargetType="{x:Type Border}">
                 <Setter Property="Margin" Value="10" />
                 <Setter Property="BorderThickness" Value="1" />
-                <Setter Property="BorderBrush" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource GitHubComboBoxBorderBrush}" />
                 <Setter Property="Effect">
                     <Setter.Value>
                         <DropShadowEffect Direction="315" ShadowDepth="5" BlurRadius="5" Opacity="0.25" />
@@ -43,7 +43,7 @@
             </Style>
 
             <Style x:Key="GitHubComboBoxContainer" TargetType="{x:Type Grid}">
-                <Setter Property="Background" Value="{DynamicResource GitHubVsMenu}" />
+                <Setter Property="Background" Value="{DynamicResource GitHubComboBoxBackgroundBrush}" />
 
                 <Style.Resources>
                     <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
@@ -55,12 +55,12 @@
                     </Style>
                     
                     <Style TargetType="{x:Type Separator}" BasedOn="{StaticResource {x:Type Separator}}">
-                        <Setter Property="Background" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
+                        <Setter Property="Background" Value="{DynamicResource GitHubComboBoxBorderBrush}" />
                         <Setter Property="Margin" Value="0" />
                     </Style>
 
                     <Style TargetType="{x:Type ui:FilterTextBox}" BasedOn="{StaticResource {x:Type ui:FilterTextBox}}">
-                        <Setter Property="BorderBrush" Value="{DynamicResource GitHubVsComboBoxPopupBorder}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource GitHubComboBoxBorderBrush}" />
                         <Setter Property="Foreground" Value="{DynamicResource GitHubVsWindowText}" />
                         <Setter Property="Background" Value="{DynamicResource GitHubVsBrandedUIBackground}" />
                         <Setter Property="Margin" Value="5" />
@@ -465,7 +465,7 @@
                                         </Grid.ColumnDefinitions>
 
                                         <TextBlock Grid.Column="0">master</TextBlock>
-                                        <ui:OcticonImage Icon="check" Grid.Column="1" HorizontalAlignment="Right" Opacity="0.3" />
+                                        <ui:OcticonImage Icon="check" Grid.Column="1" HorizontalAlignment="Right" Opacity="0.6" />
                                     </Grid>
                                 </ListBoxItem>
 
@@ -477,7 +477,7 @@
                                         </Grid.ColumnDefinitions>
 
                                         <TextBlock Grid.Column="0">not-master</TextBlock>
-                                        <TextBlock Grid.Column="1" Opacity="0.3" HorizontalAlignment="Right">March 1</TextBlock>
+                                        <TextBlock Grid.Column="1" Opacity="0.6" HorizontalAlignment="Right">March 1</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
                             </ListBox>
@@ -544,8 +544,8 @@
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
                                         <TextBlock Grid.Column="1" Margin="5,0,0,0">Haacked</TextBlock>
-                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Phil Haack</TextBlock>
-                                        <ui:OcticonImage Foreground="{DynamicResource GitHubVsToolWindowText}" Icon="check" Grid.Column="3" HorizontalAlignment="Right" Opacity="0.3" />
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.6">Phil Haack</TextBlock>
+                                        <ui:OcticonImage Foreground="{DynamicResource GitHubVsToolWindowText}" Icon="check" Grid.Column="3" HorizontalAlignment="Right" Opacity="0.6" />
                                     </Grid>
                                 </ListBoxItem>
 
@@ -563,7 +563,7 @@
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
                                         <TextBlock Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
-                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.6">Andreia Gaita</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
 
@@ -581,7 +581,7 @@
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
                                         <TextBlock Grid.Column="1" Margin="5,0,0,0">shiftkey</TextBlock>
-                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Brendan Forster</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.6">Brendan Forster</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
 
@@ -599,7 +599,7 @@
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
                                         <TextBlock Grid.Column="1" Margin="5,0,0,0">paladique</TextBlock>
-                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Jasmine Greenaway</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.6">Jasmine Greenaway</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
 
@@ -616,7 +616,7 @@
                                             Grid.Column="0"
                                             Source="/GitHub.VisualStudio;component/Resources/default_user_avatar.png"/>
                                         <TextBlock Grid.Column="1" Margin="5,0,0,0">shana</TextBlock>
-                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.5">Andreia Gaita</TextBlock>
+                                        <TextBlock Grid.Column="2" Margin="5,0,0,0" Opacity="0.6">Andreia Gaita</TextBlock>
                                     </Grid>
                                 </ListBoxItem>
                             </ListBox>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml.cs
@@ -28,5 +28,10 @@ namespace GitHub.VisualStudio.UI.Views
         {
             branchPopup.IsOpen = true;
         }
+
+        private void assigneePopupButton_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            assigneePopup.IsOpen = true;
+        }
     }
 }

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml.cs
@@ -23,5 +23,10 @@ namespace GitHub.VisualStudio.UI.Views
             {
             });
         }
+
+        private void branchSelectionButton_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            branchPopup.IsOpen = true;
+        }
     }
 }


### PR DESCRIPTION
**Destination branch:** `don/stub-ui`

This PR stubs out a filterable combobox ui for selecting branches and assignees. I originally went with a UI very similar to what we have in Desktop; however, it felt out of place with Visual Studio's UI. I ended up trying out a different approach with a look and feel closer to a native context menu.

**Desktopish (Mock-up)**
(I have a branch with this style but it has become so stale that it won't build on my machine without a bit of troubleshooting :sob:)

![image](https://cloud.githubusercontent.com/assets/1174461/14538477/d3a6f9e4-0230-11e6-9556-51a818091c6f.png)

**Context menu-ish**
![combobox-demo](https://cloud.githubusercontent.com/assets/1174461/14538416/8f1a5cda-0230-11e6-9b55-abaf2350be51.gif)

There's still some refinement, polish, and theming, that needs to be done; but I would love some thoughts on this direction.

/cc @shana, @simurai, @niik for :eyes: and :thought_balloon: (although feedback from anyone is encouraged)