### PR TITLE
Sprinkle some UI polish for description section

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -23,7 +23,9 @@ namespace GitHub.SampleData
 
 ViewModels are responsible for handling the UI on the view they control, but they shouldn't be handling UI for things outside of the view. In this case, we're showing errors in VS outside the view, and that should be handled by the section that is hosting the view.
 
-This requires that errors be propagated from the viewmodel to the view and from there to the host via the IView interface, since hosts don't usually know what they're hosting.";
+This requires that errors be propagated from the viewmodel to the view and from there to the host via the IView interface, since hosts don't usually know what they're hosting.
+
+![An image](https://cloud.githubusercontent.com/assets/1174461/18882991/5dd35648-8496-11e6-8735-82c3a182e8b4.png)";
 
             var gitHubDir = new PullRequestDirectoryViewModel("GitHub");
             var modelsDir = new PullRequestDirectoryViewModel("Models");

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -163,14 +163,14 @@
                 </Grid.RowDefinitions>
 
                 <!-- Author avatar -->
-                <Grid Grid.Column="0" Grid.Row="0" VerticalAlignment="Top" Margin="0 8">
+                <Grid Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Margin="0 6 0 3">
                     <Grid.OpacityMask>
                         <VisualBrush Visual="{Binding ElementName=avatarMask}"/>
                     </Grid.OpacityMask>
-                    <Border Name="avatarMask" Background="White" CornerRadius="3" Width="24" />
+                    <Border Name="avatarMask" Background="White" CornerRadius="3" Width="20" />
                     <Image x:Name="avatar"
-                           Width="24"
-                           Height="24"
+                           Width="20"
+                           Height="20"
                            RenderOptions.BitmapScalingMode="HighQuality"
                            Source="{Binding Author.Avatar}" />
                 </Grid>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -41,6 +41,14 @@
                 <Setter Property="FontSize" Value="12"/>
                 <Setter Property="TextAlignment" Value="Left"/>
                 <Setter Property="PagePadding" Value="0"/>
+
+                <Style.Resources>
+                    <Style TargetType="Image">
+                        <Setter Property="Stretch" Value="UniformToFill" />
+                        <Setter Property="StretchDirection" Value="DownOnly" />
+                        <Setter Property="MaxWidth" Value="{Binding ActualWidth, ElementName=bodyMarkdown}" />
+                    </Style>
+                </Style.Resources>
             </Style>
 
             <Style TargetType="GridViewColumnHeader">
@@ -147,7 +155,7 @@
 
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2"/>
 
-        <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" SharedSizeGroup="LeftMargin"/>
@@ -187,7 +195,7 @@
                                    Margin="2 6 10 6"
                                    DocumentStyle="{StaticResource DocumentStyle}"
                                    RawContent="{Binding Body}"
-                                   ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                                   ScrollViewer.VerticalScrollBarVisibility="Auto" />
 
                 <!-- View on github link -->
                 <ui:GitHubActionLink Grid.Column="2" Grid.Row="2" Margin="0 6" Command="{Binding OpenOnGitHub}">

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -155,7 +155,7 @@
 
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2"/>
 
-        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" SharedSizeGroup="LeftMargin"/>


### PR DESCRIPTION
Couple of small tweaks to the PR description:

- Shrink avatar to 20px
- Minor margin/padding adjustments
- Shrink images if they are included in the markdown file.

![body-changes](https://cloud.githubusercontent.com/assets/1174461/18892810/f41f62da-84bf-11e6-9c72-6fa5714d2adf.png)

/cc @grokys since this targets your branch