### PR TITLE
Correctly check for existing repo in clone dialog.

### DIFF
--- a/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
@@ -171,7 +171,7 @@ namespace GitHub.ViewModels
 
         bool IsAlreadyRepoAtPath(string path)
         {
-            Debug.Assert(path != null, "RepositoryCloneViewModel.IsAlreadyRepoAtPath cannot be passed null as a path paramter.");
+            Debug.Assert(path != null, "RepositoryCloneViewModel.IsAlreadyRepoAtPath cannot be passed null as a path parameter.");
 
             bool isAlreadyRepoAtPath = false;
 

--- a/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
@@ -175,12 +175,8 @@ namespace GitHub.ViewModels
 
             if (SelectedRepository != null)
             {
-                var validationResult = BaseRepositoryPathValidator.ValidationResult;
-                if (validationResult != null && validationResult.IsValid)
-                {
-                    string potentialPath = Path.Combine(path, SelectedRepository.Name);
-                    isAlreadyRepoAtPath = operatingSystem.Directory.Exists(potentialPath);
-                }
+                string potentialPath = Path.Combine(path, SelectedRepository.Name);
+                isAlreadyRepoAtPath = operatingSystem.Directory.Exists(potentialPath);
             }
 
             return isAlreadyRepoAtPath;

--- a/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
@@ -171,6 +171,8 @@ namespace GitHub.ViewModels
 
         bool IsAlreadyRepoAtPath(string path)
         {
+            Debug.Assert(path != null);
+
             bool isAlreadyRepoAtPath = false;
 
             if (SelectedRepository != null)

--- a/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
@@ -171,7 +171,7 @@ namespace GitHub.ViewModels
 
         bool IsAlreadyRepoAtPath(string path)
         {
-            Debug.Assert(path != null);
+            Debug.Assert(path != null, "RepositoryCloneViewModel.IsAlreadyRepoAtPath cannot be passed null as a path paramter.");
 
             bool isAlreadyRepoAtPath = false;
 


### PR DESCRIPTION
The clone dialog was validating for the presence of an existing repo at the destination path, but the validation was dependent upon the _previous_ validation state. Make sure the current path is always validated. Fixes #394. Fixes #109.