### PR TITLE
Add some small polish tweaks to PR details header

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -81,7 +81,7 @@
                        Text="{Binding Number, StringFormat=#{0}}"
                        VerticalAlignment="Top"/>
             <TextBlock Text="{Binding Title}"
-                       FontSize="12pt"
+                       FontSize="10pt"
                        TextWrapping="Wrap"/>
         </DockPanel>
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -119,7 +119,7 @@
                            Style="{StaticResource StateIndicator}"/>
 
                 <TextBlock Text="{Binding TargetBranchDisplayName}" VerticalAlignment="Center"/>
-                <ui:OcticonImage Icon="chevron_left" Height="13" Margin="1 0 3 0"/>
+                <ui:OcticonImage Icon="chevron_left" Height="13" Margin="1 3 3 0"/>
                 <TextBlock Text="{Binding SourceBranchDisplayName}" VerticalAlignment="Center" 
                            ToolTip="{Binding SourceBranchDisplayName}"/>
             </StackPanel>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -97,9 +97,9 @@
 
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/> <!-- Open/closed state and branches -->
-                <RowDefinition Height="2"/>
+                <RowDefinition Height="1"/>
                 <RowDefinition Height="Auto"/> <!-- Commit and files changed count -->
-                <RowDefinition Height="2"/>
+                <RowDefinition Height="1"/>
                 <RowDefinition Height="Auto"/> <!-- Checkout button -->
             </Grid.RowDefinitions>
             

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -114,6 +114,7 @@
                 <TextBlock Margin="0 0 12 0"
                            FontWeight="Bold"
                            Text="{Binding State}"
+                           VerticalAlignment="Center"
                            Style="{StaticResource StateIndicator}"/>
 
                 <TextBlock Text="{Binding TargetBranchDisplayName}" VerticalAlignment="Center"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -57,13 +57,13 @@
             <Style x:Key="StateIndicator" TargetType="TextBlock">
                 <Style.Triggers>
                     <Trigger Property="Text" Value="Open">
-                        <Setter Property="Background" Value="#6CC644"/>
+                        <Setter Property="Foreground" Value="#6CC644"/>
                     </Trigger>
                     <Trigger Property="Text" Value="Closed">
-                        <Setter Property="Background" Value="#BD2C00"/>
+                        <Setter Property="Foreground" Value="#BD2C00"/>
                     </Trigger>
                     <Trigger Property="Text" Value="Merged">
-                        <Setter Property="Background" Value="#6E5494"/>
+                        <Setter Property="Foreground" Value="#6E5494"/>
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -111,8 +111,8 @@
 
             <!-- Open/closed state and branches -->
             <StackPanel Grid.Column="2" Grid.Row="0" Orientation="Horizontal" Margin="0 6">
-                <TextBlock Padding="14 4" Margin="0 0 12 0"
-                           Foreground="White"
+                <TextBlock Margin="0 0 12 0"
+                           FontWeight="Bold"
                            Text="{Binding State}"
                            Style="{StaticResource StateIndicator}"/>
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -73,15 +73,16 @@
     <DockPanel Grid.IsSharedSizeScope="True">
         <!-- PR Title and number -->
         <DockPanel DockPanel.Dock="Top"
-                   Margin="8 0 8 8">
+                   Margin="8 4 8 8">
             <TextBlock DockPanel.Dock="Right"
                        FontSize="9pt"
                        Foreground="Gray"
-                       Margin="4 4 0 0"
+                       Margin="4 2 0 0"
                        Text="{Binding Number, StringFormat=#{0}}"
                        VerticalAlignment="Top"/>
             <TextBlock Text="{Binding Title}"
                        FontSize="10pt"
+                       VerticalAlignment="Top"
                        TextWrapping="Wrap"/>
         </DockPanel>
 


### PR DESCRIPTION
![header-changes](https://cloud.githubusercontent.com/assets/1174461/18882991/5dd35648-8496-11e6-8735-82c3a182e8b4.png)

Introducing a couple of small changes to the header:

- De-emphasize PR status by removing the color box, bolding the status text, and adding color to the text. (I was hoping to use uppercase letters but it looks like you have to [roll your own converter for that](https://stackoverflow.com/questions/1762485/how-to-make-all-text-upper-case-capital).)
- Lowered font-size of title (it was conflicting with the pull request title and making the pane feel out of place overall)
- various margins and vertical alignment tweaks.

![image](https://cloud.githubusercontent.com/assets/1174461/18883003/69f9c0ba-8496-11e6-9fac-82982915572c.png)

/cc @grokys since this is targeting your branch