### PR TITLE
Removed TempFileBaseClass.

### DIFF
--- a/src/UnitTests/GitHub.App/Models/RepositoryModelTests.cs
+++ b/src/UnitTests/GitHub.App/Models/RepositoryModelTests.cs
@@ -54,31 +54,37 @@ public class RepositoryModelTests
     }
 
     [Collection("PackageServiceProvider global data tests")]
-    public class PathConstructorTests : TempFileBaseClass
+    public class PathConstructorTests : TestBaseClass
     {
         [Fact]
         public void NoRemoteUrl()
         {
-            var provider = Substitutes.ServiceProvider;
-            var gitservice = provider.GetGitService();
-            var repo = Substitute.For<IRepository>();
-            var path = Directory.CreateSubdirectory("repo-name");
-            gitservice.GetUri(path.FullName).Returns((UriString)null);
-            var model = new SimpleRepositoryModel(path.FullName);
-            Assert.Equal("repo-name", model.Name);
+            using (var temp = new TempDirectory())
+            {
+                var provider = Substitutes.ServiceProvider;
+                var gitservice = provider.GetGitService();
+                var repo = Substitute.For<IRepository>();
+                var path = temp.Directory.CreateSubdirectory("repo-name");
+                gitservice.GetUri(path.FullName).Returns((UriString)null);
+                var model = new SimpleRepositoryModel(path.FullName);
+                Assert.Equal("repo-name", model.Name);
+            }
         }
 
         [Fact]
         public void WithRemoteUrl()
         {
-            var provider = Substitutes.ServiceProvider;
-            var gitservice = provider.GetGitService();
-            var repo = Substitute.For<IRepository>();
-            var path = Directory.CreateSubdirectory("repo-name");
-            gitservice.GetUri(path.FullName).Returns(new UriString("https://github.com/user/repo-name"));
-            var model = new SimpleRepositoryModel(path.FullName);
-            Assert.Equal("repo-name", model.Name);
-            Assert.Equal("user", model.Owner);
+            using (var temp = new TempDirectory())
+            {
+                var provider = Substitutes.ServiceProvider;
+                var gitservice = provider.GetGitService();
+                var repo = Substitute.For<IRepository>();
+                var path = temp.Directory.CreateSubdirectory("repo-name");
+                gitservice.GetUri(path.FullName).Returns(new UriString("https://github.com/user/repo-name"));
+                var model = new SimpleRepositoryModel(path.FullName);
+                Assert.Equal("repo-name", model.Name);
+                Assert.Equal("user", model.Owner);
+            }
         }
     }
 

--- a/src/UnitTests/GitHub.Exports/SimpleRepositoryModelTests.cs
+++ b/src/UnitTests/GitHub.Exports/SimpleRepositoryModelTests.cs
@@ -54,7 +54,7 @@ public class SimpleRepositoryModelTests : TestBaseClass
     [InlineData(19, false, "git@github.com/foo/bar", "123123", @"src\dir\file1.cs", -1, -1, "https://github.com/foo/bar/blob/123123/src/dir/file1.cs")]
     public void GenerateUrl(int testid, bool createRootedPath, string baseUrl, string sha, string path, int startLine, int endLine, string expected)
     {
-        using (var temp = new TempDirectory(output))
+        using (var temp = new TempDirectory())
         {
             SetupRepository(sha);
 

--- a/src/UnitTests/Helpers/TestBaseClass.cs
+++ b/src/UnitTests/Helpers/TestBaseClass.cs
@@ -3,6 +3,7 @@ using GitHub.Models;
 using Octokit;
 using System;
 using System.IO;
+using Xunit.Abstractions;
 
 /// <summary>
 /// This base class will get its methods called by the most-derived
@@ -62,25 +63,28 @@ public class TestBaseClass : IEntryExitDecorator
             commentCount, reviewCommentCount, 0, 0, 0, 0,
             null, false);
     }
-}
 
-public class TempFileBaseClass : TestBaseClass
-{
-    public DirectoryInfo Directory { get; set; }
-
-    public override void OnEntry()
+    protected class TempDirectory : IDisposable
     {
-        var f = Path.GetTempFileName();
-        var name = Path.GetFileNameWithoutExtension(f);
-        File.Delete(f);
-        Directory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), name));
-        Directory.Create();
-        base.OnEntry();
-    }
+        ITestOutputHelper output;
 
-    public override void OnExit()
-    {
-        Directory.Delete(true);
-        base.OnExit();
+        public TempDirectory(ITestOutputHelper output = null)
+        {
+            this.output = output;
+            var f = Path.GetTempFileName();
+            var name = Path.GetFileNameWithoutExtension(f);
+            File.Delete(f);
+            Directory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), name));
+            Directory.Create();
+            output?.WriteLine("Created " + Directory);
+        }
+
+        public DirectoryInfo Directory { get; }
+
+        public void Dispose()
+        {
+            output?.WriteLine("Deleted " + Directory);
+            Directory.Delete(true);
+        }
     }
 }

--- a/src/UnitTests/Helpers/TestBaseClass.cs
+++ b/src/UnitTests/Helpers/TestBaseClass.cs
@@ -66,24 +66,19 @@ public class TestBaseClass : IEntryExitDecorator
 
     protected class TempDirectory : IDisposable
     {
-        ITestOutputHelper output;
-
-        public TempDirectory(ITestOutputHelper output = null)
+        public TempDirectory()
         {
-            this.output = output;
             var f = Path.GetTempFileName();
             var name = Path.GetFileNameWithoutExtension(f);
             File.Delete(f);
             Directory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), name));
             Directory.Create();
-            output?.WriteLine("Created " + Directory);
         }
 
         public DirectoryInfo Directory { get; }
 
         public void Dispose()
         {
-            output?.WriteLine("Deleted " + Directory);
             Directory.Delete(true);
         }
     }


### PR DESCRIPTION
Instead tests should construct a new instance of
`TestBaseClass.TempDirectory` and use that. Fixes #543.