### PR TITLE
Fix test reporting on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,6 @@ build_script:
 - cmd: msbuild "GitHubVS.sln" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=Release /p:DeployExtension=false /verbosity:minimal /p:VisualStudioVersion=14.0
 test_script:
 - ps: >-
-    scripts\Run-Nunit.ps1 TrackingCollectionTests 180 Release
+    scripts\Run-Nunit.ps1 TrackingCollectionTests 180 Release -AppVeyor
 
-    scripts\Run-Xunit.ps1 UnitTests 180 Release
+    scripts\Run-Xunit.ps1 UnitTests 180 Release -AppVeyor

--- a/scripts/Run-NUnit.ps1
+++ b/scripts/Run-NUnit.ps1
@@ -8,40 +8,55 @@ Param(
     [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
     [string]
-    $project,
-	[int]$timeoutDuration,
-	[string]$configuration
+    $Project,
+    [int]
+    $TimeoutDuration,
+    [string]
+    $Configuration,
+    [switch]
+    $AppVeyor = $false
 )
 
 $rootDirectory = Split-Path (Split-Path $MyInvocation.MyCommand.Path)
 Push-Location $rootDirectory
-$dll = "src\$project\bin\$configuration\$project.dll"
+$dll = "src\$Project\bin\$Configuration\$Project.dll"
 
-$nunitDirectory = Join-Path $rootDirectory packages\NUnit.Runners.2.6.4\tools
-$consoleRunner = Join-Path $nunitDirectory nunit-console-x86.exe
-$xml = Join-Path $rootDirectory "nunit-$project.xml"
-$outputPath = [System.IO.Path]::GetTempFileName()
-
-$args = "-noshadow", "-xml:$xml", "-framework:net-4.5", "-exclude:Timings", $dll
-[object[]] $output = "$consoleRunner " + ($args -join " ")
-
-$process = Start-Process -PassThru -NoNewWindow -RedirectStandardOutput $outputPath $consoleRunner ($args | %{ "`"$_`"" })
-Wait-Process -InputObject $process -Timeout $timeoutDuration -ErrorAction SilentlyContinue
-if ($process.HasExited) {
-    $output += Get-Content $outputPath
-    $exitCode = $process.ExitCode
+if ($AppVeyor) {
+    $nunitDirectory = Join-Path $rootDirectory packages\NUnit.Runners.2.6.4\tools
+    $consoleRunner = Join-Path $nunitDirectory nunit-console-x86.exe
+    $args = "-noshadow", "-framework:net-4.5", "-exclude:Timings", $dll
+    [object[]] $output = "$consoleRunner " + ($args -join " ")
+    & $consoleRunner ($args | %{ "`"$_`"" })
+    if($LastExitCode -ne 0) {
+        $host.SetShouldExit($LastExitCode)
+    }
 } else {
-    $output += "Tests timed out. Backtrace:"
-    $output += Get-DotNetStack $process.Id
-    $exitCode = 9999
+    $nunitDirectory = Join-Path $rootDirectory packages\NUnit.Runners.2.6.4\tools
+    $consoleRunner = Join-Path $nunitDirectory nunit-console-x86.exe
+
+    $xml = Join-Path $rootDirectory "nunit-$Project.xml"
+    $outputPath = [System.IO.Path]::GetTempFileName()
+
+    $args = "-noshadow", "-xml:$xml", "-framework:net-4.5", "-exclude:Timings", $dll
+    [object[]] $output = "$consoleRunner " + ($args -join " ")
+
+    $process = Start-Process -PassThru -NoNewWindow -RedirectStandardOutput $outputPath $consoleRunner ($args | %{ "`"$_`"" })
+    Wait-Process -InputObject $process -Timeout $TimeoutDuration -ErrorAction SilentlyContinue
+    if ($process.HasExited) {
+        $output += Get-Content $outputPath
+        $exitCode = $process.ExitCode
+    } else {
+        $output += "Tests timed out. Backtrace:"
+        $output += Get-DotNetStack $process.Id
+        $exitCode = 9999
+    }
+
+    Stop-Process -InputObject $process
+    Remove-Item $outputPath
+    Pop-Location
+
+    $result = New-Object System.Object
+    $result | Add-Member -Type NoteProperty -Name Output -Value $output
+    $result | Add-Member -Type NoteProperty -Name ExitCode -Value $exitCode
+    $result
 }
-
-Stop-Process -InputObject $process
-Remove-Item $outputPath
-Pop-Location
-
-$result = New-Object System.Object
-$result | Add-Member -Type NoteProperty -Name Output -Value $output
-$result | Add-Member -Type NoteProperty -Name ExitCode -Value $exitCode
-$result
-

--- a/scripts/Run-XUnit.ps1
+++ b/scripts/Run-XUnit.ps1
@@ -8,40 +8,55 @@ Param(
     [Parameter(Mandatory=$true)]
     [ValidateNotNullOrEmpty()]
     [string]
-    $project,
-	[int]$timeoutDuration,
-	[string]$configuration
+    $Project,
+    [int]
+    $TimeoutDuration,
+    [string]
+    $Configuration,
+    [switch]
+    $AppVeyor = $false
 )
 
 $rootDirectory = Split-Path (Split-Path $MyInvocation.MyCommand.Path)
 Push-Location $rootDirectory
 
-$dll = "src\$project\bin\$configuration\$project.dll"
+$dll = "src\$Project\bin\$Configuration\$Project.dll"
 
-$xunitDirectory = Join-Path $rootDirectory packages\xunit.runner.console.2.1.0\tools
-$consoleRunner = Join-Path $xunitDirectory xunit.console.x86.exe
-$xml = Join-Path $rootDirectory "nunit-$project.xml"
-$outputPath = [System.IO.Path]::GetTempFileName()
-
-$args = $dll, "-noshadow", "-xml", $xml, "-parallel", "all"
-[object[]] $output = "$consoleRunner " + ($args -join " ")
-
-$process = Start-Process -PassThru -NoNewWindow -RedirectStandardOutput $outputPath $consoleRunner ($args | %{ "`"$_`"" })
-Wait-Process -InputObject $process -Timeout $timeoutDuration -ErrorAction SilentlyContinue
-if ($process.HasExited) {
-    $output += Get-Content $outputPath
-    $exitCode = $process.ExitCode
+if ($AppVeyor) {
+    $xunitDirectory = Join-Path $rootDirectory packages\xunit.runner.console.2.1.0\tools
+    $consoleRunner = Join-Path $xunitDirectory xunit.console.x86.exe
+    $args = $dll, "-noshadow", "-parallel", "all", "-appveyor"
+    [object[]] $output = "$consoleRunner " + ($args -join " ")
+    & $consoleRunner ($args | %{ "`"$_`"" })
+    if($LastExitCode -ne 0) {
+        $host.SetShouldExit($LastExitCode)
+    }
 } else {
-    $output += "Tests timed out. Backtrace:"
-    $output += Get-DotNetStack $process.Id
-    $exitCode = 9999
-}
-Stop-Process -InputObject $process
-Remove-Item $outputPath
-Pop-Location
+    $xunitDirectory = Join-Path $rootDirectory packages\xunit.runner.console.2.1.0\tools
+    $consoleRunner = Join-Path $xunitDirectory xunit.console.x86.exe
+    $xml = Join-Path $rootDirectory "nunit-$Project.xml"
+    $outputPath = [System.IO.Path]::GetTempFileName()
 
-$result = New-Object System.Object
-$result | Add-Member -Type NoteProperty -Name Output -Value $output
-$result | Add-Member -Type NoteProperty -Name ExitCode -Value $exitCode
-$result
-	
+    $args = $dll, "-noshadow", "-xml", $xml, "-parallel", "all"
+
+    [object[]] $output = "$consoleRunner " + ($args -join " ")
+
+    $process = Start-Process -PassThru -NoNewWindow -RedirectStandardOutput $outputPath $consoleRunner ($args | %{ "`"$_`"" })
+    Wait-Process -InputObject $process -Timeout $TimeoutDuration -ErrorAction SilentlyContinue
+    if ($process.HasExited) {
+        $output += Get-Content $outputPath
+        $exitCode = $process.ExitCode
+    } else {
+        $output += "Tests timed out. Backtrace:"
+        $output += Get-DotNetStack $process.Id
+        $exitCode = 9999
+    }
+    Stop-Process -InputObject $process
+    Remove-Item $outputPath
+    Pop-Location
+
+    $result = New-Object System.Object
+    $result | Add-Member -Type NoteProperty -Name Output -Value $output
+    $result | Add-Member -Type NoteProperty -Name ExitCode -Value $exitCode
+    $result
+}


### PR DESCRIPTION
Output directly to the console when running tests on appveyor, with appropriate flags. This isn't using the appveyor-bundled test runners because 1) I have no clue what version they are and 2) apparently they're not the same as what we use.

This should make builds correctly report build failure when tests fail.