### PR TITLE
Fix premature cache disposal

### DIFF
--- a/src/GitHub.App/Factories/HostCacheFactory.cs
+++ b/src/GitHub.App/Factories/HostCacheFactory.cs
@@ -39,5 +39,23 @@ namespace GitHub.Factories
 
         IOperatingSystem OperatingSystem { get { return operatingSystem.Value; } }
         IBlobCacheFactory BlobCacheFactory { get { return blobCacheFactory.Value; } }
+
+        bool disposed;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (disposed) return;
+                disposed = true;
+                if (blobCacheFactory.IsValueCreated)
+                    blobCacheFactory.Value.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/GitHub.App/Factories/IBlobCacheFactory.cs
+++ b/src/GitHub.App/Factories/IBlobCacheFactory.cs
@@ -1,8 +1,9 @@
 ﻿using Akavache;
+using System;
 
 namespace GitHub.Factories
 {
-    public interface IBlobCacheFactory
+    public interface IBlobCacheFactory : IDisposable
     {
         IBlobCache CreateBlobCache(string path);
     }

--- a/src/GitHub.App/Factories/IHostCacheFactory.cs
+++ b/src/GitHub.App/Factories/IHostCacheFactory.cs
@@ -1,9 +1,10 @@
 ﻿using Akavache;
 using GitHub.Primitives;
+using System;
 
 namespace GitHub.Factories
 {
-    public interface IHostCacheFactory
+    public interface IHostCacheFactory : IDisposable
     {
         IBlobCache Create(HostAddress hostAddress);
     }

--- a/src/GitHub.App/Factories/RepositoryHostFactory.cs
+++ b/src/GitHub.App/Factories/RepositoryHostFactory.cs
@@ -51,6 +51,7 @@ namespace GitHub.Factories
 
                 loginCache.Dispose();
                 avatarProvider.Dispose();
+                hostCacheFactory.Dispose();
                 disposed = true;
             }
         }

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -277,15 +277,6 @@ namespace GitHub.Services
             if (disposing)
             {
                 if (disposed) return;
-
-                try
-                {
-                    hostCache.Dispose();
-                }
-                catch (Exception e)
-                {
-                    log.Warn("Exception occured while disposing host cache", e);
-                }
                 disposed = true;
             }
         }


### PR DESCRIPTION
Turns out #270 wasn't quite the flawless victory... it causes premature disposal of caches, as seen in #277

Now that we're not creating a million copies of the same cache every time something wants something from it, `ModelService` can't just willy-nilly dispose of the `hostCache` object when it feels like it,
because that cache object will be reused by other services, if needed.

The factory is the one responsible for keeping the lifetime of its cached objects (and yes, now it should probably not be called a factory anymore, it should be a service but oh well), and so now it needs to be
disposable and take care of things when it itself is disposed of, usually when MEF shuts down.