### PR TITLE
Fix stackoverflow and resource disposal

### DIFF
--- a/src/GitHub.App/Caches/ImageCache.cs
+++ b/src/GitHub.App/Caches/ImageCache.cs
@@ -213,33 +213,8 @@ namespace GitHub.Caches
             return url.ToString();
         }
 
-        bool disposed;
-        void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (disposed) return;
-
-                try
-                {
-                    cacheFactory.Select(x =>
-                    {
-                        x.Dispose();
-                        return x.Shutdown;
-                    }).Wait();
-                }
-                catch (Exception e)
-                {
-                    log.Warn("Exception occured while disposing ImageCache", e);
-                }
-                disposed = true;
-            }
-        }
-
         public void Dispose()
-        {
-            Dispose(true);
-        }
+        {}
 
         class UriComparer : IEqualityComparer<Uri>
         {

--- a/src/GitHub.App/Caches/LoginCache.cs
+++ b/src/GitHub.App/Caches/LoginCache.cs
@@ -56,28 +56,7 @@ namespace GitHub.Caches
             return cache.Secure.Flush();
         }
 
-        bool disposed;
-        void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (disposed) return;
-
-                try
-                {
-                    cache.Dispose();
-                }
-                catch (Exception e)
-                {
-                    log.Warn("Exception occurred while disposing shared cache", e);
-                }
-                disposed = true;
-            }
-        }
-
         public void Dispose()
-        {
-            Dispose(true);
-        }
+        {}
     }
 }

--- a/src/GitHub.App/Factories/HostCacheFactory.cs
+++ b/src/GitHub.App/Factories/HostCacheFactory.cs
@@ -40,17 +40,8 @@ namespace GitHub.Factories
         IOperatingSystem OperatingSystem { get { return operatingSystem.Value; } }
         IBlobCacheFactory BlobCacheFactory { get { return blobCacheFactory.Value; } }
 
-        bool disposed;
         protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (disposed) return;
-                disposed = true;
-                if (blobCacheFactory.IsValueCreated)
-                    blobCacheFactory.Value.Dispose();
-            }
-        }
+        {}
 
         public void Dispose()
         {

--- a/src/GitHub.App/Factories/SqlitePersistentBlobCacheFactory.cs
+++ b/src/GitHub.App/Factories/SqlitePersistentBlobCacheFactory.cs
@@ -4,7 +4,8 @@ using NLog;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
 
 namespace GitHub.Factories
 {
@@ -12,7 +13,6 @@ namespace GitHub.Factories
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class SqlitePersistentBlobCacheFactory : IBlobCacheFactory
     {
-        readonly CompositeDisposable disposables = new CompositeDisposable();
         static readonly Logger log = LogManager.GetCurrentClassLogger();
         Dictionary<string, IBlobCache> cache = new Dictionary<string, IBlobCache>();
 
@@ -26,7 +26,6 @@ namespace GitHub.Factories
             {
                 var c = new SQLitePersistentBlobCache(path);
                 cache.Add(path, c);
-                disposables.Add(c);
                 return c;
             }
             catch(Exception ex)
@@ -43,7 +42,14 @@ namespace GitHub.Factories
             {
                 if (disposed) return;
                 disposed = true;
-                disposables.Dispose();
+                Task.Run(() =>
+                {
+                    foreach (var c in cache.Values)
+                    {
+                        c.Dispose();
+                        c.Shutdown.Wait();
+                    }
+                }).Wait(500);
             }
         }
 

--- a/src/GitHub.App/Factories/UIFactory.cs
+++ b/src/GitHub.App/Factories/UIFactory.cs
@@ -35,6 +35,16 @@ namespace GitHub.App.Factories
         {
             return new UIPair(viewType, factory.GetView(viewType), factory.GetViewModel(viewType));
         }
+
+        protected virtual void Dispose(bool disposing)
+        {}
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
     }
 
     /// <summary>

--- a/src/GitHub.App/Models/RepositoryHost.cs
+++ b/src/GitHub.App/Models/RepositoryHost.cs
@@ -268,24 +268,8 @@ namespace GitHub.Models
             return Observable.Defer(() => ApiClient.GetUser());
         }
 
-        bool disposed;
         protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (disposed) return;
-
-                try
-                {
-                    ModelService.Dispose();
-                }
-                catch (Exception e)
-                {
-                    log.Warn("Exception occured while disposing RepositoryHost's ModelService", e);
-                }
-                disposed = true;
-            }
-        }
+        {}
 
         public void Dispose()
         {

--- a/src/GitHub.App/Models/RepositoryHosts.cs
+++ b/src/GitHub.App/Models/RepositoryHosts.cs
@@ -39,7 +39,6 @@ namespace GitHub.Models
             this.connectionManager = connectionManager;
 
             RepositoryHostFactory = repositoryHostFactory;
-            disposables.Add(repositoryHostFactory);
             GitHubHost = DisconnectedRepositoryHost;
             EnterpriseHost = DisconnectedRepositoryHost;
 
@@ -101,9 +100,7 @@ namespace GitHub.Models
                 {
                     var host = LookupHost(x.HostAddress);
                     if (host.Address != x.HostAddress)
-                    {
                         host = RepositoryHostFactory.Create(x.HostAddress);
-                    }
                     return host;
                 })
                 .Select(h => LogOut(h))
@@ -147,7 +144,6 @@ namespace GitHub.Models
         {
             var isDotCom = HostAddress.GitHubDotComHostAddress == address;
             var host = RepositoryHostFactory.Create(address);
-            disposables.Add(host);
             return host.LogIn(usernameOrEmail, password)
                 .Catch<AuthenticationResult, Exception>(Observable.Throw<AuthenticationResult>)
                 .Do(result =>
@@ -180,7 +176,6 @@ namespace GitHub.Models
         {
             var isDotCom = HostAddress.GitHubDotComHostAddress == address;
             var host = RepositoryHostFactory.Create(address);
-            disposables.Add(host);
             return host.LogInFromCache()
                 .Catch<AuthenticationResult, Exception>(Observable.Throw<AuthenticationResult>)
                 .Do(result =>
@@ -210,7 +205,7 @@ namespace GitHub.Models
                     else
                         EnterpriseHost = null;
                     connectionManager.RemoveConnection(address);
-                    disposables.Remove(host);
+                    RepositoryHostFactory.Remove(host);
                 });
         }
 

--- a/src/GitHub.App/Services/AvatarProvider.cs
+++ b/src/GitHub.App/Services/AvatarProvider.cs
@@ -77,16 +77,8 @@ namespace GitHub.Services
             return apiAccount.IsUser ? DefaultUserBitmapImage : DefaultOrgBitmapImage;
         }
 
-        bool disposed;
         protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (disposed) return;
-                imageCache.Dispose();
-                disposed = true;
-            }
-        }
+        {}
 
         public void Dispose()
         {

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -280,15 +280,8 @@ namespace GitHub.Services
             return hostCache.InsertObject("user", user);
         }
 
-        bool disposed;
         protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (disposed) return;
-                disposed = true;
-            }
-        }
+        {}
 
         public void Dispose()
         {

--- a/src/GitHub.App/ViewModels/RepositoryCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/RepositoryCreationViewModel.cs
@@ -44,16 +44,14 @@ namespace GitHub.ViewModels
         RepositoryCreationViewModel(
             IConnectionRepositoryHostMap connectionRepositoryHostMap,
             IOperatingSystem operatingSystem,
-            IRepositoryCreationService repositoryCreationService,
-            IAvatarProvider avatarProvider)
-            : this(connectionRepositoryHostMap.CurrentRepositoryHost, operatingSystem, repositoryCreationService, avatarProvider)
+            IRepositoryCreationService repositoryCreationService)
+            : this(connectionRepositoryHostMap.CurrentRepositoryHost, operatingSystem, repositoryCreationService)
         {}
 
         public RepositoryCreationViewModel(
             IRepositoryHost repositoryHost,
             IOperatingSystem operatingSystem,
-            IRepositoryCreationService repositoryCreationService,
-            IAvatarProvider avatarProvider)
+            IRepositoryCreationService repositoryCreationService)
         {
             this.repositoryHost = repositoryHost;
             this.operatingSystem = operatingSystem;

--- a/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
+++ b/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
@@ -117,13 +117,11 @@ namespace GitHub.Collections
             sourceQueue = obs
                 .Do(data => queue.Enqueue(new ActionData(data)));
 
-            source = Observable
-                .Generate(StartQueue(),
-                    i => !disposed,
-                    i => i + 1,
-                    i => GetFromQueue(),
-                    i => delay
-                )
+            source = Observable.Defer(() => {
+                StartQueue();
+                return Observable.Timer(TimeSpan.Zero, delay)
+                                 .Select(_ => GetFromQueue());
+            })
                 .Where(data => data.Item != null)
                 .ObserveOn(scheduler)
                 .Select(x => ProcessItem(x, original))

--- a/src/GitHub.Exports.Reactive/Factories/IApiClientFactory.cs
+++ b/src/GitHub.Exports.Reactive/Factories/IApiClientFactory.cs
@@ -1,5 +1,6 @@
 ﻿using GitHub.Api;
 using GitHub.Primitives;
+using System;
 
 namespace GitHub.Factories
 {

--- a/src/GitHub.Exports.Reactive/Factories/IRepositoryHostFactory.cs
+++ b/src/GitHub.Exports.Reactive/Factories/IRepositoryHostFactory.cs
@@ -7,5 +7,6 @@ namespace GitHub.Factories
     public interface IRepositoryHostFactory : IDisposable
     {
         IRepositoryHost Create(HostAddress hostAddress);
+        void Remove(IRepositoryHost host);
     }
 }

--- a/src/GitHub.Exports/Factories/IUIFactory.cs
+++ b/src/GitHub.Exports/Factories/IUIFactory.cs
@@ -1,8 +1,9 @@
 ﻿using GitHub.Exports;
+using System;
 
 namespace GitHub.App.Factories
 {
-    public interface IUIFactory
+    public interface IUIFactory : IDisposable
     {
         IUIPair CreateViewAndViewModel(UIViewType viewType);
     }

--- a/src/UnitTests/GitHub.App/ViewModels/RepositoryCreationViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/RepositoryCreationViewModelTests.cs
@@ -33,7 +33,7 @@ public class RepositoryCreationViewModelTests
         var avatarProvider = provider.GetAvatarProvider();
         var connection = provider.GetConnection();
 
-        return new RepositoryCreationViewModel(repositoryHost, os, creationService, avatarProvider);
+        return new RepositoryCreationViewModel(repositoryHost, os, creationService);
     }
 
     public class TheSafeRepositoryNameProperty : TestBaseClass
@@ -333,8 +333,7 @@ public class RepositoryCreationViewModelTests
             var vm = new RepositoryCreationViewModel(
                 repositoryHost,
                 Substitute.For<IOperatingSystem>(),
-                Substitute.For<IRepositoryCreationService>(),
-                Substitute.For<IAvatarProvider>());
+                Substitute.For<IRepositoryCreationService>());
 
             Assert.Equal(vm.Accounts[0], vm.SelectedAccount);
             Assert.Equal(2, vm.Accounts.Count);


### PR DESCRIPTION
Fixes #324

I'll take a guess and say that Observable.Generate is doing weird things and causing our crashes.
Also, MEF disposes of everything for us when the container goes away, so there's no need to manually dispose of imported things.