### PR TITLE
Update octokit to 0.22.0

### DIFF
--- a/src/GitHub.App/Api/ApiClient.cs
+++ b/src/GitHub.App/Api/ApiClient.cs
@@ -257,7 +257,11 @@ namespace GitHub.Api
 
         public IObservable<Branch> GetBranches(string owner, string repo)
         {
+#pragma warning disable CS0618
+            // GetAllBranches is obsolete, but don't want to introduce the change to fix the
+            // warning in the PR, so disabling for now.
             return gitHubClient.Repository.GetAllBranches(owner, repo);
+#pragma warning restore
         }
 
         public IObservable<Repository> GetRepository(string owner, string repo)


### PR DESCRIPTION
This fixes #534 via https://github.com/octokit/octokit.net/pull/1411. Previously the request to /site/sha to detect an enterprise instance wasn't getting sent due to octokit's implementation of `RedirectHandler`.