### PR TITLE
Remember section expanded state.

### DIFF
--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -130,6 +130,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>IPackageSettings.tt</DependentUpon>
     </Compile>
+    <Compile Include="Settings\GitHubConnectSectionState.cs" />
+    <Compile Include="Settings\UIState.cs" />
     <Compile Include="ViewModels\IServiceProviderAware.cs" />
     <Compile Include="UI\IView.cs" />
     <Compile Include="UI\Octicon.cs" />

--- a/src/GitHub.Exports/Settings/GitHubConnectSectionState.cs
+++ b/src/GitHub.Exports/Settings/GitHubConnectSectionState.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using GitHub.Settings;
+
+namespace GitHub.Settings
+{
+    /// <summary>
+    /// Stores persistent UI state for a <see cref="GitHubConnectSection"/> in 
+    /// <see cref="IPackageSettings"/>.
+    /// </summary>
+    public class GitHubConnectSectionState
+    {
+        /// <summary>
+        /// Gets or sets the name of the connection section.
+        /// </summary>
+        public string SectionName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the section should be expanded.
+        /// </summary>
+        public bool IsExpanded { get; set; } = true;
+    }
+}

--- a/src/GitHub.Exports/Settings/UIState.cs
+++ b/src/GitHub.Exports/Settings/UIState.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using GitHub.Settings;
+using System.Linq;
+using GitHub.VisualStudio.TeamExplorer.Connect;
+
+namespace GitHub.Settings
+{
+    /// <summary>
+    /// Stores persistent UI state in <see cref="IPackageSettings"/>.
+    /// </summary>
+    public class UIState
+    {
+        /// <summary>
+        /// Gets or sets the UI state for the <see cref="IGitHubConnectSection"/>s in Team Explorer.
+        /// </summary>
+        public List<GitHubConnectSectionState> GitHubConnectSections { get; set; }
+            = new List<GitHubConnectSectionState>();
+
+        /// <summary>
+        /// Gets or creates the UI state for a named <see cref="IGitHubConnectSection"/>.
+        /// </summary>
+        /// <param name="sectionName">The name of the section.</param>
+        /// <returns>A <see cref="GitHubConnectSectionState"/> object.</returns>
+        public GitHubConnectSectionState GetOrCreateConnectSection(string sectionName)
+        {
+            var result = GitHubConnectSections.FirstOrDefault(x => x.SectionName == sectionName);
+
+            if (result == null)
+            {
+                result = new GitHubConnectSectionState { SectionName = sectionName };
+                GitHubConnectSections.Add(result);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/GitHub.Exports/Settings/generated/IPackageSettings.tt
+++ b/src/GitHub.Exports/Settings/generated/IPackageSettings.tt
@@ -27,5 +27,6 @@ foreach (var j in json["settings"].Children()) {
 <#
 }
 #>
+		UIState UIState { get; }
     }
 }

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection0.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection0.cs
@@ -1,6 +1,7 @@
 ﻿using GitHub.Api;
 using GitHub.Models;
 using GitHub.Services;
+using GitHub.Settings;
 using Microsoft.TeamFoundation.Controls;
 using System.ComponentModel.Composition;
 
@@ -13,8 +14,11 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
         public const string GitHubConnectSection0Id = "519B47D3-F2A9-4E19-8491-8C9FA25ABE90";
 
         [ImportingConstructor]
-        public GitHubConnectSection0(ISimpleApiClientFactory apiFactory, ITeamExplorerServiceHolder holder, IConnectionManager manager)
-            : base(apiFactory, holder, manager, 0)
+        public GitHubConnectSection0(ISimpleApiClientFactory apiFactory,
+            ITeamExplorerServiceHolder holder,
+            IConnectionManager manager,
+            IPackageSettings settings)
+            : base(apiFactory, holder, manager, settings, 0)
         {
         }
     }

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection1.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection1.cs
@@ -1,6 +1,7 @@
 ﻿using GitHub.Api;
 using GitHub.Models;
 using GitHub.Services;
+using GitHub.Settings;
 using Microsoft.TeamFoundation.Controls;
 using System.ComponentModel.Composition;
 
@@ -13,8 +14,11 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
         public const string GitHubConnectSection1Id = "519B47D3-F2A9-4E19-8491-8C9FA25ABE91";
 
         [ImportingConstructor]
-        public GitHubConnectSection1(ISimpleApiClientFactory apiFactory, ITeamExplorerServiceHolder holder, IConnectionManager manager)
-            : base(apiFactory, holder, manager, 1)
+        public GitHubConnectSection1(ISimpleApiClientFactory apiFactory,
+            ITeamExplorerServiceHolder holder,
+            IConnectionManager manager,
+            IPackageSettings settings)
+            : base(apiFactory, holder, manager, settings, 1)
         {
         }
     }

--- a/src/GitHub.VisualStudio/Settings/PackageSettings.cs
+++ b/src/GitHub.VisualStudio/Settings/PackageSettings.cs
@@ -9,7 +9,7 @@ using GitHub.Settings;
 namespace GitHub.VisualStudio.Settings
 {
     [Export(typeof(IPackageSettings))]
-    [PartCreationPolicy(CreationPolicy.NonShared)]
+    [PartCreationPolicy(CreationPolicy.Shared)]
     public partial class PackageSettings : IPackageSettings
     {
         readonly SettingsStore settingsStore;
@@ -20,11 +20,15 @@ namespace GitHub.VisualStudio.Settings
             var sm = new ShellSettingsManager(serviceProvider);
             settingsStore = new SettingsStore(sm.GetWritableSettingsStore(SettingsScope.UserSettings), Info.ApplicationInfo.ApplicationSafeName);
             LoadSettings();
+            UIState = SimpleJson.DeserializeObject<UIState>((string)settingsStore.Read("UIState", "{}"));
         }
+
+        public UIState UIState { get; }
 
         public void Save()
         {
             SaveSettings();
+            settingsStore.Write("UIState", SimpleJson.SerializeObject(UIState));
         }
     }
 }


### PR DESCRIPTION
Fixes #149 .

Sections in the Connect pane in Team Explorer now remember their expanded state between Visual Studio sessions.