### PR TITLE
Initial support for collapsing in clone dialog.

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
@@ -2,18 +2,18 @@
                             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                            xmlns:cache="clr-namespace:GitHub.VisualStudio.Helpers"
                             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                            xmlns:helpers="clr-namespace:GitHub.Helpers;assembly=GitHub.UI"
+                            xmlns:local="clr-namespace:GitHub.VisualStudio.UI.Views.Controls"
+                            xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI"
+                            xmlns:sampleData="clr-namespace:GitHub.SampleData;assembly=GitHub.App"
                             xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
                             xmlns:uirx="clr-namespace:GitHub.UI;assembly=GitHub.UI.Reactive"
-                            xmlns:local="clr-namespace:GitHub.VisualStudio.UI.Views.Controls"
-                            xmlns:helpers="clr-namespace:GitHub.Helpers;assembly=GitHub.UI"
-                            xmlns:sampleData="clr-namespace:GitHub.SampleData;assembly=GitHub.App"
-                            xmlns:GitHub="clr-namespace:GitHub.VisualStudio.Helpers"
-                            xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI"
-                            mc:Ignorable="d"
-                            d:DesignWidth="414"
                             d:DesignHeight="440"
-                            Background="Transparent">
+                            d:DesignWidth="414"
+                            Background="Transparent"
+                            mc:Ignorable="d">
   <d:DesignProperties.DataContext>
     <Binding>
       <Binding.Source>
@@ -25,181 +25,209 @@
   <UserControl.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
-        <GitHub:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
-        <GitHub:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </UserControl.Resources>
 
   <DockPanel LastChildFill="True">
     <DockPanel.Resources>
-      <Style x:Key="repositoryBorderStyle"
-             TargetType="Border">
-        <Setter Property="BorderBrush"
-                Value="#EAEAEA" />
-        <Setter Property="BorderThickness"
-                Value="0,0,0,1" />
-        <Setter Property="VerticalAlignment"
-                Value="Center" />
-        <Setter Property="Height"
-                Value="30" />
-        <Setter Property="Margin"
-                Value="0" />
+      <Style x:Key="repositoryBorderStyle" TargetType="Border">
+        <Setter Property="BorderBrush" Value="#EAEAEA" />
+        <Setter Property="BorderThickness" Value="0,0,0,1" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Height" Value="30" />
+        <Setter Property="Margin" Value="0" />
       </Style>
 
-            <Style x:Key="expanderDownHeaderStyle" TargetType="{x:Type ToggleButton}">
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type ToggleButton}">
-                            <Border Padding="{TemplateBinding Padding}" Style="{StaticResource repositoryBorderStyle}">
-                                <StackPanel Orientation="Horizontal" Background="#F8F8F8">
-                                    <ui:OcticonImage x:Name="arrow" Icon="triangle_right" Foreground="Black" Height="10" Margin="5,0,0,0" />
-                                    <ContentPresenter HorizontalAlignment="Left" Margin="0" RecognizesAccessKey="True" SnapsToDevicePixels="True" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </Border>
+      <Style x:Key="expanderDownHeaderStyle" TargetType="{x:Type ToggleButton}">
+        <Setter Property="Template">
+          <Setter.Value>
+            <ControlTemplate TargetType="{x:Type ToggleButton}">
+              <Border Padding="{TemplateBinding Padding}" Style="{StaticResource repositoryBorderStyle}">
+                <StackPanel Background="#F8F8F8" Orientation="Horizontal">
+                  <ui:OcticonImage x:Name="arrow"
+                                   Height="10"
+                                   Margin="5,0,0,0"
+                                   Foreground="Black"
+                                   Icon="triangle_right" />
+                  <ContentPresenter Margin="0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    RecognizesAccessKey="True"
+                                    SnapsToDevicePixels="True" />
+                </StackPanel>
+              </Border>
 
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsChecked" Value="True">
-                                    <Setter TargetName="arrow" Property="Icon" Value="triangle_down" />
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
+              <ControlTemplate.Triggers>
+                <Trigger Property="IsChecked" Value="True">
+                  <Setter TargetName="arrow" Property="Icon" Value="triangle_down" />
+                </Trigger>
+              </ControlTemplate.Triggers>
+            </ControlTemplate>
+          </Setter.Value>
+        </Setter>
+      </Style>
 
-            <Style x:Key="ExpanderHeaderFocusVisual">
-                <Setter Property="Control.Template">
-                    <Setter.Value>
-                        <ControlTemplate>
-                            <Border>
-                                <Rectangle Margin="0" SnapsToDevicePixels="true" Stroke="Black" StrokeThickness="1" StrokeDashArray="1 2"/>
-                            </Border>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
+      <Style x:Key="expanderHeaderFocusVisual">
+        <Setter Property="Control.Template">
+          <Setter.Value>
+            <ControlTemplate>
+              <Border>
+                <Rectangle Margin="0"
+                           SnapsToDevicePixels="true"
+                           Stroke="Black"
+                           StrokeDashArray="1 2"
+                           StrokeThickness="1" />
+              </Border>
+            </ControlTemplate>
+          </Setter.Value>
+        </Setter>
+      </Style>
 
-            <Style x:Key="cloneGroupExpander" TargetType="{x:Type Expander}">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
-                <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                <Setter Property="VerticalContentAlignment" Value="Stretch"/>
-                <Setter Property="BorderBrush" Value="Transparent"/>
-                <Setter Property="BorderThickness" Value="0"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type Expander}">
-                            <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="3" SnapsToDevicePixels="true">
-                                <DockPanel>
-                                    <ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="0" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource expanderDownHeaderStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                                    <ContentPresenter x:Name="ExpandSite" DockPanel.Dock="Bottom" Focusable="false" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" Visibility="Collapsed" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                                </DockPanel>
-                            </Border>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsExpanded" Value="true">
-                                    <Setter Property="Visibility" TargetName="ExpandSite" Value="Visible"/>
-                                </Trigger>
-                                <Trigger Property="IsEnabled" Value="false">
-                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
+      <Style x:Key="cloneGroupExpander" TargetType="{x:Type Expander}">
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Template">
+          <Setter.Value>
+            <ControlTemplate TargetType="{x:Type Expander}">
+              <Border Background="{TemplateBinding Background}"
+                      BorderBrush="{TemplateBinding BorderBrush}"
+                      BorderThickness="{TemplateBinding BorderThickness}"
+                      CornerRadius="3"
+                      SnapsToDevicePixels="true">
+                <DockPanel>
+                  <ToggleButton x:Name="HeaderSite"
+                                MinWidth="0"
+                                MinHeight="0"
+                                Margin="0"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding Header}"
+                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                DockPanel.Dock="Top"
+                                FocusVisualStyle="{StaticResource expanderHeaderFocusVisual}"
+                                FontFamily="{TemplateBinding FontFamily}"
+                                FontSize="{TemplateBinding FontSize}"
+                                FontStretch="{TemplateBinding FontStretch}"
+                                FontStyle="{TemplateBinding FontStyle}"
+                                FontWeight="{TemplateBinding FontWeight}"
+                                Foreground="{TemplateBinding Foreground}"
+                                IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                Padding="{TemplateBinding Padding}"
+                                Style="{StaticResource expanderDownHeaderStyle}" />
+                  <ContentPresenter x:Name="ExpandSite"
+                                    Margin="{TemplateBinding Padding}"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    DockPanel.Dock="Bottom"
+                                    Focusable="false"
+                                    Visibility="Collapsed" />
+                </DockPanel>
+              </Border>
+              <ControlTemplate.Triggers>
+                <Trigger Property="IsExpanded" Value="true">
+                  <Setter TargetName="ExpandSite" Property="Visibility" Value="Visible" />
+                </Trigger>
+                <Trigger Property="IsEnabled" Value="false">
+                  <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                </Trigger>
+              </ControlTemplate.Triggers>
+            </ControlTemplate>
+          </Setter.Value>
+        </Setter>
+      </Style>
     </DockPanel.Resources>
-    
+
     <ui:FilterTextBox x:Name="filterText"
+                      Margin="10"
                       DockPanel.Dock="Top"
-                      PromptText="{x:Static prop:Resources.filterTextPromptText}"
-                      Margin="10" />
+                      PromptText="{x:Static prop:Resources.filterTextPromptText}" />
 
     <ui:GitHubProgressBar x:Name="loadingProgressBar"
+                          Margin="0"
+                          HorizontalContentAlignment="Stretch"
                           DockPanel.Dock="Top"
                           Foreground="{DynamicResource GitHubAccentBrush}"
-                          Style="{DynamicResource GitHubProgressBar}"
-                          HorizontalContentAlignment="Stretch"
-                          Visibility="Visible"
                           IsIndeterminate="True"
-                          Margin="0" />
-    
+                          Style="{DynamicResource GitHubProgressBar}"
+                          Visibility="Visible" />
+
     <StackPanel x:Name="loadingFailedPanel"
-                DockPanel.Dock="Top"
-                VerticalAlignment="Center"
+                Margin="0,4,0,4"
                 HorizontalAlignment="Center"
-                Margin="0,4,0,4">
+                VerticalAlignment="Center"
+                DockPanel.Dock="Top">
       <uirx:ErrorMessageDisplay x:Name="loadingFailedMessage"
-                                Icon="stop"
-                                Visibility="Visible"
                                 Margin="8,0"
                                 Content="{x:Static prop:Resources.loadingFailedMessageContent}"
-                                Message="{x:Static prop:Resources.loadingFailedMessageMessage}" />
+                                Icon="stop"
+                                Message="{x:Static prop:Resources.loadingFailedMessageMessage}"
+                                Visibility="Visible" />
     </StackPanel>
 
-    <ui:OcticonCircleButton DockPanel.Dock="Bottom"
-                            IsDefault="True"
+    <ui:OcticonCircleButton x:Name="cloneButton"
                             Margin="12"
-                            x:Name="cloneButton"
                             HorizontalAlignment="Center"
-                            Icon="check">
+                            DockPanel.Dock="Bottom"
+                            Icon="check"
+                            IsDefault="True">
       <TextBlock Text="{x:Static prop:Resources.CloneLink}" />
     </ui:OcticonCircleButton>
 
-    <Border DockPanel.Dock="Bottom"
-            Style="{StaticResource repositoryBorderStyle}">
+    <Border DockPanel.Dock="Bottom" Style="{StaticResource repositoryBorderStyle}">
       <Grid>
         <Grid.ColumnDefinitions>
           <ColumnDefinition Width="Auto" />
           <ColumnDefinition Width="*" />
           <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
-        <Label Grid.Column="0"
-               Grid.Row="3"
-               Margin="4,0"
-               Target="{Binding ElementName=clonePath}"
-               Content="{x:Static prop:Resources.pathText}" />
 
         <ui:PromptTextBox x:Name="clonePath"
                           Grid.Column="1"
                           Margin="0,2" />
-        <uirx:ValidationMessage x:Name="pathValidationMessage"
-                                Grid.Column="1"
-                                Grid.Row="4"
-                                ValidatesControl="{Binding ElementName=clonePath}" />
         <Button x:Name="browsePathButton"
                 Grid.Column="2"
-                VerticalContentAlignment="Center"
-                Padding="0"
                 Margin="4,0,4,0"
-                Style="{StaticResource GitHubBlueLinkButton}"
-                Content="{x:Static prop:Resources.browsePathButtonContent}" />
+                VerticalContentAlignment="Center"
+                Content="{x:Static prop:Resources.browsePathButtonContent}"
+                Padding="0"
+                Style="{StaticResource GitHubBlueLinkButton}" />
+        <Label Grid.Row="3"
+               Grid.Column="0"
+               Margin="4,0"
+               Content="{x:Static prop:Resources.pathText}"
+               Target="{Binding ElementName=clonePath}" />
+        <uirx:ValidationMessage x:Name="pathValidationMessage"
+                                Grid.Row="4"
+                                Grid.Column="1"
+                                ValidatesControl="{Binding ElementName=clonePath}" />
       </Grid>
     </Border>
 
     <Border x:Name="repositoriesListPane"
-            FocusManager.IsFocusScope="True"
-            FocusVisualStyle="{x:Null}"
+            Margin="0"
             BorderBrush="#EAEAEA"
             BorderThickness="0,1"
-            Margin="0">
+            FocusManager.IsFocusScope="True"
+            FocusVisualStyle="{x:Null}">
       <Border.Resources>
-        <Style TargetType="{x:Type ui:TrimmedTextBlock}"
-               BasedOn="{StaticResource GitHubTextBlock}">
+        <Style BasedOn="{StaticResource GitHubTextBlock}" TargetType="{x:Type ui:TrimmedTextBlock}">
           <Style.Triggers>
-            <Trigger Property="IsTextTrimmed"
-                     Value="True">
-              <Setter Property="ToolTip"
-                      Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=Text}" />
+            <Trigger Property="IsTextTrimmed" Value="True">
+              <Setter Property="ToolTip" Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=Text}" />
             </Trigger>
           </Style.Triggers>
         </Style>
-        <Style x:Key="cloneRepoHeaderStyle"
-               TargetType="TextBlock">
-          <Setter Property="Foreground"
-                  Value="{DynamicResource GHTextBrush}" />
-          <Setter Property="Margin"
-                  Value="0,6,12,6" />
+        <Style x:Key="cloneRepoHeaderStyle" TargetType="TextBlock">
+          <Setter Property="Foreground" Value="{DynamicResource GHTextBrush}" />
+          <Setter Property="Margin" Value="0,6,12,6" />
         </Style>
       </Border.Resources>
       <Grid Margin="0">
@@ -214,23 +242,22 @@
                   <Setter Property="Template">
                     <Setter.Value>
                       <ControlTemplate TargetType="{x:Type GroupItem}">
-                        <Expander Style="{StaticResource cloneGroupExpander}" IsExpanded="{Binding Name.IsExpanded}">
+                        <Expander IsExpanded="{Binding Name.IsExpanded}" Style="{StaticResource cloneGroupExpander}">
                           <Expander.Header>
                             <Border Style="{StaticResource repositoryBorderStyle}">
-                                <StackPanel Orientation="Horizontal"
-                                            VerticalAlignment="Center"
-                                            Margin="0">
-                                    <Image x:Name="avatar"
-                                            Width="16"
-                                            Height="16"
-                                            Margin="0,0,5,0"
-                                            RenderOptions.BitmapScalingMode="HighQuality"
-                                            Source="{Binding Items[0].Owner.Avatar}" />
-                                    <TextBlock Text="{Binding Path=Name.Header}"
-                                               Style="{StaticResource cloneRepoHeaderStyle}" />
-                                </StackPanel>
+                              <StackPanel Margin="0"
+                                          VerticalAlignment="Center"
+                                          Orientation="Horizontal">
+                                <Image x:Name="avatar"
+                                       Width="16"
+                                       Height="16"
+                                       Margin="0,0,5,0"
+                                       RenderOptions.BitmapScalingMode="HighQuality"
+                                       Source="{Binding Items[0].Owner.Avatar}" />
+                                <TextBlock Style="{StaticResource cloneRepoHeaderStyle}" Text="{Binding Path=Name.Header}" />
+                              </StackPanel>
                             </Border>
-                          </Expander.Header>                        
+                          </Expander.Header>
                           <ItemsPresenter Margin="0" />
                         </Expander>
                       </ControlTemplate>
@@ -243,39 +270,33 @@
           <ListBox.ItemTemplate>
             <DataTemplate>
               <Border Style="{StaticResource repositoryBorderStyle}">
-                <StackPanel Orientation="Horizontal"
+                <StackPanel Margin="0"
                             VerticalAlignment="Center"
-                            Margin="0">
+                            Orientation="Horizontal">
                   <ui:OcticonImage x:Name="iconPath"
                                    Width="16"
                                    Height="16"
                                    Margin="32,0,6,0"
                                    VerticalAlignment="Center"
-                                   Icon="{Binding Icon}"
-                                   Foreground="#D0D0D0" />
+                                   Foreground="#D0D0D0"
+                                   Icon="{Binding Icon}" />
 
                   <ui:TrimmedTextBlock x:Name="label"
                                        VerticalAlignment="Center"
-                                       Text="{Binding Name}"
                                        Foreground="#666"
+                                       Text="{Binding Name}"
                                        TextTrimming="CharacterEllipsis" />
                 </StackPanel>
               </Border>
               <DataTemplate.Triggers>
                 <MultiDataTrigger>
                   <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}}"
-                               Value="True" />
-                    <Condition Binding="{Binding Path=(Selector.IsSelectionActive), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}}"
-                               Value="True" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}}" Value="True" />
+                    <Condition Binding="{Binding Path=(Selector.IsSelectionActive), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}}" Value="True" />
                   </MultiDataTrigger.Conditions>
                   <MultiDataTrigger.Setters>
-                    <Setter Property="Foreground"
-                            Value="White"
-                            TargetName="iconPath" />
-                    <Setter Property="Foreground"
-                            Value="White"
-                            TargetName="label" />
+                    <Setter TargetName="iconPath" Property="Foreground" Value="White" />
+                    <Setter TargetName="label" Property="Foreground" Value="White" />
                   </MultiDataTrigger.Setters>
                 </MultiDataTrigger>
               </DataTemplate.Triggers>
@@ -283,9 +304,9 @@
           </ListBox.ItemTemplate>
         </ListBox>
         <StackPanel x:Name="noRepositoriesMessage"
-                    VerticalAlignment="Center"
+                    Margin="0,-70,0,0"
                     HorizontalAlignment="Center"
-                    Margin="0,-70,0,0">
+                    VerticalAlignment="Center">
           <TextBlock HorizontalAlignment="Center"
                      Style="{DynamicResource GitHubH2TextBlock}"
                      Text="{x:Static prop:Resources.noRepositoriesMessageText}" />

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
@@ -152,25 +152,26 @@
                   <Setter Property="Template">
                     <Setter.Value>
                       <ControlTemplate TargetType="{x:Type GroupItem}">
-                        <StackPanel Orientation="Vertical"
-                                    Margin="0">
-                          <Border Background="#F8F8F8"
-                                  Style="{StaticResource repositoryBorderStyle}">
+                        <Expander IsExpanded="{Binding Name.IsExpanded}">
+                          <Expander.Header>
+                            <Border Background="#F8F8F8"
+                                    Style="{StaticResource repositoryBorderStyle}">
                             <StackPanel Orientation="Horizontal"
                                         VerticalAlignment="Center"
                                         Margin="0">
-                              <Image x:Name="avatar"
-                                     Width="16"
-                                     Height="16"
-                                     Margin="10,0,6,0"
-                                     RenderOptions.BitmapScalingMode="HighQuality"
-                                     Source="{Binding Items[0].Owner.Avatar}" />
-                              <TextBlock Text="{Binding Path=Name}"
-                                         Style="{StaticResource cloneRepoHeaderStyle}" />
+                                <Image x:Name="avatar"
+                                        Width="16"
+                                        Height="16"
+                                        Margin="10,0,6,0"
+                                        RenderOptions.BitmapScalingMode="HighQuality"
+                                        Source="{Binding Items[0].Owner.Avatar}" />
+                                <TextBlock Text="{Binding Path=Name.Header}"
+                                           Style="{StaticResource cloneRepoHeaderStyle}" />
                             </StackPanel>
-                          </Border>
+                            </Border>
+                          </Expander.Header>                        
                           <ItemsPresenter Margin="0" />
-                        </StackPanel>
+                        </Expander>
                       </ControlTemplate>
                     </Setter.Value>
                   </Setter>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml.cs
@@ -31,7 +31,7 @@ namespace GitHub.VisualStudio.UI.Views.Controls
     [PartCreationPolicy(CreationPolicy.NonShared)]
     public partial class RepositoryCloneControl : GenericRepositoryCloneControl
     {
-        private Dictionary<string, RepositoryGroup> groups = new Dictionary<string, RepositoryGroup>();
+        readonly Dictionary<string, RepositoryGroup> groups = new Dictionary<string, RepositoryGroup>();
 
         public RepositoryCloneControl()
         {
@@ -73,7 +73,7 @@ namespace GitHub.VisualStudio.UI.Views.Controls
 
         class RepositoryGroupDescription : GroupDescription
         {
-            RepositoryCloneControl owner;
+            readonly RepositoryCloneControl owner;
 
             public RepositoryGroupDescription(RepositoryCloneControl owner)
             {
@@ -82,7 +82,9 @@ namespace GitHub.VisualStudio.UI.Views.Controls
 
             public override object GroupNameFromItem(object item, int level, System.Globalization.CultureInfo culture)
             {
-                var name = ((IRepositoryModel)item).Owner.Login;
+                var repo = item as IRepositoryModel;
+                Debug.Assert(repo.Owner != null, "Repository owner cannot be null, did something get changed in the RepositoryModel ctor?");
+                var name = repo.Owner.Login;
                 RepositoryGroup group;
 
                 if (!owner.groups.TryGetValue(name, out group))
@@ -90,10 +92,7 @@ namespace GitHub.VisualStudio.UI.Views.Controls
                     group = new RepositoryGroup(name, owner.groups.Count == 0);
 
                     if (owner.groups.Count == 1)
-                    {
                         owner.groups.Values.First().IsExpanded = false;
-                    }
-
                     owner.groups.Add(name, group);
                 }
 
@@ -103,7 +102,7 @@ namespace GitHub.VisualStudio.UI.Views.Controls
 
         class RepositoryGroup : ReactiveObject
         {
-            private bool isExpanded;
+            bool isExpanded;
 
             public RepositoryGroup(string header, bool isExpanded)
             {


### PR DESCRIPTION
Fix for #276 

Makes groups in the clone dialog collapsible. If there is only a single
group, then it will be expanded; as more groups are created, the first
group is collapsed and further groups will be added collapsed.

Only problem with this is that you can see an initial flash of expanded
items when loading with multiple groups, however I felt this was
preferable to everything being collapsed until the whole list is
loaded...