### PR TITLE
Use Merge instead of Amb on login control.

### DIFF
--- a/src/GitHub.App/ViewModels/LoginControlViewModel.cs
+++ b/src/GitHub.App/ViewModels/LoginControlViewModel.cs
@@ -45,7 +45,7 @@ namespace GitHub.ViewModels
 
                 }).ToProperty(this, x => x.LoginMode);
 
-            AuthenticationResults = Observable.Amb(
+            AuthenticationResults = Observable.Merge(
                 loginToGitHubViewModel.Login,
                 EnterpriseLogin.Login);
             CancelCommand = ReactiveCommand.Create();

--- a/src/UnitTests/GitHub.App/ViewModels/LoginControlViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/LoginControlViewModelTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Net;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using GitHub.Authentication;
+using GitHub.Info;
+using GitHub.Models;
+using GitHub.Primitives;
+using GitHub.Services;
+using GitHub.ViewModels;
+using NSubstitute;
+using Octokit;
+using ReactiveUI;
+using Xunit;
+
+public class LoginControlViewModelTests
+{
+    public class TheAuthenticationResultsCommand : TestBaseClass
+    {
+        [Fact]
+        public async void AllowsLoginFromEnterpriseAfterGitHubLoginHasFailed()
+        {
+            var repositoryHosts = Substitute.For<IRepositoryHosts>();
+
+            var gitHubLogin = Substitute.For<ILoginToGitHubViewModel>();
+            var gitHubLoginCommand = ReactiveCommand.CreateAsyncObservable(_ => 
+                Observable.Return(AuthenticationResult.CredentialFailure));
+            gitHubLogin.Login.Returns(gitHubLoginCommand);
+
+            var enterpriseLogin = Substitute.For<ILoginToGitHubForEnterpriseViewModel>();
+            var enterpriseLoginCommand = ReactiveCommand.CreateAsyncObservable(_ =>
+                Observable.Return(AuthenticationResult.Success));
+            enterpriseLogin.Login.Returns(enterpriseLoginCommand);
+
+            var loginViewModel = new LoginControlViewModel(repositoryHosts, gitHubLogin, enterpriseLogin);
+            var success = false;
+
+            loginViewModel.AuthenticationResults
+                .Where(x => x == AuthenticationResult.Success)
+                .Subscribe(_ => success = true);
+
+            await gitHubLoginCommand.ExecuteAsync();
+            await enterpriseLoginCommand.ExecuteAsync();
+
+            Assert.True(success);
+        }
+    }
+}
+  

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -163,6 +163,7 @@
     <Compile Include="GitHub.App\Services\GitClientTests.cs" />
     <Compile Include="GitHub.App\Services\RepositoryCloneServiceTests.cs" />
     <Compile Include="GitHub.App\Services\RepositoryCreationServiceTests.cs" />
+    <Compile Include="GitHub.App\ViewModels\LoginControlViewModelTests.cs" />
     <Compile Include="GitHub.App\ViewModels\LoginToGitHubViewModelTests.cs" />
     <Compile Include="GitHub.App\ViewModels\RepositoryCloneViewModelTests.cs" />
     <Compile Include="GitHub.App\ViewModels\RepositoryCreationViewModelTests.cs" />


### PR DESCRIPTION
Fixes #309. `Observable.Amb` "emits all of the items from only the firstof these Observables to emit an item or notification". This means that if the user tries to login first to .com with an invalid login, then
tries to login to enterprise with a valid login the login from enterprise will be ignored because the .com observable fired first.Instead use `Observable.Merge` which will emit authentication results from both in any order.