### PR TITLE
Polish expander styles

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
@@ -46,7 +46,68 @@
         <Setter Property="Margin"
                 Value="0" />
       </Style>
-    </DockPanel.Resources>
+
+            <Style x:Key="ExpanderDownHeaderStyle" TargetType="{x:Type ToggleButton}">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ToggleButton}">
+                            <Border Padding="{TemplateBinding Padding}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock x:Name="arrow" Text="Foobar" Foreground="Red" />
+                                </StackPanel>
+                            </Border>
+
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter Property="Foreground" TargetName="arrow" Value="Blue" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style x:Key="ExpanderHeaderFocusVisual">
+                <Setter Property="Control.Template">
+                    <Setter.Value>
+                        <ControlTemplate>
+                            <Border>
+                                <Rectangle Margin="0" SnapsToDevicePixels="true" Stroke="Black" StrokeThickness="1" StrokeDashArray="1 2"/>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style x:Key="StatusGroupExpander" TargetType="{x:Type Expander}">
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                <Setter Property="VerticalContentAlignment" Value="Stretch"/>
+                <Setter Property="BorderBrush" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type Expander}">
+                            <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="3" SnapsToDevicePixels="true">
+                                <DockPanel>
+                                    <ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="1" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource ExpanderDownHeaderStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                    <ContentPresenter x:Name="ExpandSite" DockPanel.Dock="Bottom" Focusable="false" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" Visibility="Collapsed" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                </DockPanel>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsExpanded" Value="true">
+                                    <Setter Property="Visibility" TargetName="ExpandSite" Value="Visible"/>
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="false">
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </DockPanel.Resources>
     
     <ui:FilterTextBox x:Name="filterText"
                       DockPanel.Dock="Top"
@@ -151,13 +212,15 @@
                 <Style TargetType="{x:Type GroupItem}">
                   <Setter Property="Template">
                     <Setter.Value>
-                      <ControlTemplate TargetType="{x:Type GroupItem}">
-                        <Expander IsExpanded="{Binding Name.IsExpanded}">
+                    <ControlTemplate TargetType="{x:Type GroupItem}">
+                        <Expander Style="{StaticResource StatusGroupExpander}" IsExpanded="{Binding Name.IsExpanded}">
                           <Expander.Header>
                             <Border Background="#F8F8F8"
+                                    Width="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Expander}}, Path=ActualWidth}"
                                     Style="{StaticResource repositoryBorderStyle}">
                             <StackPanel Orientation="Horizontal"
                                         VerticalAlignment="Center"
+                                        HorizontalAlignment="Stretch"
                                         Margin="0">
                                 <Image x:Name="avatar"
                                         Width="16"

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
@@ -47,7 +47,7 @@
                 Value="0" />
       </Style>
 
-            <Style x:Key="ExpanderDownHeaderStyle" TargetType="{x:Type ToggleButton}">
+            <Style x:Key="expanderDownHeaderStyle" TargetType="{x:Type ToggleButton}">
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ToggleButton}">
@@ -80,7 +80,7 @@
                 </Setter>
             </Style>
 
-            <Style x:Key="StatusGroupExpander" TargetType="{x:Type Expander}">
+            <Style x:Key="cloneGroupExpander" TargetType="{x:Type Expander}">
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
                 <Setter Property="Background" Value="Transparent"/>
                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
@@ -92,7 +92,7 @@
                         <ControlTemplate TargetType="{x:Type Expander}">
                             <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="3" SnapsToDevicePixels="true">
                                 <DockPanel>
-                                    <ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="0" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource ExpanderDownHeaderStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                    <ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="0" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource expanderDownHeaderStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
                                     <ContentPresenter x:Name="ExpandSite" DockPanel.Dock="Bottom" Focusable="false" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" Visibility="Collapsed" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                                 </DockPanel>
                             </Border>
@@ -108,7 +108,7 @@
                     </Setter.Value>
                 </Setter>
             </Style>
-        </DockPanel.Resources>
+    </DockPanel.Resources>
     
     <ui:FilterTextBox x:Name="filterText"
                       DockPanel.Dock="Top"
@@ -213,8 +213,8 @@
                 <Style TargetType="{x:Type GroupItem}">
                   <Setter Property="Template">
                     <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type GroupItem}">
-                        <Expander Style="{StaticResource StatusGroupExpander}" IsExpanded="{Binding Name.IsExpanded}">
+                      <ControlTemplate TargetType="{x:Type GroupItem}">
+                        <Expander Style="{StaticResource cloneGroupExpander}" IsExpanded="{Binding Name.IsExpanded}">
                           <Expander.Header>
                             <Border Style="{StaticResource repositoryBorderStyle}">
                                 <StackPanel Orientation="Horizontal"

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
@@ -86,13 +86,13 @@
                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
                 <Setter Property="VerticalContentAlignment" Value="Stretch"/>
                 <Setter Property="BorderBrush" Value="Transparent"/>
-                <Setter Property="BorderThickness" Value="1"/>
+                <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type Expander}">
                             <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="3" SnapsToDevicePixels="true">
                                 <DockPanel>
-                                    <ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="1" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource ExpanderDownHeaderStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                    <ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="0" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource ExpanderDownHeaderStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
                                     <ContentPresenter x:Name="ExpandSite" DockPanel.Dock="Bottom" Focusable="false" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" Visibility="Collapsed" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                                 </DockPanel>
                             </Border>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
@@ -51,15 +51,16 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ToggleButton}">
-                            <Border Padding="{TemplateBinding Padding}">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock x:Name="arrow" Text="Foobar" Foreground="Red" />
+                            <Border Padding="{TemplateBinding Padding}" Style="{StaticResource repositoryBorderStyle}">
+                                <StackPanel Orientation="Horizontal" Background="#F8F8F8">
+                                    <ui:OcticonImage x:Name="arrow" Icon="triangle_right" Foreground="Black" Height="10" Margin="5,0,0,0" />
+                                    <ContentPresenter HorizontalAlignment="Left" Margin="0" RecognizesAccessKey="True" SnapsToDevicePixels="True" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Border>
 
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsChecked" Value="True">
-                                    <Setter Property="Foreground" TargetName="arrow" Value="Blue" />
+                                    <Setter TargetName="arrow" Property="Icon" Value="triangle_down" />
                                 </Trigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
@@ -215,22 +216,19 @@
                     <ControlTemplate TargetType="{x:Type GroupItem}">
                         <Expander Style="{StaticResource StatusGroupExpander}" IsExpanded="{Binding Name.IsExpanded}">
                           <Expander.Header>
-                            <Border Background="#F8F8F8"
-                                    Width="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Expander}}, Path=ActualWidth}"
-                                    Style="{StaticResource repositoryBorderStyle}">
-                            <StackPanel Orientation="Horizontal"
-                                        VerticalAlignment="Center"
-                                        HorizontalAlignment="Stretch"
-                                        Margin="0">
-                                <Image x:Name="avatar"
-                                        Width="16"
-                                        Height="16"
-                                        Margin="10,0,6,0"
-                                        RenderOptions.BitmapScalingMode="HighQuality"
-                                        Source="{Binding Items[0].Owner.Avatar}" />
-                                <TextBlock Text="{Binding Path=Name.Header}"
-                                           Style="{StaticResource cloneRepoHeaderStyle}" />
-                            </StackPanel>
+                            <Border Style="{StaticResource repositoryBorderStyle}">
+                                <StackPanel Orientation="Horizontal"
+                                            VerticalAlignment="Center"
+                                            Margin="0">
+                                    <Image x:Name="avatar"
+                                            Width="16"
+                                            Height="16"
+                                            Margin="0,0,5,0"
+                                            RenderOptions.BitmapScalingMode="HighQuality"
+                                            Source="{Binding Items[0].Owner.Avatar}" />
+                                    <TextBlock Text="{Binding Path=Name.Header}"
+                                               Style="{StaticResource cloneRepoHeaderStyle}" />
+                                </StackPanel>
                             </Border>
                           </Expander.Header>                        
                           <ItemsPresenter Margin="0" />


### PR DESCRIPTION
Destination Branch: `276-collapse-clone-groups` (https://github.com/github/VisualStudio/pull/288)

This pull request give a little UI love to the collapsed clone groups. 

**Before**

![image](https://cloud.githubusercontent.com/assets/1174461/15058426/e92bb952-12d0-11e6-89ec-a9d37e95b479.png)

**After**

![image](https://cloud.githubusercontent.com/assets/1174461/15059315/b55b0226-12d6-11e6-870a-cab45c549270.png)

My initial mock had the icons and avatars aligned with each other:

![image](https://cloud.githubusercontent.com/assets/1174461/15059344/eb8f47d0-12d6-11e6-8ca7-60c51fbd5292.png)

However, I liked how the indented icons are consistent with the repo list in the Team Explorer pane:

![image](https://cloud.githubusercontent.com/assets/1174461/15059410/48bf7f6a-12d7-11e6-9324-83322a1b0abd.png)

That said, I can align them up if we think it'll look better 😄 

In https://github.com/github/VisualStudio/pull/288, @grokys mentioned:

> Only problem with this is that you can see an initial flash of expanded
> items when loading with multiple groups, however I felt this was
> preferable to everything being collapsed until the whole list is
> loaded...

We about using an animated transition when collapsing and expanding each organization to help with the initial flash of expanded items. That's not included in this PR but would be my next focus!

/cc @shana @simurai @grokys for 👀  and 💭 