### PR TITLE
Fix creating private repos for organizations.

### DIFF
--- a/src/GitHub.App/Api/ApiClient.cs
+++ b/src/GitHub.App/Api/ApiClient.cs
@@ -127,7 +127,14 @@ namespace GitHub.Api
 
         public IObservable<Organization> GetOrganizations()
         {
-            return gitHubClient.Organization.GetAllForCurrent();
+            // Organization.GetAllForCurrent doesn't return all of the information we need (we 
+            // need information about the plan the organization is on in order to enable/disable
+            // the "Private Repository" checkbox in the "Create Repository" dialog). To get this
+            // we have to do an Organization.Get on each repository received.
+            return gitHubClient.Organization
+                .GetAllForCurrent()
+                .Select(x => gitHubClient.Organization.Get(x.Login))
+                .Merge();
         }
 
         public IObservable<Repository> GetUserRepositories(RepositoryType repositoryType)

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -107,6 +107,10 @@ namespace GitHub.Services
                 hostCache.GetAndRefreshObject(user.Login + "|orgs",
                     () => apiClient.GetOrganizations().Select(AccountCacheItem.Create).ToList(),
                     TimeSpan.FromMinutes(2), TimeSpan.FromDays(7)))
+                // TODO: Akavache returns the cached version followed by the fresh version if > 2
+                // minutes have expired from the last request. Here we make sure the latest value is
+                // returned but it's a hack. We really need a better way to cache this stuff.
+                .TakeLast(1)
                 .Catch<IEnumerable<AccountCacheItem>, KeyNotFoundException>(
                     // This could in theory happen if we try to call this before the user is logged in.
                     e =>


### PR DESCRIPTION
Organization.GetAllForCurrent doesn't return all of the information we need (we need information about the plan the organization is on in order to enable/disable the "Private Repository" checkbox in the "Create Repository" dialog). To get this we have to do an Organization.Get on each repository received.

This PR required https://github.com/octokit/octokit.net/pull/1448 to be merged into our fork. 

Fixes #436 .