### PR TITLE
Cache blob caches

### DIFF
--- a/src/GitHub.App/Factories/SqlitePersistentBlobCacheFactory.cs
+++ b/src/GitHub.App/Factories/SqlitePersistentBlobCacheFactory.cs
@@ -2,6 +2,7 @@
 using Akavache.Sqlite3;
 using NLog;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 
 namespace GitHub.Factories
@@ -11,14 +12,19 @@ namespace GitHub.Factories
     public class SqlitePersistentBlobCacheFactory : IBlobCacheFactory
     {
         static readonly Logger log = LogManager.GetCurrentClassLogger();
+        Dictionary<string, IBlobCache> cache = new Dictionary<string, IBlobCache>();
 
         public IBlobCache CreateBlobCache(string path)
         {
             Guard.ArgumentNotEmptyString(path, nameof(path));
+            if (cache.ContainsKey(path))
+                return cache[path];
 
             try
             {
-                return new SQLitePersistentBlobCache(path);
+                var c = new SQLitePersistentBlobCache(path);
+                cache.Add(path, c);
+                return c;
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
SQLitePersistentBlobCache need to be cached, `ImageCache` creates a new one every time it needs to load an image from the cache, and they persist across the lifetime of the application, resulting in a million tasks just hanging there waiting for work, eventually exhausting system resources.