### PR TITLE
Descriptive Pull Request Creation Errors 

### DIFF
--- a/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
@@ -79,7 +79,7 @@ namespace GitHub.ViewModels
                     //TODO:Will need a uniform solution to HTTP exception message handling
                     var apiException = ex as ApiValidationException;
                     var error = apiException?.ApiError?.Errors?.FirstOrDefault();
-                    notifications.ShowError(error.Message ?? ex.Message);
+                    notifications.ShowError(error?.Message ?? ex.Message);
                 }
             });
         }

--- a/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
@@ -13,6 +13,7 @@ using GitHub.Validation;
 using GitHub.Extensions;
 using NullGuard;
 using GitHub.App;
+using Octokit;
 
 namespace GitHub.ViewModels
 {
@@ -75,7 +76,10 @@ namespace GitHub.ViewModels
             {
                 if (!ex.IsCriticalException())
                 {
-                    notifications.ShowError(ex.Message);
+                    //TODO:Will need a uniform solution to HTTP exception message handling
+                    var apiException = ex as ApiValidationException;
+                    var error = apiException?.ApiError?.Errors?.FirstOrDefault();
+                    notifications.ShowError(error.Message ?? ex.Message);
                 }
             });
         }


### PR DESCRIPTION
In this specific instance, we notify the user when they are trying to a duplicate PR on a branch, but with just a "Validation Failed" message. A more informative message lies within the response from the exception. If the type of exception is checked (like `APIValidationException`), we can convert and grab the actual message we want to convey to the user. If it's not that type (it's null), then just display the exception message.

Fixes #453 