### PR TITLE
Make sure the assembly resolver code always runs

### DIFF
--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -210,9 +210,7 @@
     </Compile>
     <Compile Include="Base\MenuBase.cs" />
     <Compile Include="Menus\CreateGist.cs" />
-    <Compile Include="..\common\SharedDictionaryManager.cs">
-      <Link>Helpers\SharedDictionaryManager.cs</Link>
-    </Compile>
+    <Compile Include="Helpers\SharedDictionaryManager.cs" />
     <Compile Include="Helpers\ActiveDocumentSnapshot.cs" />
     <Compile Include="Menus\OpenLink.cs" />
     <Compile Include="Menus\LinkMenuBase.cs" />

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -53,6 +53,12 @@ namespace GitHub.VisualStudio
         };
 
         readonly IServiceProvider serviceProvider;
+        static bool resolverInitialized;
+
+        static GitHubPackage()
+        {
+            InitializeAssemblyResolver();
+        }
 
         public GitHubPackage()
         {
@@ -64,10 +70,16 @@ namespace GitHub.VisualStudio
             this.serviceProvider = serviceProvider;
         }
 
+        public static void InitializeAssemblyResolver()
+        {
+            if (resolverInitialized)
+                return;
+            AppDomain.CurrentDomain.AssemblyResolve += LoadAssemblyFromRunDir;
+            resolverInitialized = true;
+        }
+
         protected override void Initialize()
         {
-            AppDomain.CurrentDomain.AssemblyResolve += LoadAssemblyFromRunDir;
-
             base.Initialize();
             IncrementLaunchCount();
 

--- a/src/GitHub.VisualStudio/Helpers/SharedDictionaryManager.cs
+++ b/src/GitHub.VisualStudio/Helpers/SharedDictionaryManager.cs
@@ -6,6 +6,11 @@ namespace GitHub.VisualStudio.Helpers
 {
     public class SharedDictionaryManager : ResourceDictionary
     {
+        static SharedDictionaryManager()
+        {
+            GitHubPackage.InitializeAssemblyResolver();
+        }
+
         static readonly Dictionary<Uri, ResourceDictionary> resourceDicts = new Dictionary<Uri, ResourceDictionary>();
 
         Uri sourceUri;


### PR DESCRIPTION
Fixes #461

This is likely a race condition between the `GitHubPackage` class initializing and the xaml loader running. I can't repro it, but we've had this problem before, which is why there used to be an `AssemblyResolver` event hookup in `SharedDictionaryManager.cs`. This got moved to `GitHubPackage.cs` in 7a88701d6607fe91852a3fe92c8632034122b6c4 because the `OptionsControl` UserControl needs it as well but doesn't use `SharedDictionaryManager` to load dependencies (and relying on having a dependency loaded to trigger this is brittle). 

Turns out, having it only during the package loading phase is too late in some cases, since Team Explorer can potentially load before the package is initialized. Sooooo, we need it in both places, preferably. This makes it so without dupe'ing code.

![](http://fullnomad.com/wp-content/uploads/2015/08/make-it-so.png)