### PR TITLE
Add a loader for external packages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "script"]
 	path = script
 	url = https://github.com/github/VisualStudioBuildScripts
+[submodule "submodules/externalpackages/StartPage"]
+	path = submodules/externalpackages/StartPage
+	url = https://github.com/editor-tools/StartPage.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ install:
       Set-Content c:\users\appveyor\.ssh\id_rsa $fileContent
     } else {
       git submodule deinit script
+      git submodule deinit submodules/externalpackages/StartPage
     }
 
     git submodule update

--- a/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
@@ -22,6 +22,7 @@ using Rothko;
 using System.Collections.ObjectModel;
 using GitHub.Collections;
 using GitHub.UI;
+using GitHub.Extensions.Reactive;
 
 namespace GitHub.ViewModels
 {
@@ -152,12 +153,16 @@ namespace GitHub.ViewModels
                     notificationService.ShowError(Resources.RepositoryCloneFailedNoSelectedRepo);
                     return Observable.Return(Unit.Default);
                 }
-                
+
                 // The following is a noop if the directory already exists.
                 operatingSystem.Directory.CreateDirectory(BaseRepositoryPath);
 
                 return cloneService.CloneRepository(repository.CloneUrl, repository.Name, BaseRepositoryPath)
-                    .Do(_ => this.usageTracker.IncrementCloneCount());
+                    .ContinueAfter(() =>
+                    {
+                        usageTracker.IncrementCloneCount();
+                        return Observable.Return(Unit.Default);
+                    });
             })
             .SelectMany(_ => _)
             .Catch<Unit, Exception>(e =>

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -153,6 +153,7 @@
       <DependentUpon>IPackageSettings.tt</DependentUpon>
     </Compile>
     <Compile Include="Settings\GitHubConnectSectionState.cs" />
+    <Compile Include="Settings\Guids.cs" />
     <Compile Include="Settings\PullRequestListUIState.cs" />
     <Compile Include="Settings\RepositoryUIState.cs" />
     <Compile Include="Settings\UIState.cs" />

--- a/src/GitHub.Exports/Helpers/AssemblyResolver.cs
+++ b/src/GitHub.Exports/Helpers/AssemblyResolver.cs
@@ -52,7 +52,7 @@ namespace GitHub.Helpers
             {
                 var requestedName = e.Name.TrimSuffix(".dll", StringComparison.OrdinalIgnoreCase);
                 var name = new AssemblyName(requestedName).Name;
-                if (!ourAssemblies.Contains(name, new LambdaComparer<string>((lhs, rhs) => String.Compare(lhs, rhs, StringComparison.OrdinalIgnoreCase))))
+                if (!ourAssemblies.Contains(name, StringComparer.OrdinalIgnoreCase))
                     return null;
                 var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 var filename = Path.Combine(path, name + ".dll");

--- a/src/GitHub.Exports/Helpers/AssemblyResolver.cs
+++ b/src/GitHub.Exports/Helpers/AssemblyResolver.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using System.Diagnostics;
 
 namespace GitHub.Helpers
 {
@@ -47,13 +49,15 @@ namespace GitHub.Helpers
         {
             try
             {
-                var name = new AssemblyName(e.Name);
-                if (!ourAssemblies.Contains(name.Name))
+                var requestedName = e.Name.TrimSuffix(".dll", StringComparison.OrdinalIgnoreCase);
+                var name = new AssemblyName(requestedName).Name;
+                if (!ourAssemblies.Contains(name))
                     return null;
                 var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                var filename = Path.Combine(path, name.Name + ".dll");
+                var filename = Path.Combine(path, name + ".dll");
                 if (!File.Exists(filename))
                     return null;
+
                 return Assembly.LoadFrom(filename);
             }
             catch (Exception ex)

--- a/src/GitHub.Exports/Helpers/AssemblyResolver.cs
+++ b/src/GitHub.Exports/Helpers/AssemblyResolver.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using System.Diagnostics;
+using GitHub.Collections;
 
 namespace GitHub.Helpers
 {
@@ -51,7 +52,7 @@ namespace GitHub.Helpers
             {
                 var requestedName = e.Name.TrimSuffix(".dll", StringComparison.OrdinalIgnoreCase);
                 var name = new AssemblyName(requestedName).Name;
-                if (!ourAssemblies.Contains(name))
+                if (!ourAssemblies.Contains(name, new LambdaComparer<string>((lhs, rhs) => String.Compare(lhs, rhs, StringComparison.OrdinalIgnoreCase))))
                     return null;
                 var path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
                 var filename = Path.Combine(path, name + ".dll");

--- a/src/GitHub.Exports/Services/IUIProvider.cs
+++ b/src/GitHub.Exports/Services/IUIProvider.cs
@@ -3,9 +3,11 @@ using System.ComponentModel.Composition.Hosting;
 using GitHub.Models;
 using GitHub.UI;
 using System.Windows.Controls;
+using System.Runtime.InteropServices;
 
 namespace GitHub.Services
 {
+    [Guid("76909E1A-9D58-41AB-8957-C26B9550787B")]
     public interface IUIProvider : IServiceProvider
     {
         ExportProvider ExportProvider { get; }

--- a/src/GitHub.Exports/Settings/Guids.cs
+++ b/src/GitHub.Exports/Settings/Guids.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace GitHub.VisualStudio
+{
+    public static class Guids
+    {
+        public const string PackageId = "c3d3dc68-c977-411f-b3e8-03b0dccf7dfc";
+        public const string ImagesId = "27841f47-070a-46d6-90be-a5cbbfc724ac";
+    }
+}

--- a/src/GitHub.Extensions/LambdaComparer.cs
+++ b/src/GitHub.Extensions/LambdaComparer.cs
@@ -14,7 +14,7 @@ namespace GitHub.Collections
         {
         }
 
-        public LambdaComparer(Func<T, T, int> lambdaComparer, Func<T, int> lambdaHash)
+        public LambdaComparer(Func<T, T, int> lambdaComparer, [AllowNull] Func<T, int> lambdaHash)
         {
             this.lambdaComparer = lambdaComparer;
             this.lambdaHash = lambdaHash;

--- a/src/GitHub.Extensions/LambdaComparer.cs
+++ b/src/GitHub.Extensions/LambdaComparer.cs
@@ -10,11 +10,11 @@ namespace GitHub.Collections
         readonly Func<T, int> lambdaHash;
 
         public LambdaComparer(Func<T, T, int> lambdaComparer) :
-            this(lambdaComparer, o => 0)
+            this(lambdaComparer, null)
         {
         }
 
-        LambdaComparer(Func<T, T, int> lambdaComparer, Func<T, int> lambdaHash)
+        public LambdaComparer(Func<T, T, int> lambdaComparer, Func<T, int> lambdaHash)
         {
             this.lambdaComparer = lambdaComparer;
             this.lambdaHash = lambdaHash;
@@ -32,7 +32,9 @@ namespace GitHub.Collections
 
         public int GetHashCode([AllowNull] T obj)
         {
-            return lambdaHash(obj);
+            return lambdaHash != null
+                ? lambdaHash(obj)
+                : obj?.GetHashCode() ?? 0;
         }
     }
 }

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -605,7 +605,7 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="$(Buildtype) == 'Internal'">
     <Content Include="..\..\submodules\externalpackages\StartPage\build\GitHub.StartPage.pkgdef">
       <Link>GitHub.StartPage.pkgdef</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -107,12 +107,26 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Immutable.11.0.11.0.50727\lib\net45\Microsoft.VisualStudio.Shell.Immutable.11.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Immutable.14.0.14.3.25407\lib\net45\Microsoft.VisualStudio.Shell.Immutable.14.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6071\lib\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.UI, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
@@ -123,10 +137,12 @@
       <EmbedInteropTypes>true</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.TextManager.Interop" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0" />
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -234,7 +250,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Settings\PackageSettings.cs" />
-    <Compile Include="Settings\Settings.cs" />
+    <Compile Include="Settings\Guids.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="GitHubPackage.cs" />
     <Compile Include="PkgCmdID.cs" />
@@ -547,14 +563,14 @@
       <Project>{161dbf01-1dbf-4b00-8551-c5c00f26720d}</Project>
       <Name>GitHub.TeamFoundation.14</Name>
       <Private>False</Private>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bDebugSymbolsProjectOutputGroup%3bBuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <ProjectReference Include="..\GitHub.TeamFoundation.15\GitHub.TeamFoundation.15.csproj">
       <Project>{161dbf01-1dbf-4b00-8551-c5c00f26720e}</Project>
       <Name>GitHub.TeamFoundation.15</Name>
       <Private>False</Private>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bGetCopyToOutputDirectoryItems%3bDebugSymbolsProjectOutputGroup%3bBuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <ProjectReference Include="..\GitHub.UI.Reactive\GitHub.UI.Reactive.csproj">
@@ -588,6 +604,23 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\submodules\externalpackages\StartPage\build\GitHub.StartPage.pkgdef">
+      <Link>GitHub.StartPage.pkgdef</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="..\..\submodules\externalpackages\StartPage\build\GitHub.StartPage.dll">
+      <Link>GitHub.StartPage.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="..\..\submodules\externalpackages\StartPage\build\GitHub.StartPage.pdb">
+      <Link>GitHub.StartPage.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
   </ItemGroup>
   <PropertyGroup>
     <UseCodebase>true</UseCodebase>

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -82,9 +82,9 @@ namespace GitHub.VisualStudio
     [Guid(StartPagePackageId)]
     public sealed class ServiceProviderPackage : AsyncPackage
     {
-        static Version vsversion;
-        public static Version VSVersion
         const string StartPagePackageId = "D5CE1488-DEDE-426D-9E5B-BFCCFBE33E53";
+        Version vsversion;
+        Version VSVersion
         {
             get
             {

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -79,11 +79,12 @@ namespace GitHub.VisualStudio
     [ProvideService(typeof(IUIProvider), IsAsyncQueryable = true)]
     [ProvideAutoLoad(UIContextGuids.NoSolution)]
     [ProvideAutoLoad(UIContextGuids.SolutionExists)]
-    [Guid("D5CE1488-DEDE-426D-9E5B-BFCCFBE33E53")]
+    [Guid(StartPagePackageId)]
     public sealed class ServiceProviderPackage : AsyncPackage
     {
         static Version vsversion;
         public static Version VSVersion
+        const string StartPagePackageId = "D5CE1488-DEDE-426D-9E5B-BFCCFBE33E53";
         {
             get
             {

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -79,10 +79,12 @@ namespace GitHub.VisualStudio
     [ProvideService(typeof(IUIProvider), IsAsyncQueryable = true)]
     [ProvideAutoLoad(UIContextGuids.NoSolution)]
     [ProvideAutoLoad(UIContextGuids.SolutionExists)]
-    [Guid(StartPagePackageId)]
+    [Guid(ServiceProviderPackageId)]
     public sealed class ServiceProviderPackage : AsyncPackage
     {
-        const string StartPagePackageId = "D5CE1488-DEDE-426D-9E5B-BFCCFBE33E53";
+        const string ServiceProviderPackageId = "D5CE1488-DEDE-426D-9E5B-BFCCFBE33E53";
+        const string StartPagePreview4PackageId = "3b764d23-faf7-486f-94c7-b3accc44a70d";
+
         Version vsversion;
         Version VSVersion
         {
@@ -117,7 +119,7 @@ namespace GitHub.VisualStudio
             {
                 var shell = await GetServiceAsync(typeof(SVsShell)) as IVsShell;
                 IVsPackage startPagePackage;
-                if (ErrorHandler.Failed(shell?.LoadPackage(new Guid("3b764d23-faf7-486f-94c7-b3accc44a70d"), out startPagePackage) ?? -1))
+                if (ErrorHandler.Failed(shell?.LoadPackage(new Guid(StartPagePreview4PackageId), out startPagePackage) ?? -1))
                 {
                     // ¯\_(ツ)_/¯
                 }

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -1,32 +1,26 @@
 ﻿using System;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using GitHub.Extensions;
 using GitHub.Models;
-using GitHub.Primitives;
 using GitHub.Services;
-using GitHub.UI;
-using GitHub.VisualStudio.Base;
 using GitHub.VisualStudio.UI;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Octokit;
 using GitHub.Helpers;
+using System.ComponentModel.Design;
+using System.Diagnostics;
+using System.Threading;
+using tasks = System.Threading.Tasks;
 
 namespace GitHub.VisualStudio
 {
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
     [Guid(GuidList.guidGitHubPkgString)]
-    //[ProvideBindingPath]
     [ProvideMenuResource("Menus.ctmenu", 1)]
-    //[ProvideAutoLoad(UIContextGuids.NoSolution)]
     // this is the Git service GUID, so we load whenever it loads
     [ProvideAutoLoad("11B8E6D7-C08B-4385-B321-321078CDD1F8")]
     [ProvideToolWindow(typeof(GitHubPane), Orientation = ToolWindowOrientation.Right, Style = VsDockStyle.Tabbed, Window = EnvDTE.Constants.vsWindowKindSolutionExplorer)]
@@ -78,6 +72,62 @@ namespace GitHub.VisualStudio
         public GHClient(IProgram program)
             : base(program.ProductHeader)
         {
+        }
+    }
+
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    [ProvideService(typeof(IUIProvider), IsAsyncQueryable = true)]
+    [ProvideAutoLoad(UIContextGuids.NoSolution)]
+    [ProvideAutoLoad(UIContextGuids.SolutionExists)]
+    [Guid("D5CE1488-DEDE-426D-9E5B-BFCCFBE33E53")]
+    public sealed class ServiceProviderPackage : AsyncPackage
+    {
+        static Version vsversion;
+        public static Version VSVersion
+        {
+            get
+            {
+                if (vsversion == null)
+                {
+                    var asm = typeof(ITaskList).Assembly;
+                    try
+                    {
+                        // this will return Microsoft.VisualStudio.Shell.Immutable.14.0 in VS15
+                        // but Microsoft.VisualStudio.Shell.Framework in Dev15
+                        var vinfo = FileVersionInfo.GetVersionInfo(asm.Location);
+                        vsversion = new Version(vinfo.FileMajorPart, vinfo.FileMinorPart, vinfo.FileBuildPart, vinfo.FilePrivatePart);
+                    }
+                    catch
+                    {
+                        // something wrong, fallback to assembly version
+                        vsversion = asm.GetName().Version;
+                    }
+                }
+                return vsversion;
+            }
+        }
+
+        protected override async tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            AddService(typeof(IUIProvider), CreateService, true);
+
+            // Load the start page package only for Dev15 Preview 4
+            if (VSVersion.Major == 15 && VSVersion.Build == 25618)
+            {
+                var shell = await GetServiceAsync(typeof(SVsShell)) as IVsShell;
+                IVsPackage startPagePackage;
+                if (ErrorHandler.Failed(shell?.LoadPackage(new Guid("3b764d23-faf7-486f-94c7-b3accc44a70d"), out startPagePackage) ?? -1))
+                {
+                    // ¯\_(ツ)_/¯
+                }
+            }
+        }
+
+        tasks.Task<object> CreateService(IAsyncServiceContainer container, CancellationToken cancellationToken, Type serviceType)
+        {
+            AssemblyResolver.InitializeAssemblyResolver();
+            var ret = Services.ComponentModel.DefaultExportProvider.GetExportedValueOrDefault<IUIProvider>();
+            return tasks.Task.FromResult((object)ret);
         }
     }
 }

--- a/src/GitHub.VisualStudio/Settings/Guids.cs
+++ b/src/GitHub.VisualStudio/Settings/Guids.cs
@@ -1,7 +1,4 @@
-﻿// Guids.cs
-// MUST match guids.h
-using System;
-using System.Diagnostics;
+﻿using System;
 
 namespace GitHub.VisualStudio
 {
@@ -11,10 +8,10 @@ namespace GitHub.VisualStudio
         public const string guidGitHubCmdSetString = "c4c91892-8881-4588-a5d9-b41e8f540f5a";
         public const string guidGitHubToolbarCmdSetString = "C5F1193E-F300-41B3-B4C4-5A703DD3C1C6";
         public const string guidContextMenuSetString = "31057D08-8C3C-4C5B-9F91-8682EA08EC27";
+        public const string guidImageMoniker = "27841f47-070a-46d6-90be-a5cbbfc724ac";
 
         public static readonly Guid guidGitHubCmdSet = new Guid(guidGitHubCmdSetString);
         public static readonly Guid guidGitHubToolbarCmdSet = new Guid(guidGitHubToolbarCmdSetString);
-
         public static readonly Guid guidContextMenuSet = new Guid(guidContextMenuSetString);
     }
 }

--- a/src/GitHub.VisualStudio/packages.config
+++ b/src/GitHub.VisualStudio/packages.config
@@ -4,6 +4,11 @@
   <package id="Fody" version="1.28.0" targetFramework="net45" developmentDependency="true" />
   <package id="LibGit2Sharp" version="0.22.0" targetFramework="net461" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.11.0" version="11.0.50727" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Immutable.14.0" version="14.3.25407" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net461" />
   <package id="Microsoft.VSSDK.Vsixsigntool" version="14.1.24720" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NLog" version="3.1.0" targetFramework="net45" />

--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -28,5 +28,6 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.App" Path="|GitHub.App|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.TeamFoundation.14" Path="|GitHub.TeamFoundation.14|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.TeamFoundation.15" Path="|GitHub.TeamFoundation.15|" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="GitHub.StartPage.pkgdef" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
Fixes #522 

This PR adds a way to load external packages that are included in the vsix and expose the `IUIProvider` as a global service, so those packages can make use of our services.

The way it works is that we now ship two packages - one that only loads when the git ui context loads (as before), which tracks app startups and loads menus and things, and one that loads as soon as VS loads and registers the `IUIProvider` service as a global service. This service loader package is an async package, so it loads in the background, and doesn't create the `IUIProvider` instance until someone requests it via a `GetService` call.

This PR also includes a submodule for the [StartPage package](https://github.com/editor-tools/StartPage), includes it in the vsix if it is available, and only loads it at runtime if we're running on VS "15" Preview 4 (and only then).

I've also added a little change to make sure we only record a clone metric if the clone method returns successfully. It doesn't necessarily mean that the clone is completed successfully, but we can't track that so this is the best we can do right now.

@haacked I could really use your 👀 on this one.