### PR TITLE
Continuation of GitClient cleanup

### DIFF
--- a/src/GitHub.App/Services/RepositoryPublishService.cs
+++ b/src/GitHub.App/Services/RepositoryPublishService.cs
@@ -40,15 +40,14 @@ namespace GitHub.Services
         {
             return Observable.Defer(() => apiClient.CreateRepository(newRepository, account.Login, account.IsUser)
                                      .Select(remoteRepo => new { RemoteRepo = remoteRepo, LocalRepo = activeRepository }))
-                             .Select(async repo =>
+                             .SelectMany(async repo =>
                              {
                                  await gitClient.SetRemote(repo.LocalRepo, "origin", new Uri(repo.RemoteRepo.CloneUrl));
                                  await gitClient.Push(repo.LocalRepo, "master", "origin");
                                  await gitClient.Fetch(repo.LocalRepo, "origin");
                                  await gitClient.SetTrackingBranch(repo.LocalRepo, "master", "origin");
                                  return repo.RemoteRepo;
-                             })
-                            .Select(t => t.Result);
+                             });
         }
     }
 }


### PR DESCRIPTION
Make sure we don't block when publishing repositories. Continuation of #558 