### PR TITLE
Fix ScrollViewer

### DIFF
--- a/src/GitHub.VisualStudio.UI/UI/Views/GitHubConnectContent.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/UI/Views/GitHubConnectContent.xaml.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using GitHub.Services;
 using GitHub.Models;
 using System;
+using System.Windows.Input;
 
 namespace GitHub.VisualStudio.UI.Views
 {
@@ -16,8 +17,33 @@ namespace GitHub.VisualStudio.UI.Views
             InitializeComponent();
 
             DataContextChanged += (s, e) => ViewModel = e.NewValue as IGitHubConnectSection;
+            repositories.PreviewMouseWheel += Repositories_PreviewMouseWheel;
         }
 
+        void Repositories_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            try
+            {
+                if (!e.Handled)
+                {
+                    var uIElement = base.Parent as UIElement;
+
+                    if (uIElement != null)
+                    {
+                        e.Handled = true;
+                        uIElement.RaiseEvent(new MouseWheelEventArgs(e.MouseDevice, e.Timestamp, e.Delta)
+                        {
+                            RoutedEvent = UIElement.MouseWheelEvent,
+                            Source = this
+                        });
+                    }
+                }
+            }
+            catch
+            {
+                // TODO: Add trace logging: event handler called - who knows what can happen!
+            }
+        }
         void cloneLink_Click(object sender, RoutedEventArgs e)
         {
             cloneLink.IsEnabled = false;


### PR DESCRIPTION
ScrollViewer is broken - it doesn't pass mouse wheel events to parent even when there's nothing to scroll. Work around it by manually passing the event to the parent. See https://serialseb.blogspot.com/2007/09/wpf-tips-6-preventing-scrollviewer-from.html for more info. Fixes #409 .