### PR TITLE
Tracking collection should throw some more

### DIFF
--- a/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
+++ b/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
@@ -397,6 +397,8 @@ namespace GitHub.Collections
 
         public void AddItem(T item)
         {
+            if (source == null)
+                throw new InvalidOperationException("No source observable has been set. Call Listen or pass an observable to the constructor");
             if (disposed)
                 throw new ObjectDisposedException("TrackingCollection");
 
@@ -411,6 +413,8 @@ namespace GitHub.Collections
 
         public void RemoveItem(T item)
         {
+            if (source == null)
+                throw new InvalidOperationException("No source observable has been set. Call Listen or pass an observable to the constructor");
             if (disposed)
                 throw new ObjectDisposedException("TrackingCollection");
 

--- a/src/TrackingCollectionTests/TrackingCollectionTests.cs
+++ b/src/TrackingCollectionTests/TrackingCollectionTests.cs
@@ -1943,4 +1943,18 @@ public class TrackingTests : TestBase
 
         CollectionAssert.AreEqual(list2, col);
     }
+
+    [Test]
+    public void AddingWithNoObservableSetThrows()
+    {
+        ITrackingCollection<Thing> col = new TrackingCollection<Thing>();
+        Assert.Throws<InvalidOperationException>(() => col.AddItem(new Thing()));
+    }
+
+    [Test]
+    public void RemovingWithNoObservableSetThrows()
+    {
+        ITrackingCollection<Thing> col = new TrackingCollection<Thing>();
+        Assert.Throws<InvalidOperationException>(() => col.RemoveItem(new Thing()));
+    }
 }


### PR DESCRIPTION
AddItem and RemoveItem should not be called if the TrackingCollection hasn't been correctly initialized with a source observable (otherwise why are you using a TrackingCollection anyways?)
