### PR TITLE
Don't call cancel.OnCompleted after disposal.

### DIFF
--- a/src/GitHub.UI.Reactive/Controls/SimpleViewUserControl.cs
+++ b/src/GitHub.UI.Reactive/Controls/SimpleViewUserControl.cs
@@ -56,7 +56,6 @@ namespace GitHub.UI
                 return;
 
             cancel.OnNext(null);
-            cancel.OnCompleted();
         }
 
         protected void NotifyIsBusy(bool busy)


### PR DESCRIPTION
`cancel.OnNext` causes `cancel` to get disposed, so don't try calling
`OnCompleted` on it afterwards. Fixes #311.