### PR TITLE
Added TempRepository helper class.

### DIFF
--- a/src/UnitTests/Helpers/TestBaseClass.cs
+++ b/src/UnitTests/Helpers/TestBaseClass.cs
@@ -3,6 +3,7 @@ using GitHub.Models;
 using Octokit;
 using System;
 using System.IO;
+using System.IO.Compression;
 using Xunit.Abstractions;
 
 /// <summary>
@@ -80,6 +81,25 @@ public class TestBaseClass : IEntryExitDecorator
         public void Dispose()
         {
             Directory.Delete(true);
+        }
+    }
+
+    protected class TempRepository : TempDirectory
+    {
+        public TempRepository(string name, byte[] repositoryZip)
+            : base()
+        {
+            var outputZip = Path.Combine(Directory.FullName, name + ".zip");
+            var outputDir = Path.Combine(Directory.FullName, name);
+            var repositoryPath = Path.Combine(outputDir, name);
+            File.WriteAllBytes(outputZip, repositoryZip);
+            ZipFile.ExtractToDirectory(outputZip, outputDir);
+            Repository = new LibGit2Sharp.Repository(repositoryPath);
+        }
+
+        public LibGit2Sharp.Repository Repository
+        {
+            get;
         }
     }
 }

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -108,6 +108,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=62aa029873c516b4, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Rx-Core.2.2.5-custom\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
This can be used to create a temporary repository for unit tests. To use, zip up a repository directory (zip the directory containing the .git directory) and add it to your unit test resources (or you can load it from disk). The you can access it in your unit tests like so (assuming you test class inherits from `TestBaseClass`):

```
 public static readonly byte[] RepositoryBinary = UnitTests.Properties.Resources.test_get_tracking_branch;
 public const string RepositoryBinaryName = nameof(UnitTests.Properties.Resources.test_get_tracking_branch);

 [Fact]
 public async void FindsUpToDateTrackingBranch()
 {
  using (var temp = new TempRepository(RepositoryBinaryName, RepositoryBinary))
  {
   var target = new GitClient(Substitute.For<IGitHubCredentialProvider>());
   var result = await target.GetTrackingBranch(temp.Repository, "refs/pull/1/head").DefaultIfEmpty();

   Assert.NotNull(result);
   Assert.Equal("refs/heads/pr-1", result.CanonicalName);
  }
 }
```
 
Where `test_get_tracking_branch` is the name of the resource (added from project Properties -> Resources -> Add Existing File). 