### PR TITLE
Removed DefaultRepositoryName

### DIFF
--- a/src/GitHub.App/SampleData/SampleViewModels.cs
+++ b/src/GitHub.App/SampleData/SampleViewModels.cs
@@ -232,14 +232,6 @@ namespace GitHub.SampleData
             SelectedConnection = Connections[0];
         }
 
-        public string DefaultRepositoryName
-        {
-            get
-            {
-                return "whatever";
-            }
-        }
-
         public bool IsHostComboBoxVisible
         {
             get

--- a/src/GitHub.App/ViewModels/RepositoryPublishViewModel.cs
+++ b/src/GitHub.App/ViewModels/RepositoryPublishViewModel.cs
@@ -91,7 +91,7 @@ namespace GitHub.ViewModels
 
             var defaultRepositoryName = repositoryPublishService.LocalRepositoryName;
             if (!string.IsNullOrEmpty(defaultRepositoryName))
-                DefaultRepositoryName = defaultRepositoryName;
+                RepositoryName = defaultRepositoryName;
 
             this.WhenAny(x => x.SelectedConnection, x => x.SelectedAccount,
                 (a,b) => true)
@@ -106,7 +106,6 @@ namespace GitHub.ViewModels
                 });
         }
 
-        public string DefaultRepositoryName { get; private set; }
         public new string Title { get { return title.Value; } }
         public bool CanKeepPrivate { get { return canKeepPrivate.Value; } }
         public bool IsPublishing { get { return isPublishing.Value; } }

--- a/src/GitHub.Exports.Reactive/ViewModels/IRepositoryPublishViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IRepositoryPublishViewModel.cs
@@ -28,11 +28,6 @@ namespace GitHub.ViewModels
         /// The selected host to publish to.
         /// </summary>
         IConnection SelectedConnection { get; set; }
-
-        /// <summary>
-        /// Sets the default repository name when prepopulating the form.
-        /// </summary>
-        string DefaultRepositoryName { get; }
     }
 
     public enum ProgressState

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml.cs
@@ -57,8 +57,6 @@ namespace GitHub.VisualStudio.UI.Views.Controls
                         else
                             teServices.ClearNotifications();
                     }));
-
-                nameText.Text = ViewModel.DefaultRepositoryName;
             });
             IsVisibleChanged += (s, e) =>
             {


### PR DESCRIPTION
From `IRepositoryPublishViewModel`. Seems to not be needed and was causing #279.

The default repository name was being placed directly into `RepositoryPublishControl.nameText` in the control which meant:

- it was only written to `RepositoryName` when the user clicked on the `nameText` control
- which meant that `RepositoryName` was up until that point null
- which meant that the validation for it was failing
- which meant the "Publish" button was disabled.

This commit just sets the `RepositoryName` to the default in the VM ctor meaning that that name gets immediately validated. `DefaultRepositoryName` didn't seem to be used anywhere else, so I removed it.

cc: @Haacked for a sanity check because it looks like you wrote this.

Fixes #279