### PR TITLE
Reduce font-size for titles in PR list

### DIFF
--- a/src/GitHub.UI/Controls/Buttons/GitHubActionLink.cs
+++ b/src/GitHub.UI/Controls/Buttons/GitHubActionLink.cs
@@ -8,10 +8,19 @@ namespace GitHub.UI
         public static readonly DependencyProperty HasDropDownProperty = DependencyProperty.Register(
             "HasDropDown", typeof(bool), typeof(GitHubActionLink));
 
+        public static readonly DependencyProperty TextTrimmingProperty = DependencyProperty.Register(
+            "TextTrimming", typeof(TextTrimming), typeof(GitHubActionLink));
+
         public bool HasDropDown
         {
             get { return (bool)GetValue(HasDropDownProperty); }
             set { SetValue(HasDropDownProperty, value); }
+        }
+
+        public TextTrimming TextTrimming
+        {
+            get { return (TextTrimming)GetValue(TextTrimmingProperty); }
+            set { SetValue(TextTrimmingProperty, value); }
         }
 
         public GitHubActionLink()

--- a/src/GitHub.UI/Controls/Buttons/GitHubActionLink.cs
+++ b/src/GitHub.UI/Controls/Buttons/GitHubActionLink.cs
@@ -8,8 +8,8 @@ namespace GitHub.UI
         public static readonly DependencyProperty HasDropDownProperty = DependencyProperty.Register(
             "HasDropDown", typeof(bool), typeof(GitHubActionLink));
 
-        public static readonly DependencyProperty TextTrimmingProperty = DependencyProperty.Register(
-            "TextTrimming", typeof(TextTrimming), typeof(GitHubActionLink));
+        public static readonly DependencyProperty TextTrimmingProperty =
+            TextBlock.TextTrimmingProperty.AddOwner(typeof(GitHubActionLink));
 
         public bool HasDropDown
         {

--- a/src/GitHub.VisualStudio.UI/Styles/ActionLinkButton.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ActionLinkButton.xaml
@@ -10,7 +10,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="Button">
-          <TextBlock>
+          <TextBlock TextTrimming="CharacterEllipsis">
             <Hyperlink Command="{TemplateBinding Command}"
                        CommandParameter="{TemplateBinding CommandParameter}"
                        Foreground="{TemplateBinding Foreground}">

--- a/src/GitHub.VisualStudio.UI/Styles/ActionLinkButton.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ActionLinkButton.xaml
@@ -10,7 +10,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="Button">
-          <TextBlock TextTrimming="CharacterEllipsis">
+          <TextBlock>
             <Hyperlink Command="{TemplateBinding Command}"
                        CommandParameter="{TemplateBinding CommandParameter}"
                        Foreground="{TemplateBinding Foreground}">

--- a/src/GitHub.VisualStudio.UI/Styles/GitHubActionLink.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/GitHubActionLink.xaml
@@ -8,10 +8,11 @@
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Focusable" Value="True" />
     <Setter Property="Foreground" Value="{DynamicResource GitHubActionLinkItemBrush}" />
+    <Setter Property="TextTrimming" Value="None" />
     <Setter Property="Template">
       <Setter.Value>
-        <ControlTemplate TargetType="Button">
-          <TextBlock>
+        <ControlTemplate TargetType="{x:Type ui:GitHubActionLink}">
+          <TextBlock TextTrimming="{TemplateBinding TextTrimming}">
             <Hyperlink Command="{TemplateBinding Command}"
                        CommandParameter="{TemplateBinding CommandParameter}"
                        Foreground="{TemplateBinding Foreground}">

--- a/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
@@ -54,7 +54,6 @@
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
             Foreground="{DynamicResource GitHubVsToolWindowText}"
-            FontWeight="SemiBold"
             TextTrimming="CharacterEllipsis"
             Margin="0,-3,5,0"
             Content="{Binding Title}"

--- a/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
@@ -55,7 +55,6 @@
             VerticalAlignment="Top"
             Foreground="{DynamicResource GitHubVsToolWindowText}"
             Margin="0,-3,5,0"
-            FontSize="{DynamicResource {x:Static vsui:VsFonts.Environment122PercentFontSizeKey}}"
             Style="{StaticResource ActionLinkButton}"
             Content="{Binding Title}"
             ToolTip="{Binding Title}"

--- a/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
@@ -48,14 +48,15 @@
           </StackPanel>
       </Grid>
 
-      <Button x:Name="title"
+      <ui:GitHubActionLink x:Name="title"
             Grid.Row="0"
             Grid.Column="1"
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
             Foreground="{DynamicResource GitHubVsToolWindowText}"
+            FontWeight="SemiBold"
+            TextTrimming="CharacterEllipsis"
             Margin="0,-3,5,0"
-            Style="{StaticResource ActionLinkButton}"
             Content="{Binding Title}"
             ToolTip="{Binding Title}"
             Command="{Binding OpenPR, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"


### PR DESCRIPTION
The font size for titles in the pull request list were large, which tends to draw the eye away from the main area of Visual Studio. This PR reduces the font size back to the default size and adds text trimming for long PR titles.

**Before**

![image](https://cloud.githubusercontent.com/assets/1174461/17570675/40b06cc2-5f02-11e6-9f32-b9bff1a78fa8.png)

**After**

![image](https://cloud.githubusercontent.com/assets/1174461/17573230/e5d0ebf4-5f0d-11e6-9e67-cc6677a13053.png)

