### PR TITLE
Keep validation adornment visibility up to date

### DIFF
--- a/src/GitHub.UI.Reactive/Controls/Validation/ValidationMessage.cs
+++ b/src/GitHub.UI.Reactive/Controls/Validation/ValidationMessage.cs
@@ -33,6 +33,7 @@ namespace GitHub.UI
                 .Do(CreateBinding)
                 .Select(control =>
                     Observable.Merge(
+                        this.WhenAnyValue(x => x.ShowError),
                         control.Events().TextChanged
                             .Throttle(TimeSpan.FromSeconds(ShowError ? defaultTextChangeThrottle : TextChangeThrottle),
                             RxApp.MainThreadScheduler)


### PR DESCRIPTION
Fix for issue #242 

The `ShowValidateError` method wasn't getting called to update the validation adorner when `ValidationMessage.ShowError` changes independent of a `TextChanged` or focus event.

I'm not sure if this should be done here or in the `WhenAny` above which updates `ShowError` - I've put it here as that's where the existing call to ShowValidateError is.