### PR TITLE
Correctly validate source branch in PR creation.

### DIFF
--- a/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
@@ -15,11 +15,13 @@ using NullGuard;
 using GitHub.App;
 using System.Reactive.Subjects;
 using System.Reactive;
+using System.Diagnostics.CodeAnalysis;
 
 namespace GitHub.ViewModels
 {
     [ExportViewModel(ViewType = UIViewType.PRCreation)]
     [PartCreationPolicy(CreationPolicy.NonShared)]
+    [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable")]
     public class PullRequestCreationViewModel : BaseViewModel, IPullRequestCreationViewModel
     {
         readonly IRepositoryHost repositoryHost;

--- a/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
@@ -58,8 +58,7 @@ namespace GitHub.ViewModels
                 x => x.SourceBranch,
                 source => source.Value)
                 .Where(_ => initialized)
-                .Merge(initializationComplete.Select(_ => SourceBranch))
-                .Do(x => System.Diagnostics.Debug.WriteLine("SourceBranch:" + x));
+                .Merge(initializationComplete.Select(_ => SourceBranch));
 
             BranchValidator = ReactivePropertyValidator.ForObservable(branchObs)
                 .IfTrue(x => x == null, Resources.PullRequestSourceBranchDoesNotExist)


### PR DESCRIPTION
Don't try to validate source branch using `BranchValidator` while initialization is in progress. Fixes #455.