### PR TITLE
Allow "Create PR" comment TextBox to grow as more content is entered

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -109,43 +109,45 @@
 
     </DockPanel>
 
-    <StackPanel Orientation="Vertical">
-      <ui:PromptTextBox x:Name="titleText"
-                        Margin="10,5"
-                        Text="{Binding PRTitle, UpdateSourceTrigger=PropertyChanged}"
-                        PromptText="{x:Static prop:Resources.TitleRequired}"
-                        Style="{DynamicResource GitHubVsPromptTextBox}" />
+    <ScrollViewer HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto">
+        <StackPanel Orientation="Vertical">
+            <ui:PromptTextBox x:Name="titleText"
+                    Margin="10,5"
+                    Text="{Binding PRTitle, UpdateSourceTrigger=PropertyChanged}"
+                    PromptText="{x:Static prop:Resources.TitleRequired}"
+                    Style="{DynamicResource GitHubVsPromptTextBox}" />
 
-      <uirx:ValidationMessage x:Name="titleValidationMessage"
-                              DockPanel.Dock="Bottom"
-                              Fill="{StaticResource GitHubWarningBrush}"
-                              Icon="alert"
-                              ValidatesControl="{Binding ElementName=titleText}"
-                              ReactiveValidator="{Binding TitleValidator, Mode=OneWay}"
-                              />
+            <uirx:ValidationMessage x:Name="titleValidationMessage"
+                            DockPanel.Dock="Bottom"
+                            Fill="{StaticResource GitHubWarningBrush}"
+                            Icon="alert"
+                            ValidatesControl="{Binding ElementName=titleText}"
+                            ReactiveValidator="{Binding TitleValidator, Mode=OneWay}"
+                            />
 
-      <ui:PromptTextBox Height="100"
-                        Margin="10,5"
-                        AcceptsReturn="True"
-                        PromptText="{x:Static prop:Resources.Description}"
-                        Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
-                        Style="{DynamicResource GitHubVsPromptTextBox}"
-                        TextWrapping="Wrap" />
+            <ui:PromptTextBox MinHeight="100"
+                    Margin="10,5"
+                    AcceptsReturn="True"
+                    PromptText="{x:Static prop:Resources.Description}"
+                    Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
+                    Style="{DynamicResource GitHubVsPromptTextBox}"
+                    TextWrapping="Wrap" />
 
-      <DockPanel Margin="10,10,10,20" HorizontalAlignment="Stretch">
-        <Button DockPanel.Dock="Right"
-                Margin="6,0,0,0"
-                HorizontalAlignment="Right"
-                Command="{Binding CreatePullRequest}"
-                Content="Create pull request"
-                Style="{StaticResource GitHubVsPrimaryActionButton}" />
-        <Button DockPanel.Dock="Right"
-                HorizontalAlignment="Right"
-                Command="{Binding Cancel}"
-                Content="Cancel"
-                Style="{StaticResource GitHubVsButton}" />
-      </DockPanel>
-    </StackPanel>
+            <DockPanel Margin="10,10,10,20" HorizontalAlignment="Stretch">
+                <Button DockPanel.Dock="Right"
+            Margin="6,0,0,0"
+            HorizontalAlignment="Right"
+            Command="{Binding CreatePullRequest}"
+            Content="Create pull request"
+            Style="{StaticResource GitHubVsPrimaryActionButton}" />
+                <Button DockPanel.Dock="Right"
+            HorizontalAlignment="Right"
+            Command="{Binding Cancel}"
+            Content="Cancel"
+            Style="{StaticResource GitHubVsButton}" />
+            </DockPanel>
+        </StackPanel>
+    </ScrollViewer>
 
   </DockPanel>
 </local:GenericPullRequestCreationView>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -112,39 +112,38 @@
     <ScrollViewer HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto">
         <StackPanel Orientation="Vertical">
             <ui:PromptTextBox x:Name="titleText"
-                    Margin="10,5"
-                    Text="{Binding PRTitle, UpdateSourceTrigger=PropertyChanged}"
-                    PromptText="{x:Static prop:Resources.TitleRequired}"
-                    Style="{DynamicResource GitHubVsPromptTextBox}" />
+                              Margin="10,5"
+                              Text="{Binding PRTitle, UpdateSourceTrigger=PropertyChanged}"
+                              PromptText="{x:Static prop:Resources.TitleRequired}"
+                              Style="{DynamicResource GitHubVsPromptTextBox}" />
 
             <uirx:ValidationMessage x:Name="titleValidationMessage"
-                            DockPanel.Dock="Bottom"
-                            Fill="{StaticResource GitHubWarningBrush}"
-                            Icon="alert"
-                            ValidatesControl="{Binding ElementName=titleText}"
-                            ReactiveValidator="{Binding TitleValidator, Mode=OneWay}"
-                            />
+                                    DockPanel.Dock="Bottom"
+                                    Fill="{StaticResource GitHubWarningBrush}"
+                                    Icon="alert"
+                                    ValidatesControl="{Binding ElementName=titleText}"
+                                    ReactiveValidator="{Binding TitleValidator, Mode=OneWay}"/>
 
             <ui:PromptTextBox MinHeight="100"
-                    Margin="10,5"
-                    AcceptsReturn="True"
-                    PromptText="{x:Static prop:Resources.Description}"
-                    Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
-                    Style="{DynamicResource GitHubVsPromptTextBox}"
-                    TextWrapping="Wrap" />
+                              Margin="10,5"
+                              AcceptsReturn="True"
+                              PromptText="{x:Static prop:Resources.Description}"
+                              Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
+                              Style="{DynamicResource GitHubVsPromptTextBox}"
+                              TextWrapping="Wrap" />
 
             <DockPanel Margin="10,10,10,20" HorizontalAlignment="Stretch">
                 <Button DockPanel.Dock="Right"
-            Margin="6,0,0,0"
-            HorizontalAlignment="Right"
-            Command="{Binding CreatePullRequest}"
-            Content="Create pull request"
-            Style="{StaticResource GitHubVsPrimaryActionButton}" />
+                        Margin="6,0,0,0"
+                        HorizontalAlignment="Right"
+                        Command="{Binding CreatePullRequest}"
+                        Content="Create pull request"
+                        Style="{StaticResource GitHubVsPrimaryActionButton}" />
                 <Button DockPanel.Dock="Right"
-            HorizontalAlignment="Right"
-            Command="{Binding Cancel}"
-            Content="Cancel"
-            Style="{StaticResource GitHubVsButton}" />
+                        HorizontalAlignment="Right"
+                        Command="{Binding Cancel}"
+                        Content="Cancel"
+                        Style="{StaticResource GitHubVsButton}" />  
             </DockPanel>
         </StackPanel>
     </ScrollViewer>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -17,136 +17,138 @@
                                       DataContext="{Binding ViewModel}"
                                       mc:Ignorable="d">
 
-  <d:DesignProperties.DataContext>
-    <Binding>
-      <Binding.Source>
-        <sampleData:PullRequestCreationViewModelDesigner />
-      </Binding.Source>
-    </Binding>
-  </d:DesignProperties.DataContext>
+    <d:DesignProperties.DataContext>
+        <Binding>
+            <Binding.Source>
+                <sampleData:PullRequestCreationViewModelDesigner />
+            </Binding.Source>
+        </Binding>
+    </d:DesignProperties.DataContext>
 
-  <UserControl.Resources>
-    <ResourceDictionary>
-      <ResourceDictionary.MergedDictionaries>
-        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
-        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
-        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
-      </ResourceDictionary.MergedDictionaries>
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
 
-      <Style x:Key="CommitListItemContainerStyle" TargetType="{x:Type ListViewItem}">
-        <Setter Property="SnapsToDevicePixels" Value="True" />
-        <Setter Property="Margin" Value="5" />
-        <Setter Property="Padding" Value="1" />
+            <Style x:Key="CommitListItemContainerStyle" TargetType="{x:Type ListViewItem}">
+                <Setter Property="SnapsToDevicePixels" Value="True" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Padding" Value="1" />
 
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="VerticalContentAlignment" Value="Center" />
 
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="BorderBrush" Value="Transparent" />
-        <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderBrush" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0" />
 
-        <Setter Property="Template">
-          <Setter.Value>
-            <ControlTemplate TargetType="{x:Type ListViewItem}">
-              <Border x:Name="Bd"
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ListViewItem}">
+                            <Border x:Name="Bd"
                       Background="{TemplateBinding Background}"
                       BorderThickness="{TemplateBinding BorderThickness}"
                       Padding="{TemplateBinding Padding}">
-                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-              </Border>
-            </ControlTemplate>
-          </Setter.Value>
-        </Setter>
-      </Style>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
 
-      <Style x:Key="GitHubPopupThing" TargetType="{x:Type ListBox}">
-        <Setter Property="ItemTemplate">
-          <Setter.Value>
-            <DataTemplate>
-              <TextBlock Text="{Binding Path=Name}" />
-            </DataTemplate>
-          </Setter.Value>
-        </Setter>
-      </Style>
+            <Style x:Key="GitHubPopupThing" TargetType="{x:Type ListBox}">
+                <Setter Property="ItemTemplate">
+                    <Setter.Value>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Path=Name}" />
+                        </DataTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
 
-    </ResourceDictionary>
-  </UserControl.Resources>
+    <Grid VerticalAlignment="Top" MaxHeight="{Binding ActualHeight, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:GenericPullRequestCreationView}}}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
 
-  <DockPanel>
+        <DockPanel Grid.Row="0">
+            <Grid Margin="10,-3,10,5">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-    <DockPanel DockPanel.Dock="Top">
-      <Grid Margin="10,-3,10,5">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <ui:OcticonImage Foreground="{DynamicResource GitHubVsGrayText}" Icon="git_branch" />
+                    <ui:GitHubActionLink x:Name="branchSelectionButton"
+                                    Margin="5,0,0,0"
+                                    VerticalAlignment="Center"
+                                    Content="master"
+                                    HasDropDown="False" />
+                    <ui:OcticonImage Height="13"
+                                Margin="5,2,3,0"
+                                VerticalAlignment="Center"
+                                Foreground="{DynamicResource GitHubVsGrayText}"
+                                Icon="chevron_left" />
+                    <TextBlock Foreground="{DynamicResource GitHubVsGrayText}" Text="{Binding TargetBranch}" />
+                </StackPanel>
 
-        <StackPanel Grid.Column="0" Orientation="Horizontal">
-          <ui:OcticonImage Foreground="{DynamicResource GitHubVsGrayText}" Icon="git_branch" />
-          <ui:GitHubActionLink x:Name="branchSelectionButton"
-                               Margin="5,0,0,0"
-                               VerticalAlignment="Center"
-                               Content="master"
-                               HasDropDown="False" />
-          <ui:OcticonImage Height="13"
-                           Margin="5,2,3,0"
-                           VerticalAlignment="Center"
-                           Foreground="{DynamicResource GitHubVsGrayText}"
-                           Icon="chevron_left" />
-          <TextBlock Foreground="{DynamicResource GitHubVsGrayText}" Text="{Binding TargetBranch}" />
-        </StackPanel>
+                <ui:LinkDropDown Header="Source Branch"
+                                ItemsSource="{Binding Branches}"
+                                DisplayMemberPath="Name"
+                                SelectedItem="{Binding SourceBranch}"
+                                ToolTip="Select a branch"
+                                Margin="0,1,0,0"
+                                Grid.Column="1"/>
+            </Grid>
+        </DockPanel>
 
-        <ui:LinkDropDown Header="Source Branch"
-                         ItemsSource="{Binding Branches}"
-                         DisplayMemberPath="Name"
-                         SelectedItem="{Binding SourceBranch}"
-                         ToolTip="Select a branch"
-                         Margin="0,1,0,0"
-                         Grid.Column="1"/>
-      </Grid>
+        <ui:PromptTextBox x:Name="titleText"
+                            Grid.Row="1"
+                            Margin="10,5"
+                            Text="{Binding PRTitle, UpdateSourceTrigger=PropertyChanged}"
+                            PromptText="{x:Static prop:Resources.TitleRequired}"
+                            Style="{DynamicResource GitHubVsPromptTextBox}" />
 
-    </DockPanel>
+        <ui:PromptTextBox Grid.Row="2"
+                            MinHeight="100"
+                            Margin="10,5"
+                            AcceptsReturn="True"
+                            PromptText="{x:Static prop:Resources.Description}"
+                            Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
+                            Style="{DynamicResource GitHubVsPromptTextBox}"
+                            TextWrapping="Wrap" />
 
-    <ScrollViewer HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Auto">
-        <StackPanel Orientation="Vertical">
-            <ui:PromptTextBox x:Name="titleText"
-                              Margin="10,5"
-                              Text="{Binding PRTitle, UpdateSourceTrigger=PropertyChanged}"
-                              PromptText="{x:Static prop:Resources.TitleRequired}"
-                              Style="{DynamicResource GitHubVsPromptTextBox}" />
+        <uirx:ValidationMessage x:Name="titleValidationMessage"
+                                Grid.Row="3"
+                                Fill="{StaticResource GitHubWarningBrush}"
+                                Icon="alert"
+                                ValidatesControl="{Binding ElementName=titleText}"
+                                ReactiveValidator="{Binding TitleValidator, Mode=OneWay}"/>
 
-            <uirx:ValidationMessage x:Name="titleValidationMessage"
-                                    DockPanel.Dock="Bottom"
-                                    Fill="{StaticResource GitHubWarningBrush}"
-                                    Icon="alert"
-                                    ValidatesControl="{Binding ElementName=titleText}"
-                                    ReactiveValidator="{Binding TitleValidator, Mode=OneWay}"/>
-
-            <ui:PromptTextBox MinHeight="100"
-                              Margin="10,5"
-                              AcceptsReturn="True"
-                              PromptText="{x:Static prop:Resources.Description}"
-                              Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
-                              Style="{DynamicResource GitHubVsPromptTextBox}"
-                              TextWrapping="Wrap" />
-
-            <DockPanel Margin="10,10,10,20" HorizontalAlignment="Stretch">
-                <Button DockPanel.Dock="Right"
-                        Margin="6,0,0,0"
-                        HorizontalAlignment="Right"
-                        Command="{Binding CreatePullRequest}"
-                        Content="Create pull request"
-                        Style="{StaticResource GitHubVsPrimaryActionButton}" />
-                <Button DockPanel.Dock="Right"
-                        HorizontalAlignment="Right"
-                        Command="{Binding Cancel}"
-                        Content="Cancel"
-                        Style="{StaticResource GitHubVsButton}" />  
-            </DockPanel>
-        </StackPanel>
-    </ScrollViewer>
-
-  </DockPanel>
+        <DockPanel Grid.Row="4" Margin="10,10,10,20" HorizontalAlignment="Stretch">
+            <Button DockPanel.Dock="Right"
+                    Margin="6,0,0,0"
+                    HorizontalAlignment="Right"
+                    Command="{Binding CreatePullRequest}"
+                    Content="Create pull request"
+                    Style="{StaticResource GitHubVsPrimaryActionButton}" />
+            <Button DockPanel.Dock="Right"
+                    HorizontalAlignment="Right"
+                    Command="{Binding Cancel}"
+                    Content="Cancel"
+                    Style="{StaticResource GitHubVsButton}" />
+        </DockPanel>
+    </Grid>
 </local:GenericPullRequestCreationView>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -127,6 +127,7 @@
                             PromptText="{x:Static prop:Resources.Description}"
                             Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
                             Style="{DynamicResource GitHubVsPromptTextBox}"
+                            VerticalScrollBarVisibility="Auto"
                             TextWrapping="Wrap" />
 
         <uirx:ValidationMessage x:Name="titleValidationMessage"


### PR DESCRIPTION
Allow "Create PR" comment TextBox to grow as more content is entered. Wrapped the containing panel in a ScrollViewer so that it can be scrolled if it gets too large for the GitHub pane.

I would've prefered to allow the TextBox to grow only as far as to fill the available space, but there seems to be no panel with the desired behavior in WPF and creating a new panel for this case seems overkill.

Fixes #458 