### PR TITLE
Allow canonical refs in SetTrackingBranch.

### DIFF
--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -97,7 +97,7 @@ namespace GitHub.Services
                 });
         }
 
-        private static bool IsCanonical(string s)
+        static bool IsCanonical(string s)
         {
             return s.StartsWith("refs/", StringComparison.Ordinal);
         }

--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -71,12 +71,12 @@ namespace GitHub.Services
 
             return Observable.Defer(() =>
             {
-                var remoteBranchName = "refs/remotes/" + remoteName + "/" + branchName;
+                var remoteBranchName = IsCanonical(remoteName) ? remoteName : "refs/remotes/" + remoteName + "/" + branchName;
                 var remoteBranch = repository.Branches[remoteBranchName];
                 // if it's null, it's because nothing was pushed
                 if (remoteBranch != null)
                 {
-                    var localBranchName = "refs/heads/" + branchName;
+                    var localBranchName = IsCanonical(branchName) ? branchName : "refs/heads/" + branchName;
                     var localBranch = repository.Branches[localBranchName];
                     repository.Branches.Update(localBranch, b => b.TrackedBranch = remoteBranch.CanonicalName);
                 }
@@ -95,6 +95,11 @@ namespace GitHub.Services
                         ret = repo.Network.Remotes.Add(r.Remote, UriString.ToUriString(r.Uri.ToRepositoryUrl()));
                     return ret;
                 });
+        }
+
+        private static bool IsCanonical(string s)
+        {
+            return s.StartsWith("refs/", StringComparison.Ordinal);
         }
     }
 }

--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -36,8 +36,8 @@ namespace GitHub.Services
         /// Sets the remote branch that the local branch tracks
         /// </summary>
         /// <param name="repository">The repository to set</param>
-        /// <param name="branchName">The name of the remote</param>
-        /// <param name="remoteName">The name of the branch (local and remote)</param>
+        /// <param name="branchName">The name of the local remote</param>
+        /// <param name="remoteName">The name of the remote branch</param>
         /// <returns></returns>
         IObservable<Unit> SetTrackingBranch(IRepository repository, string branchName, string remoteName);
 


### PR DESCRIPTION
Allow canonical or friendly refs to be passed to `GitClient.SetTrackingBranch`. Also fixed up what appeared to be incorrect doc comments in `IGitClient`.