### PR TITLE
Bump octokit to 0.20.0

### DIFF
--- a/src/GitHub.App/Api/ApiClient.cs
+++ b/src/GitHub.App/Api/ApiClient.cs
@@ -232,7 +232,7 @@ namespace GitHub.Api
         {
             return gitHubClient.PullRequest.GetAllForRepository(owner, name,
                 new PullRequestRequest {
-                    State = ItemState.All,
+                    State = ItemStateFilter.All,
                     SortProperty = PullRequestSort.Updated,
                     SortDirection = SortDirection.Descending
                 });

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -433,7 +433,7 @@ namespace GitHub.Services
             {
                 Title = pr.Title;
                 Number = pr.Number;
-                CommentCount = pr.Comments;
+                CommentCount = pr.Comments + pr.ReviewComments;
                 Author = new AccountCacheItem(pr.User);
                 Assignee = pr.Assignee != null ? new AccountCacheItem(pr.Assignee) : null;
                 CreatedAt = pr.CreatedAt;

--- a/src/UnitTests/GitHub.Api/SimpleApiClientTests.cs
+++ b/src/UnitTests/GitHub.Api/SimpleApiClientTests.cs
@@ -161,8 +161,9 @@ public class SimpleApiClientTests
 
     private static Repository CreateRepository(int id, bool hasWiki)
     {
-        return new Repository("", "", "", "", "", "", "", id, new User(), "", "", "", "", "", false, false, 0, 0, 0, "",
-            0, null, DateTimeOffset.Now, DateTimeOffset.Now, new RepositoryPermissions(), new User(), null, null, false,
+        return new Repository("", "", "", "", "", "", "",
+            id, new User(), "", "", "", "", "", false, false, 0, 0, "",
+            0, null, DateTimeOffset.Now, DateTimeOffset.Now, new RepositoryPermissions(), null, null, false,
             hasWiki, false);
     }
 }

--- a/src/UnitTests/GitHub.App/Models/ModelServiceTests.cs
+++ b/src/UnitTests/GitHub.App/Models/ModelServiceTests.cs
@@ -398,7 +398,7 @@ public class ModelServiceTests
             var indexKey = string.Format(CultureInfo.InvariantCulture, "{0}|{1}:{2}", CacheIndex.PRPrefix, user.Login, repo.Name);
 
             var prcache = Enumerable.Range(1, expected)
-                .Select(id => CreatePullRequest(user, id, ItemState.Open, "Cache " + id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, 0));
+                .Select(id => CreatePullRequest(user, id, ItemState.Open, "Cache " + id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
 
             // seed the cache
             prcache
@@ -408,7 +408,7 @@ public class ModelServiceTests
                 .ToList();
 
             var prlive = Observable.Range(1, expected)
-                .Select(id => CreatePullRequest(user, id, ItemState.Open, "Live " + id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, 0))
+                .Select(id => CreatePullRequest(user, id, ItemState.Open, "Live " + id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow))
                 .DelaySubscription(TimeSpan.FromMilliseconds(10));
 
             apiClient.GetPullRequestsForRepository(user.Login, repo.Name).Returns(prlive);
@@ -449,7 +449,7 @@ public class ModelServiceTests
             var indexKey = string.Format(CultureInfo.InvariantCulture, "{0}|{1}:{2}", CacheIndex.PRPrefix, user.Login, repo.Name);
 
             var prcache = Enumerable.Range(1, expected)
-                .Select(id => CreatePullRequest(user, id, ItemState.Open, "Cache " + id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, 0));
+                .Select(id => CreatePullRequest(user, id, ItemState.Open, "Cache " + id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
 
             // seed the cache
             prcache
@@ -464,7 +464,7 @@ public class ModelServiceTests
             await cache.InsertObject(indexKey, indexobj);
 
             var prlive = Observable.Range(1, expected)
-                .Select(id => CreatePullRequest(user, id, ItemState.Open, "Live " + id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, 0))
+                .Select(id => CreatePullRequest(user, id, ItemState.Open, "Live " + id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow))
                 .DelaySubscription(TimeSpan.FromMilliseconds(10));
 
             apiClient.GetPullRequestsForRepository(user.Login, repo.Name).Returns(prlive);
@@ -516,7 +516,7 @@ public class ModelServiceTests
             var indexKey = string.Format(CultureInfo.InvariantCulture, "{0}|{1}:{2}", CacheIndex.PRPrefix, user.Login, repo.Name);
 
             var prcache = Enumerable.Range(1, expected)
-                .Select(id => CreatePullRequest(user, id, ItemState.Open, "Cache " + id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, 0));
+                .Select(id => CreatePullRequest(user, id, ItemState.Open, "Cache " + id, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
 
             // seed the cache
             prcache
@@ -569,36 +569,5 @@ public class ModelServiceTests
                 t => { Assert.True(t.Title.StartsWith("Live")); Assert.Equal(9, t.Number); }
             );
         }
-    }
-
-    static UserAndScopes CreateUserAndScopes(string login)
-    {
-        return new UserAndScopes(CreateOctokitUser(login), null);
-    }
-
-    static User CreateOctokitUser(string login)
-    {
-        return new User("https://url", "", "", 1, "GitHub", DateTimeOffset.UtcNow, 0, "email", 100, 100, true, "http://url", 10, 42, "somewhere", login, "Who cares", 1, new Plan(), 1, 1, 1, "https://url", false, null, null);
-    }
-
-    static Organization CreateOctokitOrganization(string login)
-    {
-        return new Organization("https://url", "", "", 1, "GitHub", DateTimeOffset.UtcNow, 0, "email", 100, 100, true, "http://url", 10, 42, "somewhere", login, "Who cares", 1, new Plan(), 1, 1, 1, "https://url", "billing");
-    }
-
-    static Repository CreateRepository(string owner, string name)
-    {
-        return new Repository("https://url", "https://url", "https://url", "https://url", "https://url", "https://url", "https://url", 1, CreateOctokitUser(owner), name, "fullname", "description", "https://url", "c#", false, false, 0, 0, 0, "master", 0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, new RepositoryPermissions(), null, null, null, true, false, false);
-    }
-
-    static PullRequest CreatePullRequest(User user, int id, ItemState state, string title,
-        DateTimeOffset createdAt, DateTimeOffset updatedAt, int commentCount)
-    {
-        var uri = new Uri("https://url");
-        return new PullRequest(uri, uri, uri, uri, uri, uri,
-            id, state, title, "", createdAt, updatedAt,
-            null, null, null, null, user, null, false, null,
-            commentCount, 0, 0, 0, 0,
-            null, false);
     }
 }

--- a/src/UnitTests/GitHub.App/Models/RepositoryHostTests.cs
+++ b/src/UnitTests/GitHub.App/Models/RepositoryHostTests.cs
@@ -217,19 +217,4 @@ public class RepositoryHostTests
             Assert.True(host.SupportsGist);
         }
     }
-
-    static UserAndScopes CreateUserAndScopes(string login, string[] scopes = null)
-    {
-        return new UserAndScopes(CreateOctokitUser(login), scopes);
-    }
-
-    static User CreateOctokitUser(string login)
-    {
-        return new User("https://url", "", "", 1, "GitHub", DateTimeOffset.UtcNow, 0, "email", 100, 100, true, "http://url", 10, 42, "somewhere", login, "Who cares", 1, new Plan(), 1, 1, 1, "https://url", false, null, null);
-    }
-
-    static Organization CreateOctokitOrganization(string login)
-    {
-        return new Organization("https://url", "", "", 1, "GitHub", DateTimeOffset.UtcNow, 0, "email", 100, 100, true, "http://url", 10, 42, "somewhere", login, "Who cares", 1, new Plan(), 1, 1, 1, "https://url", "billing");
-    }
 }

--- a/src/UnitTests/GitHub.Exports.Reactive/Caches/AccountCacheItemTests.cs
+++ b/src/UnitTests/GitHub.Exports.Reactive/Caches/AccountCacheItemTests.cs
@@ -16,15 +16,10 @@ public class AccountCacheItemTests
         [InlineData("GARBAGE", false)]
         public void SetsIsEnterpriseCorrectly(string htmlUrl, bool expected)
         {
-            var apiAccount = CreateOctokitUser(htmlUrl);
+            var apiAccount = CreateOctokitUser("foo", htmlUrl);
             var cachedAccount = new AccountCacheItem(apiAccount);
 
             Assert.Equal(expected, cachedAccount.IsEnterprise);
         }
-    }
-
-    static User CreateOctokitUser(string url)
-    {
-        return new User("https://url", "", "", 1, "GitHub", DateTimeOffset.UtcNow, 0, "email", 100, 100, true, url, 10, 42, "somewhere", "foo", "Who cares", 1, new Plan(), 1, 1, 1, "https://url", false, null, null);
     }
 }

--- a/src/UnitTests/GitHub.VisualStudio/Services/RepositoryPublishServiceTests.cs
+++ b/src/UnitTests/GitHub.VisualStudio/Services/RepositoryPublishServiceTests.cs
@@ -22,19 +22,13 @@ public class RepositoryPublishServiceTests
             var account = Substitute.For<IAccount>();
             account.Login.Returns("monalisa");
             account.IsUser.Returns(true);
-            var gitHubRepository = CreateOctokitRepository("https://github.com/monalisa/test");
+            var gitHubRepository = CreateRepository(account.Login, newRepository.Name);
             var apiClient = Substitute.For<IApiClient>();
             apiClient.CreateRepository(newRepository, "monalisa", true).Returns(Observable.Return(gitHubRepository));
 
             var repository = await service.PublishRepository(newRepository, account, apiClient);
 
             Assert.Equal("https://github.com/monalisa/test", repository.CloneUrl);
-        }
-
-        static Octokit.Repository CreateOctokitRepository(string cloneUrl)
-        {
-            var notCloneUrl = cloneUrl + "x";
-            return new Octokit.Repository(notCloneUrl, notCloneUrl, cloneUrl, notCloneUrl, notCloneUrl, notCloneUrl, notCloneUrl, 1, null, null, null, null, null, null, false, false, 0, 0, 0, "master", 0, null, DateTimeOffset.Now, DateTimeOffset.Now, null, null, null, null, false, false, false);
         }
     }
 }

--- a/src/UnitTests/Helpers/TestBaseClass.cs
+++ b/src/UnitTests/Helpers/TestBaseClass.cs
@@ -1,4 +1,7 @@
 ﻿using EntryExitDecoratorInterfaces;
+using GitHub.Models;
+using Octokit;
+using System;
 using System.IO;
 
 /// <summary>
@@ -17,6 +20,47 @@ public class TestBaseClass : IEntryExitDecorator
 
     public virtual void OnExit()
     {
+    }
+
+    protected static UserAndScopes CreateUserAndScopes(string login, string[] scopes = null)
+    {
+        return new UserAndScopes(CreateOctokitUser(login), scopes);
+    }
+
+    protected static User CreateOctokitUser(string login = "login", string url = "https://url")
+    {
+        return new User("https://url", "bio", "blog", 1, "GitHub",
+            DateTimeOffset.UtcNow, 0, "email", 100, 100, true, url,
+            10, 42, "location", login, "name", 1, new Plan(),
+            1, 1, 1, "https://url", new RepositoryPermissions(true, true, true),
+            false, null, null);
+    }
+
+    protected static Organization CreateOctokitOrganization(string login)
+    {
+        return new Organization("https://url", "", "", 1, "GitHub", DateTimeOffset.UtcNow, 0, "email", 100, 100, true, "http://url", 10, 42, "somewhere", login, "Who cares", 1, new Plan(), 1, 1, 1, "https://url", "billing");
+    }
+
+    protected static Repository CreateRepository(string owner, string name, string domain = "github.com")
+    {
+        var cloneUrl = "https://" + domain + "/" + owner + "/" + name;
+        string notCloneUrl = cloneUrl + "-x";
+        return new Repository(notCloneUrl, notCloneUrl, cloneUrl, notCloneUrl, notCloneUrl, notCloneUrl, notCloneUrl,
+            1, CreateOctokitUser(owner),
+            name, "fullname", "description", notCloneUrl, "c#", false, false, 0, 0, "master",
+            0, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow,
+            new RepositoryPermissions(), null, null, true, false, false);
+    }
+
+    protected static PullRequest CreatePullRequest(User user, int id, ItemState state, string title,
+        DateTimeOffset createdAt, DateTimeOffset updatedAt, int commentCount = 0, int reviewCommentCount = 0)
+    {
+        var uri = new Uri("https://url");
+        return new PullRequest(uri, uri, uri, uri, uri, uri,
+            id, state, title, "", createdAt, updatedAt,
+            null, null, null, null, user, null, false, null,
+            commentCount, reviewCommentCount, 0, 0, 0, 0,
+            null, false);
     }
 }
 


### PR DESCRIPTION
This bumps octokit to 0.20, updates the API for breaking changes, and also includes a local octokit fix (not yet upstream) that adds the PR Review comment count field to the PullRequest object (comment counts include commit comments and pr comments, which are stored in two different fields)

The comment count is not actually getting populated right now because the json result of listing PRs doesn't return these fields, but they are returned when we get individual PRs, so this bump is not strictly required right now.

This needs local testing before merging!