### PR TITLE
Hide comment icon and count if there's no comments

### DIFF
--- a/src/GitHub.UI/Converters/CountToVisibilityConverter.cs
+++ b/src/GitHub.UI/Converters/CountToVisibilityConverter.cs
@@ -15,7 +15,7 @@ namespace GitHub.UI
     {
         public override object Convert(object value, Type targetType, [AllowNull] object parameter, [AllowNull] CultureInfo culture)
         {
-            return ((int)value == 0) ? Visibility.Visible : Visibility.Collapsed;
+            return ((int)value > 0) ? Visibility.Visible : Visibility.Collapsed;
         }
     }
 }

--- a/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
@@ -12,9 +12,7 @@
     <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio;component/SharedDictionary.xaml"/>
     <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
   </ResourceDictionary.MergedDictionaries>
-  <ui:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-  <ui:DurationToStringConverter x:Key="DurationToStringConverter" />
-
+  
   <DataTemplate x:Key="PullRequestItemTemplate" DataType="models:IPullRequestModel">
     <Grid>
       <Grid.RowDefinitions>
@@ -70,19 +68,8 @@
                    Width="16"
                    Height="16"
                    VerticalAlignment="Top"
-                   Foreground="{DynamicResource GitHubVsToolWindowText}">
-            <!--
-            <ui:OcticonImage.Style>
-              <Style>
-                <Style.Triggers>
-                  <DataTrigger Binding="{Binding CommentCount}" Value="0">
-                    <Setter Property="FrameworkElement.IsEnabled" Value="False" />
-                  </DataTrigger>
-                </Style.Triggers>
-              </Style>
-            </ui:OcticonImage.Style>
-            -->
-        </ui:OcticonImage>
+                   Foreground="{DynamicResource GitHubVsToolWindowText}"
+                   Visibility="{Binding CommentCount, Converter={ui:CountToVisibilityConverter}}" />
 
       <TextBlock x:Name="comment_count"
                  Grid.Row="0"
@@ -92,17 +79,8 @@
                  VerticalAlignment="Top"
                  FontFamily="Segoe UI"
                  Foreground="{DynamicResource GitHubVsToolWindowText}"
-                 Text="{Binding CommentCount}">
-        <TextBlock.Style>
-          <Style>
-            <Style.Triggers>
-              <DataTrigger Binding="{Binding CommentCount}" Value="0">
-                <Setter Property="FrameworkElement.IsEnabled" Value="False" />
-              </DataTrigger>
-            </Style.Triggers>
-          </Style>
-        </TextBlock.Style>
-      </TextBlock>
+                 Text="{Binding CommentCount}"
+                 Visibility="{Binding CommentCount, Converter={ui:CountToVisibilityConverter}}" />
 
       <ui:OcticonImage x:Name="comment_new"
                        Grid.Row="0"
@@ -115,8 +93,7 @@
                        Margin="0,3"
                        Foreground="Green"
                        Icon="primitive_dot"
-                       Visibility="{Binding HasNewComments,
-                                            Converter={StaticResource BooleanToVisibilityConverter}}" />
+                       Visibility="{Binding HasNewComments, Converter={ui:BooleanToVisibilityConverter}}" />
       <Grid x:Name="status"
             Grid.Row="1"
             Grid.Column="1"
@@ -141,7 +118,7 @@
                    Foreground="{DynamicResource GitHubVsGrayText}">
           <TextBlock.Text>
             <MultiBinding StringFormat="{} {0} {1} {2}">
-              <Binding Converter="{StaticResource DurationToStringConverter}" Path="UpdatedAt" />
+              <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
               <Binding Source="{x:Static i18n:Resources.prOpenedByText}" />
               <Binding Path="Author.Login" />
             </MultiBinding>
@@ -153,7 +130,7 @@
                     <TextBlock.Text>
                        <MultiBinding StringFormat="{} {0} {1} {2} {3}">
                           <Binding Source="{x:Static i18n:Resources.prOpenedText}" />
-                          <Binding Converter="{StaticResource DurationToStringConverter}" Path="UpdatedAt" />
+                          <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
                           <Binding Source="{x:Static i18n:Resources.prOpenedByText}" />
                           <Binding Path="Author.Login" />
                         </MultiBinding>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryPublishControl.xaml
@@ -94,36 +94,26 @@
     </ComboBox>
 
     <Grid>
-      <TextBox x:Name="nameText"
+      <ui:PromptTextBox x:Name="nameText"
                Height="23"
                Margin="0"
                Background="{DynamicResource GitHubVsSearchBoxBackground}"
                Foreground="{DynamicResource GitHubVsWindowText}"
                MaxLength="{x:Static cache:Constants.MaxRepositoryNameLength}"
-               Text="{Binding RepositoryName}" />
-
-      <TextBlock Margin="7,4,0,0"
-                 Foreground="{DynamicResource GitHubVsGrayText}"
-                 IsHitTestVisible="False"
-                 Text="{x:Static prop:Resources.RepoNameText}"
-                 Visibility="{Binding ElementName=nameText, Path=Text.Length, Converter={ui:CountToVisibilityConverter}}" />
+               Text="{Binding RepositoryName}"
+               PromptText="{x:Static prop:Resources.RepoNameText}" />
     </Grid>
 
     <Grid>
-      <TextBox x:Name="description"
+      <ui:PromptTextBox x:Name="description"
                Height="52"
                Margin="0,8,0,0"
                AcceptsReturn="True"
                Background="{DynamicResource GitHubVsSearchBoxBackground}"
                Foreground="{DynamicResource GitHubVsWindowText}"
                Text="{Binding Description}"
-               TextWrapping="WrapWithOverflow" />
-
-      <TextBlock Margin="7,12,0,0"
-                 Foreground="{DynamicResource GitHubVsGrayText}"
-                 IsHitTestVisible="False"
-                 Text="{x:Static prop:Resources.DescriptionOptional}"
-                 Visibility="{Binding ElementName=description, Path=Text.Length, Converter={ui:CountToVisibilityConverter}}" />
+               TextWrapping="WrapWithOverflow"
+               PromptText="{x:Static prop:Resources.DescriptionOptional}" />
     </Grid>
 
     <CheckBox x:Name="makePrivate"


### PR DESCRIPTION
Also, yeah, there's lots of silliness going on here...

The CountToVisibilityConverter had its logic backwards because it was being used to show textblocks with "XXX required" messages in the publish control if those fields were not filled out... which is why we have PromptTextBox controls to use!

We need to hide the icon because we don't actually have comment counts on the PR body, because the PR list json returned by the API returns everything except this information (and some other status fields like merge status). So we're going to have to get the list and then query all PRs individually. That's going to be around 300+ requests for a decent-size repo for an initial cache fill.

So we're punting on the comment count for now and figuring this one out later.

GRUMBLE!