### PR TITLE
Catch File I/O exception in GitHub.Exports

### DIFF
--- a/src/GitHub.Exports/Services/Logger.cs
+++ b/src/GitHub.Exports/Services/Logger.cs
@@ -77,7 +77,13 @@ namespace GitHub.VisualStudio
             await System.Threading.Tasks.Task.Delay(500);
             lock(fileLock)
             {
-                File.AppendAllText(defaultLogPath, msg, Encoding.UTF8);
+                try
+                {
+                    File.AppendAllText(defaultLogPath, msg, Encoding.UTF8);
+                }
+                catch(Exception)
+                {
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #367. Wrapping in a try/catch. Since this is happening in `Logger.cs`, we'll add the exception message to the cache if we continue to get reports about problems here.