### PR TITLE
Display a message when project isn't a git/github repository.

### DIFF
--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -30,7 +30,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\common\GitHubVS.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>
@@ -198,6 +198,7 @@
     <Compile Include="ViewModels\BaseViewModel.cs" />
     <Compile Include="Models\ConnectionRepositoryHostMap.cs" />
     <Compile Include="ViewModels\GistCreationViewModel.cs" />
+    <Compile Include="ViewModels\NotAGitHubRepositoryViewModel.cs" />
     <Compile Include="ViewModels\LoggedOutViewModel.cs" />
     <Compile Include="ViewModels\LogoutRequiredViewModel.cs" />
     <Compile Include="ViewModels\PullRequestCreationViewModel.cs" />

--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -198,6 +198,7 @@
     <Compile Include="ViewModels\BaseViewModel.cs" />
     <Compile Include="Models\ConnectionRepositoryHostMap.cs" />
     <Compile Include="ViewModels\GistCreationViewModel.cs" />
+    <Compile Include="ViewModels\NotAGitRepositoryViewModel.cs" />
     <Compile Include="ViewModels\NotAGitHubRepositoryViewModel.cs" />
     <Compile Include="ViewModels\LoggedOutViewModel.cs" />
     <Compile Include="ViewModels\LogoutRequiredViewModel.cs" />

--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -30,7 +30,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>false</RunCodeAnalysis>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\common\GitHubVS.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>

--- a/src/GitHub.App/ViewModels/NotAGitHubRepositoryViewModel.cs
+++ b/src/GitHub.App/ViewModels/NotAGitHubRepositoryViewModel.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.Composition;
+using GitHub.Exports;
+using GitHub.Services;
+using ReactiveUI;
+
+namespace GitHub.ViewModels
+{
+    /// <summary>
+    /// The view model for the "Not a GitHub repository" view in the GitHub pane.
+    /// </summary>
+    [ExportViewModel(ViewType = UIViewType.NotAGitHubRepository)]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public class NotAGitHubRepositoryViewModel : BaseViewModel, INotAGitHubRepositoryViewModel
+    {
+        IUIProvider uiProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotAGitHubRepositoryViewModel"/> class.
+        /// </summary>
+        [ImportingConstructor]
+        public NotAGitHubRepositoryViewModel(IUIProvider uiProvider)
+        {
+            this.uiProvider = uiProvider;
+            Publish = ReactiveCommand.Create();
+        }
+
+        /// <summary>
+        /// Gets the command executed when the user clicks the "Publish to GitHub" link.
+        /// </summary>
+        public IReactiveCommand<object> Publish { get; }
+    }
+}

--- a/src/GitHub.App/ViewModels/NotAGitHubRepositoryViewModel.cs
+++ b/src/GitHub.App/ViewModels/NotAGitHubRepositoryViewModel.cs
@@ -1,6 +1,8 @@
+using System;
 using System.ComponentModel.Composition;
 using GitHub.Exports;
 using GitHub.Services;
+using GitHub.UI;
 using ReactiveUI;
 
 namespace GitHub.ViewModels
@@ -12,21 +14,32 @@ namespace GitHub.ViewModels
     [PartCreationPolicy(CreationPolicy.NonShared)]
     public class NotAGitHubRepositoryViewModel : BaseViewModel, INotAGitHubRepositoryViewModel
     {
-        IUIProvider uiProvider;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="NotAGitHubRepositoryViewModel"/> class.
         /// </summary>
         [ImportingConstructor]
-        public NotAGitHubRepositoryViewModel(IUIProvider uiProvider)
+        public NotAGitHubRepositoryViewModel()
         {
-            this.uiProvider = uiProvider;
             Publish = ReactiveCommand.Create();
+            Publish.Subscribe(_ => OnPublish());
         }
 
         /// <summary>
         /// Gets the command executed when the user clicks the "Publish to GitHub" link.
         /// </summary>
         public IReactiveCommand<object> Publish { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the repository publish dialog will be opened
+        /// with the private option checked.
+        /// </summary>
+        public bool PublishPrivate { get; set; }
+
+        /// <summary>
+        /// Called when the <see cref="Publish"/> command is executed.
+        /// </summary>
+        private void OnPublish()
+        {
+        }
     }
 }

--- a/src/GitHub.App/ViewModels/NotAGitHubRepositoryViewModel.cs
+++ b/src/GitHub.App/ViewModels/NotAGitHubRepositoryViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel.Composition;
 using GitHub.Exports;
+using GitHub.Models;
 using GitHub.Services;
 using GitHub.UI;
 using ReactiveUI;
@@ -14,12 +15,15 @@ namespace GitHub.ViewModels
     [PartCreationPolicy(CreationPolicy.NonShared)]
     public class NotAGitHubRepositoryViewModel : BaseViewModel, INotAGitHubRepositoryViewModel
     {
+        ITeamExplorerServices teamExplorerServices;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NotAGitHubRepositoryViewModel"/> class.
         /// </summary>
         [ImportingConstructor]
-        public NotAGitHubRepositoryViewModel()
+        public NotAGitHubRepositoryViewModel(ITeamExplorerServices teamExplorerServices)
         {
+            this.teamExplorerServices = teamExplorerServices;
             Publish = ReactiveCommand.Create();
             Publish.Subscribe(_ => OnPublish());
         }
@@ -30,16 +34,11 @@ namespace GitHub.ViewModels
         public IReactiveCommand<object> Publish { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the repository publish dialog will be opened
-        /// with the private option checked.
-        /// </summary>
-        public bool PublishPrivate { get; set; }
-
-        /// <summary>
         /// Called when the <see cref="Publish"/> command is executed.
         /// </summary>
         private void OnPublish()
         {
+            teamExplorerServices.ShowPublishSection();
         }
     }
 }

--- a/src/GitHub.App/ViewModels/NotAGitRepositoryViewModel.cs
+++ b/src/GitHub.App/ViewModels/NotAGitRepositoryViewModel.cs
@@ -1,0 +1,19 @@
+using System;
+using System.ComponentModel.Composition;
+using GitHub.Exports;
+using GitHub.Models;
+using GitHub.Services;
+using GitHub.UI;
+using ReactiveUI;
+
+namespace GitHub.ViewModels
+{
+    /// <summary>
+    /// The view model for the "Not a Git repository" view in the GitHub pane.
+    /// </summary>
+    [ExportViewModel(ViewType = UIViewType.NotAGitRepository)]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public class NotAGitRepositoryViewModel : BaseViewModel, INotAGitRepositoryViewModel
+    {
+    }
+}

--- a/src/GitHub.Exports.Reactive/GitHub.Exports.Reactive.csproj
+++ b/src/GitHub.Exports.Reactive/GitHub.Exports.Reactive.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Services\IGistPublishService.cs" />
     <Compile Include="ViewModels\IGistCreationViewModel.cs" />
     <Compile Include="Services\NotificationDispatcher.cs" />
+    <Compile Include="ViewModels\INotAGitRepositoryViewModel.cs" />
     <Compile Include="ViewModels\INotAGitHubRepositoryViewModel.cs" />
     <Compile Include="ViewModels\ILoggedOutViewModel.cs" />
     <Compile Include="ViewModels\ILogoutRequiredViewModel.cs" />

--- a/src/GitHub.Exports.Reactive/GitHub.Exports.Reactive.csproj
+++ b/src/GitHub.Exports.Reactive/GitHub.Exports.Reactive.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Services\IGistPublishService.cs" />
     <Compile Include="ViewModels\IGistCreationViewModel.cs" />
     <Compile Include="Services\NotificationDispatcher.cs" />
+    <Compile Include="ViewModels\INotAGitHubRepositoryViewModel.cs" />
     <Compile Include="ViewModels\ILoggedOutViewModel.cs" />
     <Compile Include="ViewModels\ILogoutRequiredViewModel.cs" />
     <Compile Include="ViewModels\ILoginControlViewModel.cs" />

--- a/src/GitHub.Exports.Reactive/ViewModels/INotAGitHubRepositoryViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/INotAGitHubRepositoryViewModel.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Reactive;
-using ReactiveUI;
+﻿using ReactiveUI;
 
 namespace GitHub.ViewModels
 {

--- a/src/GitHub.Exports.Reactive/ViewModels/INotAGitHubRepositoryViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/INotAGitHubRepositoryViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Reactive;
+using ReactiveUI;
+
+namespace GitHub.ViewModels
+{
+    /// <summary>
+    /// Defines the view model for the "Sign in to GitHub" view in the GitHub pane.
+    /// </summary>
+    public interface INotAGitHubRepositoryViewModel : IViewModel
+    {
+        /// <summary>
+        /// Gets the command executed when the user clicks the "Publish to GitHub" link.
+        /// </summary>
+        IReactiveCommand<object> Publish { get; }
+    }
+}

--- a/src/GitHub.Exports.Reactive/ViewModels/INotAGitRepositoryViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/INotAGitRepositoryViewModel.cs
@@ -1,0 +1,10 @@
+﻿namespace GitHub.ViewModels
+{
+    /// <summary>
+    /// Defines the view model for the "Not a git repository" view in the GitHub pane.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1040:AvoidEmptyInterfaces")]
+    public interface INotAGitRepositoryViewModel : IViewModel
+    {
+    }
+}

--- a/src/GitHub.Exports/Exports/ExportMetadata.cs
+++ b/src/GitHub.Exports/Exports/ExportMetadata.cs
@@ -26,6 +26,7 @@ namespace GitHub.Exports
         LogoutRequired,
         GitHubPane,
         LoggedOut,
+        NotAGitRepository,
         NotAGitHubRepository,
     }
 

--- a/src/GitHub.Exports/Exports/ExportMetadata.cs
+++ b/src/GitHub.Exports/Exports/ExportMetadata.cs
@@ -25,7 +25,8 @@ namespace GitHub.Exports
         PRCreation,
         LogoutRequired,
         GitHubPane,
-        LoggedOut
+        LoggedOut,
+        NotAGitHubRepository,
     }
 
     public enum MenuType

--- a/src/GitHub.Exports/Services/ITeamExplorerServices.cs
+++ b/src/GitHub.Exports/Services/ITeamExplorerServices.cs
@@ -4,6 +4,7 @@ namespace GitHub.Services
 {
     public interface ITeamExplorerServices : INotificationService
     {
+        void ShowPublishSection();
         void ClearNotifications();
     }
 }

--- a/src/GitHub.TeamFoundation.14/Services/TeamExplorerServices.cs
+++ b/src/GitHub.TeamFoundation.14/Services/TeamExplorerServices.cs
@@ -1,9 +1,10 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Windows.Input;
+using GitHub.Extensions;
+using GitHub.VisualStudio.TeamExplorer.Sync;
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.VisualStudio.Shell;
-using GitHub.Extensions;
 
 namespace GitHub.Services
 {
@@ -25,6 +26,14 @@ namespace GitHub.Services
         public TeamExplorerServices([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
         {
             this.serviceProvider = serviceProvider;
+        }
+
+        public void ShowPublishSection()
+        {
+            var te = serviceProvider.TryGetService<ITeamExplorer>();
+            var foo = te.NavigateToPage(new Guid(TeamExplorerPageIds.GitCommits), null);
+            var publish = foo?.GetSection(new Guid(GitHubPublishSection.GitHubPublishSectionId)) as GitHubPublishSection;
+            publish?.ShowPublish();
         }
 
         public void ShowMessage(string message)

--- a/src/GitHub.TeamFoundation.14/Sync/GitHubPublishSection.cs
+++ b/src/GitHub.TeamFoundation.14/Sync/GitHubPublishSection.cs
@@ -111,7 +111,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             uiProvider.RunUI();
         }
 
-        void ShowPublish()
+        public void ShowPublish()
         {
             IsBusy = true;
             var uiProvider = ServiceProvider.GetExportedValue<IUIProvider>();

--- a/src/GitHub.VisualStudio.UI/GitHub.VisualStudio.UI.csproj
+++ b/src/GitHub.VisualStudio.UI/GitHub.VisualStudio.UI.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Base\TeamExplorerItemBase.cs" />
     <Compile Include="Colors.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="RepositoryOrigin.cs" />
     <Compile Include="Resources.Designer.cs">
       <DependentUpon>Resources.resx</DependentUpon>
       <AutoGen>True</AutoGen>

--- a/src/GitHub.VisualStudio.UI/RepositoryOrigin.cs
+++ b/src/GitHub.VisualStudio.UI/RepositoryOrigin.cs
@@ -1,0 +1,10 @@
+﻿namespace GitHub.VisualStudio.UI
+{
+    public enum RepositoryOrigin
+    {
+        DotCom,
+        Enterprise,
+        Other,
+        NonGitRepository,
+    }
+}

--- a/src/GitHub.VisualStudio.UI/RepositoryOrigin.cs
+++ b/src/GitHub.VisualStudio.UI/RepositoryOrigin.cs
@@ -2,6 +2,7 @@
 {
     public enum RepositoryOrigin
     {
+        Unknown,
         DotCom,
         Enterprise,
         Other,

--- a/src/GitHub.VisualStudio.UI/Resources.Designer.cs
+++ b/src/GitHub.VisualStudio.UI/Resources.Designer.cs
@@ -439,6 +439,42 @@ namespace GitHub.VisualStudio.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This repository is not on GitHub.
+        /// </summary>
+        public static string NotAGitHubRepository {
+            get {
+                return ResourceManager.GetString("NotAGitHubRepository", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Publish this repository to GitHub and get powerful collaboration, code review, and code management for open source and private projects..
+        /// </summary>
+        public static string NotAGitHubRepositoryMessage {
+            get {
+                return ResourceManager.GetString("NotAGitHubRepositoryMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No repository.
+        /// </summary>
+        public static string NotAGitRepository {
+            get {
+                return ResourceManager.GetString("NotAGitRepository", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to We couldn&apos;t find a git repository here. Open a git project or click &quot;File -&gt; Add to Source Control&quot; in a project to get started..
+        /// </summary>
+        public static string NotAGitRepositoryMessage {
+            get {
+                return ResourceManager.GetString("NotAGitRepositoryMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You are not logged in to {0}, so certain git operations may fail. [Login now]({1}).
         /// </summary>
         public static string NotLoggedInMessage {

--- a/src/GitHub.VisualStudio.UI/Resources.resx
+++ b/src/GitHub.VisualStudio.UI/Resources.resx
@@ -315,4 +315,16 @@
   <data name="openInBrowser" xml:space="preserve">
     <value>Open in Browser</value>
   </data>
+  <data name="NotAGitHubRepositoryMessage" xml:space="preserve">
+    <value>Publish this repository to GitHub and get powerful collaboration, code review, and code management for open source and private projects.</value>
+  </data>
+  <data name="NotAGitHubRepository" xml:space="preserve">
+    <value>This repository is not on GitHub</value>
+  </data>
+  <data name="NotAGitRepository" xml:space="preserve">
+    <value>No repository</value>
+  </data>
+  <data name="NotAGitRepositoryMessage" xml:space="preserve">
+    <value>We couldn't find a git repository here. Open a git project or click "File -&gt; Add to Source Control" in a project to get started.</value>
+  </data>
 </root>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -274,6 +274,9 @@
       <DependentUpon>GitHubPaneView.xaml</DependentUpon>
     </Compile>
     <Compile Include="UI\Views\GitHubPaneViewModel.cs" />
+    <Compile Include="UI\Views\NotAGitHubRepositoryView.xaml.cs">
+      <DependentUpon>NotAGitHubRepositoryView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UI\Views\LoggedOutView.xaml.cs">
       <DependentUpon>LoggedOutView.xaml</DependentUpon>
     </Compile>
@@ -468,6 +471,10 @@
     <Page Include="UI\Views\GitHubPaneView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UI\Views\NotAGitHubRepositoryView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="UI\Views\LoggedOutView.xaml">
       <SubType>Designer</SubType>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -274,6 +274,9 @@
       <DependentUpon>GitHubPaneView.xaml</DependentUpon>
     </Compile>
     <Compile Include="UI\Views\GitHubPaneViewModel.cs" />
+    <Compile Include="UI\Views\NotAGitRepositoryView.xaml.cs">
+      <DependentUpon>NotAGitRepositoryView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="UI\Views\NotAGitHubRepositoryView.xaml.cs">
       <DependentUpon>NotAGitHubRepositoryView.xaml</DependentUpon>
     </Compile>
@@ -471,6 +474,10 @@
     <Page Include="UI\Views\GitHubPaneView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="UI\Views\NotAGitRepositoryView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="UI\Views\NotAGitHubRepositoryView.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/src/GitHub.VisualStudio/UI/Views/GitHubPaneViewModel.cs
+++ b/src/GitHub.VisualStudio/UI/Views/GitHubPaneViewModel.cs
@@ -110,7 +110,7 @@ namespace GitHub.VisualStudio.UI.Views
                 return;
 
             Stop();
-            RepositoryOrigin = null;
+            RepositoryOrigin = RepositoryOrigin.Unknown;
             Reload().Forget();
         }
 
@@ -130,7 +130,7 @@ namespace GitHub.VisualStudio.UI.Views
 
             navigatingViaArrows = navigating;
 
-            if (!RepositoryOrigin.HasValue)
+            if (RepositoryOrigin == RepositoryOrigin.Unknown)
             {
                 var origin = await GetRepositoryOrigin();
                 if (reloadCallId != latestReloadCallId)
@@ -154,11 +154,11 @@ namespace GitHub.VisualStudio.UI.Views
                 IsLoggedIn = isLoggedIn;
             }
 
-            if (RepositoryOrigin.Value == UI.RepositoryOrigin.NonGitRepository)
+            if (RepositoryOrigin == UI.RepositoryOrigin.NonGitRepository)
             {
                 LoadView(UIViewType.NotAGitRepository);
             }
-            else if (RepositoryOrigin.Value == UI.RepositoryOrigin.Other)
+            else if (RepositoryOrigin == UI.RepositoryOrigin.Other)
             {
                 LoadView(UIViewType.NotAGitHubRepository);
             }
@@ -340,8 +340,8 @@ namespace GitHub.VisualStudio.UI.Views
             set { isLoggedIn = value;  this.RaisePropertyChange(); }
         }
 
-        RepositoryOrigin? repositoryOrigin;
-        public RepositoryOrigin? RepositoryOrigin
+        RepositoryOrigin repositoryOrigin;
+        public RepositoryOrigin RepositoryOrigin
         {
             get { return repositoryOrigin; }
             private set { repositoryOrigin = value; }
@@ -351,10 +351,10 @@ namespace GitHub.VisualStudio.UI.Views
         {
             get
             {
-                return repositoryOrigin.HasValue ?
-                    repositoryOrigin.Value == UI.RepositoryOrigin.DotCom ||
-                    repositoryOrigin.Value == UI.RepositoryOrigin.Enterprise :
-                    (bool?)null;
+                return repositoryOrigin == RepositoryOrigin.Unknown ?
+                    (bool?)null :
+                    repositoryOrigin == UI.RepositoryOrigin.DotCom ||
+                    repositoryOrigin == UI.RepositoryOrigin.Enterprise;
             }
         }
 

--- a/src/GitHub.VisualStudio/UI/Views/GitHubPaneViewModel.cs
+++ b/src/GitHub.VisualStudio/UI/Views/GitHubPaneViewModel.cs
@@ -120,11 +120,11 @@ namespace GitHub.VisualStudio.UI.Views
             {
                 if (uiController != null)
                 {
-                    Stop();
-                    //var factory = ServiceProvider.GetExportedValue<IUIFactory>();
-                    //var c = factory.CreateViewAndViewModel(UIViewType.LoggedOut);
-                    //Control = c.View;
+                    var factory = ServiceProvider.GetExportedValue<IUIFactory>();
+                    var c = factory.CreateViewAndViewModel(UIViewType.NotAGitHubRepository);
+                    Control = c.View;
                 }
+
                 return;
             }
 

--- a/src/GitHub.VisualStudio/UI/Views/GitHubPaneViewModel.cs
+++ b/src/GitHub.VisualStudio/UI/Views/GitHubPaneViewModel.cs
@@ -118,12 +118,9 @@ namespace GitHub.VisualStudio.UI.Views
 
             if (!IsGitHubRepo.Value)
             {
-                if (uiController != null)
-                {
-                    var factory = ServiceProvider.GetExportedValue<IUIFactory>();
-                    var c = factory.CreateViewAndViewModel(UIViewType.NotAGitHubRepository);
-                    Control = c.View;
-                }
+                var factory = ServiceProvider.GetExportedValue<IUIFactory>();
+                var c = factory.CreateViewAndViewModel(UIViewType.NotAGitHubRepository);
+                Control = c.View;
 
                 return;
             }

--- a/src/GitHub.VisualStudio/UI/Views/GitHubPaneViewModel.cs
+++ b/src/GitHub.VisualStudio/UI/Views/GitHubPaneViewModel.cs
@@ -19,6 +19,7 @@ using NullGuard;
 using ReactiveUI;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GitHub.VisualStudio.UI;
 
 namespace GitHub.VisualStudio.UI.Views
 {
@@ -109,7 +110,7 @@ namespace GitHub.VisualStudio.UI.Views
                 return;
 
             Stop();
-            IsGitHubRepo = null;
+            RepositoryOrigin = null;
             Reload().Forget();
         }
 
@@ -129,13 +130,13 @@ namespace GitHub.VisualStudio.UI.Views
 
             navigatingViaArrows = navigating;
 
-            if (!IsGitHubRepo.HasValue)
+            if (!RepositoryOrigin.HasValue)
             {
-                var isGitHubRepo = await IsAGitHubRepo();
+                var origin = await GetRepositoryOrigin();
                 if (reloadCallId != latestReloadCallId)
                     return;
 
-                IsGitHubRepo = isGitHubRepo;
+                RepositoryOrigin = origin;
             }
 
             var connection = await connectionManager.LookupConnection(ActiveRepo);
@@ -153,16 +154,18 @@ namespace GitHub.VisualStudio.UI.Views
                 IsLoggedIn = isLoggedIn;
             }
 
-            if (!IsGitHubRepo.Value)
+            if (RepositoryOrigin.Value == UI.RepositoryOrigin.NonGitRepository)
+            {
+                LoadView(UIViewType.NotAGitRepository);
+            }
+            else if (RepositoryOrigin.Value == UI.RepositoryOrigin.Other)
             {
                 LoadView(UIViewType.NotAGitHubRepository);
             }
-
             else if (!IsLoggedIn)
             {
                 LoadView(UIViewType.LoggedOut);
             }
-
             else
             {
                 LoadView(data?.ActiveFlow ?? DefaultControllerFlow, connection, data);
@@ -337,13 +340,23 @@ namespace GitHub.VisualStudio.UI.Views
             set { isLoggedIn = value;  this.RaisePropertyChange(); }
         }
 
-        bool? isGitHubRepo;
-        public bool? IsGitHubRepo
+        RepositoryOrigin? repositoryOrigin;
+        public RepositoryOrigin? RepositoryOrigin
         {
-            get { return isGitHubRepo; }
-            set { isGitHubRepo = value; this.RaisePropertyChange(); }
+            get { return repositoryOrigin; }
+            private set { repositoryOrigin = value; }
         }
 
+        public bool? IsGitHubRepo
+        {
+            get
+            {
+                return repositoryOrigin.HasValue ?
+                    repositoryOrigin.Value == UI.RepositoryOrigin.DotCom ||
+                    repositoryOrigin.Value == UI.RepositoryOrigin.Enterprise :
+                    (bool?)null;
+            }
+        }
 
         public ReactiveCommand<object> CancelCommand { get; private set; }
         public ICommand Cancel => CancelCommand;

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
@@ -43,10 +43,15 @@
             HorizontalAlignment="Center"
             Orientation="Vertical">
 
-            <CheckBox Foreground="{DynamicResource GitHubVsToolWindowText}" Margin="10">Publish as a private repository</CheckBox>
+            <CheckBox Foreground="{DynamicResource GitHubVsToolWindowText}" 
+                      IsChecked="{Binding PublishPrivate}"
+                      Margin="10">
+                Publish as a private repository
+            </CheckBox>
 
-                <Button HorizontalAlignment="Center" Style="{DynamicResource GitHubVsPrimaryActionButton}">
-                    Publish to GitHub
+            <Button HorizontalAlignment="Center" Style="{DynamicResource GitHubVsPrimaryActionButton}"
+                    Command="{Binding Publish}">
+                Publish to GitHub
             </Button>
 
         </StackPanel>

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
@@ -21,5 +21,35 @@
     </ResourceDictionary>
   </UserControl.Resources>
 
-  <TextBlock HorizontalAlignment="Center">Not a GitHub repository.</TextBlock>
+  <DockPanel>
+    <StackPanel Margin="10" Orientation="Vertical">
+        <ui:OcticonImage Icon="mark_github"
+            Foreground="{DynamicResource GitHubVsWindowText}"
+            Margin="0,5"
+            Width="48"
+            Height="48" />
+        <Label
+            Foreground="{DynamicResource GitHubVsWindowText}"
+            HorizontalAlignment="Center"
+            FontSize="16"
+            Content="This repository is not on GitHub" />
+        <TextBlock
+            TextWrapping="Wrap"
+            TextAlignment="Center"
+            HorizontalAlignment="Center"
+            Text="Publish this repository to GitHub and get powerful collaboration, code review, and code management for open source and private projects." />
+        <StackPanel
+            Margin="0,5"
+            HorizontalAlignment="Center"
+            Orientation="Vertical">
+
+            <CheckBox Foreground="{DynamicResource GitHubVsToolWindowText}" Margin="10">Publish as a private repository</CheckBox>
+
+                <Button HorizontalAlignment="Center" Style="{DynamicResource GitHubVsPrimaryActionButton}">
+                    Publish to GitHub
+            </Button>
+
+        </StackPanel>
+    </StackPanel>
+  </DockPanel>
 </local:GenericNotAGitHubRepositoryView>

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
@@ -6,6 +6,7 @@
     xmlns:local="clr-namespace:GitHub.VisualStudio.UI.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
+    xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI"
     DataContext="{Binding ViewModel}"
     d:DesignHeight="300"
     d:DesignWidth="300"
@@ -32,12 +33,12 @@
             Foreground="{DynamicResource GitHubVsWindowText}"
             HorizontalAlignment="Center"
             FontSize="16"
-            Content="This repository is not on GitHub" />
+            Content="{x:Static prop:Resources.NotAGitHubRepository}" />
         <TextBlock
             TextWrapping="Wrap"
             TextAlignment="Center"
             HorizontalAlignment="Center"
-            Text="Publish this repository to GitHub and get powerful collaboration, code review, and code management for open source and private projects." />
+            Text="{x:Static prop:Resources.NotAGitHubRepositoryMessage}" />
         <Button HorizontalAlignment="Center"
                 Margin="0,15"
                 Style="{DynamicResource GitHubVsPrimaryActionButton}"

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
@@ -1,0 +1,25 @@
+﻿<local:GenericNotAGitHubRepositoryView x:Class="GitHub.VisualStudio.UI.Views.NotAGitHubRepositoryView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:cache="clr-namespace:GitHub.VisualStudio.Helpers"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:GitHub.VisualStudio.UI.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
+    DataContext="{Binding ViewModel}"
+    d:DesignHeight="300"
+    d:DesignWidth="300"
+    mc:Ignorable="d">
+
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/SharedDictionary.xaml" />
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/GitHubActionLink.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+
+    Not a GitHub repository.
+</local:GenericNotAGitHubRepositoryView>

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
@@ -21,5 +21,5 @@
     </ResourceDictionary>
   </UserControl.Resources>
 
-    Not a GitHub repository.
+  <TextBlock HorizontalAlignment="Center">Not a GitHub repository.</TextBlock>
 </local:GenericNotAGitHubRepositoryView>

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml
@@ -38,23 +38,12 @@
             TextAlignment="Center"
             HorizontalAlignment="Center"
             Text="Publish this repository to GitHub and get powerful collaboration, code review, and code management for open source and private projects." />
-        <StackPanel
-            Margin="0,5"
-            HorizontalAlignment="Center"
-            Orientation="Vertical">
-
-            <CheckBox Foreground="{DynamicResource GitHubVsToolWindowText}" 
-                      IsChecked="{Binding PublishPrivate}"
-                      Margin="10">
-                Publish as a private repository
-            </CheckBox>
-
-            <Button HorizontalAlignment="Center" Style="{DynamicResource GitHubVsPrimaryActionButton}"
-                    Command="{Binding Publish}">
-                Publish to GitHub
-            </Button>
-
-        </StackPanel>
+        <Button HorizontalAlignment="Center"
+                Margin="0,15"
+                Style="{DynamicResource GitHubVsPrimaryActionButton}"
+                Command="{Binding Publish}">
+            Get Started
+        </Button>
     </StackPanel>
   </DockPanel>
 </local:GenericNotAGitHubRepositoryView>

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitHubRepositoryView.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.Composition;
+using GitHub.Exports;
+using GitHub.UI;
+using GitHub.ViewModels;
+
+namespace GitHub.VisualStudio.UI.Views
+{
+    public class GenericNotAGitHubRepositoryView : SimpleViewUserControl<INotAGitHubRepositoryViewModel, GenericNotAGitHubRepositoryView>
+    {
+    }
+
+    [ExportView(ViewType = UIViewType.NotAGitHubRepository)]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+
+    public partial class NotAGitHubRepositoryView : GenericNotAGitHubRepositoryView
+    {
+        public NotAGitHubRepositoryView()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitRepositoryView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitRepositoryView.xaml
@@ -36,8 +36,10 @@
         <TextBlock
             TextWrapping="Wrap"
             TextAlignment="Center"
-            HorizontalAlignment="Center"
-            Text="The current project isn't a repository. You might wanna fix that bruh." />
+            HorizontalAlignment="Center">
+                We couldn't find a git repository here. Open a git project or click "File -> Add to Source Control"
+                in a project to get started
+        </TextBlock>
     </StackPanel>
   </DockPanel>
 </local:GenericNotAGitRepositoryView>

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitRepositoryView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitRepositoryView.xaml
@@ -1,0 +1,43 @@
+﻿<local:GenericNotAGitRepositoryView x:Class="GitHub.VisualStudio.UI.Views.NotAGitRepositoryView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:cache="clr-namespace:GitHub.VisualStudio.Helpers"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:GitHub.VisualStudio.UI.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
+    DataContext="{Binding ViewModel}"
+    d:DesignHeight="300"
+    d:DesignWidth="300"
+    mc:Ignorable="d">
+
+  <UserControl.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/SharedDictionary.xaml" />
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/Styles/GitHubActionLink.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </UserControl.Resources>
+
+  <DockPanel>
+    <StackPanel Margin="10" Orientation="Vertical">
+        <ui:OcticonImage Icon="mark_github"
+            Foreground="{DynamicResource GitHubVsWindowText}"
+            Margin="0,5"
+            Width="48"
+            Height="48" />
+        <Label
+            Foreground="{DynamicResource GitHubVsWindowText}"
+            HorizontalAlignment="Center"
+            FontSize="16"
+            Content="No repository" />
+        <TextBlock
+            TextWrapping="Wrap"
+            TextAlignment="Center"
+            HorizontalAlignment="Center"
+            Text="The current project isn't a repository. You might wanna fix that bruh." />
+    </StackPanel>
+  </DockPanel>
+</local:GenericNotAGitRepositoryView>

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitRepositoryView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitRepositoryView.xaml
@@ -6,6 +6,7 @@
     xmlns:local="clr-namespace:GitHub.VisualStudio.UI.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
+    xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI"
     DataContext="{Binding ViewModel}"
     d:DesignHeight="300"
     d:DesignWidth="300"
@@ -32,14 +33,12 @@
             Foreground="{DynamicResource GitHubVsWindowText}"
             HorizontalAlignment="Center"
             FontSize="16"
-            Content="No repository" />
+            Content="{x:Static prop:Resources.NotAGitRepository}" />
         <TextBlock
             TextWrapping="Wrap"
             TextAlignment="Center"
-            HorizontalAlignment="Center">
-                We couldn't find a git repository here. Open a git project or click "File -> Add to Source Control"
-                in a project to get started
-        </TextBlock>
-    </StackPanel>
+            HorizontalAlignment="Center"
+            Text="{x:Static prop:Resources.NotAGitRepositoryMessage}"/>
+        </StackPanel>
   </DockPanel>
 </local:GenericNotAGitRepositoryView>

--- a/src/GitHub.VisualStudio/UI/Views/NotAGitRepositoryView.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/NotAGitRepositoryView.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.Composition;
+using GitHub.Exports;
+using GitHub.UI;
+using GitHub.ViewModels;
+
+namespace GitHub.VisualStudio.UI.Views
+{
+    public class GenericNotAGitRepositoryView : SimpleViewUserControl<INotAGitRepositoryViewModel, GenericNotAGitRepositoryView>
+    {
+    }
+
+    [ExportView(ViewType = UIViewType.NotAGitRepository)]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+
+    public partial class NotAGitRepositoryView : GenericNotAGitRepositoryView
+    {
+        public NotAGitRepositoryView()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
We still need to decide on the wording for when the current Team Explorer context isn't a git repository.