### PR TITLE
Verify source code is not in a git repo in context menu checks

### DIFF
--- a/src/GitHub.VisualStudio/Base/MenuBase.cs
+++ b/src/GitHub.VisualStudio/Base/MenuBase.cs
@@ -113,6 +113,9 @@ namespace GitHub.VisualStudio
         {
             RefreshRepo();
 
+            if(ActiveRepo == null)
+                return false;
+
             var uri = ActiveRepo.CloneUrl;
             if (uri == null)
                 return false;

--- a/src/GitHub.VisualStudio/Base/MenuBase.cs
+++ b/src/GitHub.VisualStudio/Base/MenuBase.cs
@@ -113,10 +113,7 @@ namespace GitHub.VisualStudio
         {
             RefreshRepo();
 
-            if(ActiveRepo == null)
-                return false;
-
-            var uri = ActiveRepo.CloneUrl;
+            var uri = ActiveRepo?.CloneUrl;
             if (uri == null)
                 return false;
 


### PR DESCRIPTION
In `IsGitHubRepo()`, `ActiveRepo` is null if source code is not in a git repo, which throws a null reference exception. Modified to return false if this is the case.

Fixes #419