### PR TITLE
Use CheckBox.Content for label

### DIFF
--- a/src/GitHub.VisualStudio/UI/Settings/OptionsControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Settings/OptionsControl.xaml
@@ -74,8 +74,7 @@
     </GroupBox.Header>
     <DockPanel>
       <WrapPanel DockPanel.Dock="Top">
-        <CheckBox x:Name="chkMetrics" VerticalAlignment="Center" />
-        <Label Content="{x:Static prop:Resources.Options_MetricsLabel}" />
+        <CheckBox x:Name="chkMetrics" VerticalAlignment="Center" Content="{x:Static prop:Resources.Options_MetricsLabel}" />
       </WrapPanel>
       <TextBlock>
         <Hyperlink ToolTip="https://visualstudio.github.com/samples.html" NavigateUri="https://visualstudio.github.com/samples.html" RequestNavigate="Hyperlink_RequestNavigate"><TextBlock Text="{x:Static prop:Resources.learnMoreLink}"/></Hyperlink>


### PR DESCRIPTION
Fixes #289 - clicking on checkbox label in options new toggles the checkbox state.