### PR TITLE
Fix VS manifest targets

### DIFF
--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -12,7 +12,9 @@
   </Metadata>
   <Installation AllUsers="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,]" />
-    <InstallationTarget Id="Microsoft.VisualStudio.Express_All" Version="[14.0,]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinDesktopExpress" Version="[14.0,)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinExpress" Version="[14.0,)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.VWDExpress" Version="[14.0,)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Apparently VS has no problems with the Express_All key but the VS gallery refuses to process the vsix when I upload it. No comments.