### PR TITLE
Load the package asynchronously

### DIFF
--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -145,7 +145,6 @@
   <ItemGroup>
     <Compile Include="Authentication\AuthenticationResultExtensions.cs" />
     <Compile Include="Extensions\ServiceProviderExtensions.cs" />
-    <Compile Include="Services\UsageTracker.cs" />
     <Compile Include="Services\VSServices.cs" />
     <Compile Include="Settings\generated\IPackageSettings.cs">
       <AutoGen>True</AutoGen>

--- a/src/GitHub.Exports/Services/IMenuProvider.cs
+++ b/src/GitHub.Exports/Services/IMenuProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace GitHub.VisualStudio
 {
@@ -7,6 +8,7 @@ namespace GitHub.VisualStudio
     /// Container for static and dynamic visibility menus (context, toolbar, top, etc)
     /// Get a reference to this via MEF and register the menus
     /// </summary>
+    [Guid(Guids.MenuProviderId)]
     public interface IMenuProvider
     {
         /// <summary>

--- a/src/GitHub.Exports/Services/IUsageTracker.cs
+++ b/src/GitHub.Exports/Services/IUsageTracker.cs
@@ -1,5 +1,9 @@
-﻿namespace GitHub.Services
+﻿using GitHub.VisualStudio;
+using System.Runtime.InteropServices;
+
+namespace GitHub.Services
 {
+    [Guid(Guids.UsageTrackerId)]
     public interface IUsageTracker
     {
         void IncrementLaunchCount();

--- a/src/GitHub.Exports/Services/VSServices.cs
+++ b/src/GitHub.Exports/Services/VSServices.cs
@@ -72,8 +72,8 @@ namespace GitHub.Services
         const string EnvVersionKey = "EnvVersion";
         string GetVSVersion()
         {
-            var version = VisualStudio.Services.Dte.Version;
-            var keyPath = String.Format(CultureInfo.InvariantCulture, "{0}\\{1}_Config\\SplashInfo", RegistryRootKey, version);
+            var version = typeof(Microsoft.VisualStudio.Shell.ActivityLog).Assembly.GetName().Version;
+            var keyPath = String.Format(CultureInfo.InvariantCulture, "{0}\\{1}.{2}_Config\\SplashInfo", RegistryRootKey, version.Major, version.Minor);
             try
             {
                 using (var key = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(keyPath))
@@ -82,6 +82,7 @@ namespace GitHub.Services
                     if (!String.IsNullOrEmpty(value))
                         return value;
                 }
+                // fallback to poking the CommonIDE assembly, which most closely follows the advertised version.
                 var asm = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.FullName.StartsWith("Microsoft.VisualStudio.CommonIDE", StringComparison.OrdinalIgnoreCase));
                 if (asm != null)
                     return asm.GetName().Version.ToString();
@@ -90,7 +91,7 @@ namespace GitHub.Services
             {
                 VsOutputLogger.WriteLine(string.Format(CultureInfo.CurrentCulture, "Error getting the Visual Studio version '{0}'", ex));
             }
-            return version;
+            return version.ToString();
         }
     }
 }

--- a/src/GitHub.Exports/Settings/Guids.cs
+++ b/src/GitHub.Exports/Settings/Guids.cs
@@ -6,5 +6,7 @@ namespace GitHub.VisualStudio
     {
         public const string PackageId = "c3d3dc68-c977-411f-b3e8-03b0dccf7dfc";
         public const string ImagesId = "27841f47-070a-46d6-90be-a5cbbfc724ac";
+        public const string MenuProviderId = "36FA083F-E0BE-418E-B42F-CB7623C55A00";
+        public const string UsageTrackerId = "9362DD38-7E49-4B5D-9DE1-E843D4155716";
     }
 }

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -107,6 +107,11 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.14.3.25407\lib\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>True</Private>
@@ -124,23 +129,51 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6071\lib\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.10.0.10.0.30319\lib\Microsoft.VisualStudio.Shell.Interop.10.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.11.0.11.0.61030\lib\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.12.0.12.0.30110\lib\Microsoft.VisualStudio.Shell.Interop.12.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.14.3.25407\lib\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Text.UI, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0">
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0">
-      <EmbedInteropTypes>true</EmbedInteropTypes>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0" />
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.14.1.131\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -237,6 +270,7 @@
     <Compile Include="Menus\MenuProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\Browser.cs" />
+    <Compile Include="Services\UsageTracker.cs" />
     <Compile Include="Settings\Constants.cs" />
     <Compile Include="Services\ConnectionManager.cs" />
     <Compile Include="Services\Program.cs" />

--- a/src/GitHub.VisualStudio/Services/UsageTracker.cs
+++ b/src/GitHub.VisualStudio/Services/UsageTracker.cs
@@ -21,12 +21,13 @@ namespace GitHub.Services
         const string StoreFileName = "ghfvs.usage";
         static readonly Calendar cal = CultureInfo.InvariantCulture.Calendar;
 
-        readonly IMetricsService client;
+        IMetricsService client;
         readonly IConnectionManager connectionManager;
-        readonly IPackageSettings userSettings;
+        IPackageSettings userSettings;
         readonly IVSServices vsservices;
         readonly DispatcherTimer timer;
         readonly string storePath;
+        readonly IServiceProvider serviceProvider;
 
         Func<string, bool> fileExists;
         Func<string, Encoding, string> readAllText;
@@ -37,19 +38,18 @@ namespace GitHub.Services
         public UsageTracker(
             IProgram program,
             IConnectionManager connectionManager,
-            IPackageSettings userSettings,
             IVSServices vsservices,
             [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
         {
+            this.serviceProvider = serviceProvider;
+
             fileExists = (path) => System.IO.File.Exists(path);
             readAllText = (path, encoding) => System.IO.File.ReadAllText(path, encoding);
             writeAllText = (path, content, encoding) => System.IO.File.WriteAllText(path, content, encoding);
             dirCreate = (path) => System.IO.Directory.CreateDirectory(path);
 
             this.connectionManager = connectionManager;
-            this.userSettings = userSettings;
             this.vsservices = vsservices;
-            this.client = serviceProvider.GetExportedValue<IMetricsService>();
             this.timer = new DispatcherTimer(
                 TimeSpan.FromMinutes(1),
                 DispatcherPriority.Background,
@@ -60,15 +60,7 @@ namespace GitHub.Services
                 program.ApplicationName,
                 StoreFileName);
 
-            userSettings.PropertyChanged += (s, e) =>
-            {
-                if (e.PropertyName == nameof(userSettings.CollectMetrics))
-                {
-                    UpdateTimer(false);
-                }
-            };
-
-            UpdateTimer(true);
+            RunTimer();
         }
 
         public void IncrementLaunchCount()
@@ -156,25 +148,12 @@ namespace GitHub.Services
             writeAllText(storePath, json, Encoding.UTF8);
         }
 
-        void UpdateTimer(bool initialCall)
+        void RunTimer()
         {
-            // If the method was called due to userSettings.CollectMetrics changing, then send an
-            // opt-in/out message.
-            if (!initialCall && client != null)
-            {
-                if (userSettings.CollectMetrics)
-                    client.SendOptIn();
-                else
-                    client.SendOptOut();
-            }
-
-            // The timer first ticks after 1 minute to allow things to settle down after startup.
+            // The timer first ticks after 3 minutes to allow things to settle down after startup.
             // This will be changed to 8 hours after the first tick by the TimerTick method.
-            timer.Stop();
-            timer.Interval = TimeSpan.FromMinutes(1);
-
-            if (userSettings.CollectMetrics && client != null)
-                timer.Start();
+            timer.Interval = TimeSpan.FromMinutes(3);
+            timer.Start();
         }
 
         async void TimerTick(object sender, EventArgs e)
@@ -184,9 +163,24 @@ namespace GitHub.Services
             // Subsequent timer ticks should occur every 8 hours.
             timer.Interval = TimeSpan.FromHours(8);
 
+            if (userSettings == null)
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                client = serviceProvider.GetExportedValue<IMetricsService>();
+                if (client == null)
+                {
+                    timer.Stop();
+                    return;
+                }
+                userSettings = serviceProvider.GetExportedValue<IPackageSettings>();
+            }
+
+            if (!userSettings.CollectMetrics)
+                return;
+
             try
             {
-                // Every time we increment the launch count we increment both daily and weekly 
+                // Every time we increment the launch count we increment both daily and weekly
                 // launch count but we only submit (and clear) the weekly launch count when we've
                 // transitioned into a new week. We've defined a week by the ISO8601 definition,
                 // i.e. week starting on Monday and ending on Sunday.
@@ -232,7 +226,7 @@ namespace GitHub.Services
         // http://blogs.msdn.com/b/shawnste/archive/2006/01/24/iso-8601-week-of-year-format-in-microsoft-net.aspx
         static int GetIso8601WeekOfYear(DateTimeOffset time)
         {
-            // Seriously cheat.  If its Monday, Tuesday or Wednesday, then it'll 
+            // Seriously cheat.  If its Monday, Tuesday or Wednesday, then it'll
             // be the same week# as whatever Thursday, Friday or Saturday are,
             // and we always get those right
             DayOfWeek day = cal.GetDayOfWeek(time.UtcDateTime);

--- a/src/GitHub.VisualStudio/packages.config
+++ b/src/GitHub.VisualStudio/packages.config
@@ -4,11 +4,20 @@
   <package id="Fody" version="1.28.0" targetFramework="net45" developmentDependency="true" />
   <package id="LibGit2Sharp" version="0.22.0" targetFramework="net461" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.11.0" version="11.0.50727" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.14.0" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.12.0" version="12.0.30110" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" version="14.3.25407" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading" version="14.1.131" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net461" />
   <package id="Microsoft.VSSDK.Vsixsigntool" version="14.1.24720" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NLog" version="3.1.0" targetFramework="net45" />


### PR DESCRIPTION
Load everything asynchronously so it doesn't delay VS itself loading. This requires moving some stuff around, because during the package loading process there can't be any calls to `GetService` or `GetGlobalService`, and those happen in a bunch of places.
