### PR TITLE
Moar details polish

### DIFF
--- a/src/GitHub.VisualStudio.UI/Styles/ThemeBlue.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeBlue.xaml
@@ -48,4 +48,6 @@
   <SolidColorBrush x:Key="GitHubComboBoxBorderBrush" Color="#FFCCCEDC" />
 
   <SolidColorBrush x:Key="GitHubTabItemSelectedBorder" Color="#FFD0D7E4" />
+
+  <SolidColorBrush x:Key="GitHubDirectoryIconForeground" Color="#FFF5D367" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeDark.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeDark.xaml
@@ -48,4 +48,6 @@
   <SolidColorBrush x:Key="GitHubComboBoxBorderBrush" Color="#FF434346" />
 
   <SolidColorBrush x:Key="GitHubTabItemSelectedBorder" Color="#FF3F3F46" />
+
+  <SolidColorBrush x:Key="GitHubDirectoryIconForeground" Color="#FF87C3FC" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeDesignTime.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeDesignTime.xaml
@@ -41,4 +41,5 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FF000000" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FF8591A2" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FFFFFFFF" />
+  <SolidColorBrush x:Key="GitHubDirectoryIconForeground" Color="#FFF5D367" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeLight.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeLight.xaml
@@ -48,4 +48,6 @@
   <SolidColorBrush x:Key="GitHubComboBoxBorderBrush" Color="#FFCCCEDC" />
 
   <SolidColorBrush x:Key="GitHubTabItemSelectedBorder" Color="#FFCCCEBD" />
+
+  <SolidColorBrush x:Key="GitHubDirectoryIconForeground" Color="#FFF5D367" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -267,10 +267,10 @@
 
                 <!-- Checkout disabled message -->
                 <TextBlock Margin="0 4" TextWrapping="Wrap">
-                    <ui:OcticonImage Icon="alert" Foreground="Orange" Margin="0 0 0 -4"/>
                     <Run Text="{Binding CheckoutDisabledMessage}"/>
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">
+                            <Setter Property="Foreground" Value="Red" />
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding CheckoutDisabledMessage}" Value="{x:Null}">
                                     <Setter Property="Visibility" Value="Collapsed" />

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -424,7 +424,7 @@
                                     <HierarchicalDataTemplate DataType="{x:Type vm:PullRequestDirectoryViewModel}"
                                                           ItemsSource="{Binding Children}">
                                         <StackPanel Orientation="Horizontal">
-                                            <ui:OcticonImage Icon="file_directory" Foreground="{DynamicResource GitHubVsWindowText}"/>
+                                            <ui:OcticonImage Icon="file_directory" Foreground="{DynamicResource GitHubDirectoryIconForeground}" />
                                             <TextBlock Text="{Binding DirectoryName}" Margin="4 2" VerticalAlignment="Center"/>
                                         </StackPanel>
                                     </HierarchicalDataTemplate>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -187,7 +187,7 @@
 
                 <!-- Branch checked out and neds pull -->
                 <TextBlock TextWrapping="Wrap">
-                    <ui:OcticonImage Icon="sync" Foreground="Orange" Margin="0 0 0 -4"/>
+                    <ui:OcticonImage Icon="alert" Foreground="Orange" Margin="0 0 0 -4"/>
                     <Run>Your local branch is behind by</Run>
                     <Run FontWeight="Bold" Text="{Binding CommitsBehind, StringFormat={}{0} commits.}"/>
                     <Hyperlink Command="{Binding Checkout}">Update</Hyperlink>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -82,6 +82,10 @@
                 <Setter Property="Margin" Value="0 4"/>
             </Style>
 
+            <Style x:Key="CheckoutErrorMessage" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="Red" />
+            </Style>
+
             <!-- Hyperlink has no Visibility property, sigh. Hack around this by making the text 
                  transparent and 1 px in size. -->
             <Style x:Key="HyperlinkHiddenWhenDisabled" TargetType="Hyperlink">
@@ -269,8 +273,7 @@
                 <TextBlock Margin="0 4" TextWrapping="Wrap">
                     <Run Text="{Binding CheckoutDisabledMessage}"/>
                     <TextBlock.Style>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Foreground" Value="Red" />
+                        <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutErrorMessage}">
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding CheckoutDisabledMessage}" Value="{x:Null}">
                                     <Setter Property="Visibility" Value="Collapsed" />

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -424,8 +424,7 @@
                                     <HierarchicalDataTemplate DataType="{x:Type vm:PullRequestDirectoryViewModel}"
                                                           ItemsSource="{Binding Children}">
                                         <StackPanel Orientation="Horizontal">
-                                            <!-- TODO: Use the right icon here -->
-                                            <ui:OcticonImage Icon="briefcase" Foreground="{DynamicResource GitHubVsWindowText}"/>
+                                            <ui:OcticonImage Icon="file_directory" Foreground="{DynamicResource GitHubVsWindowText}"/>
                                             <TextBlock Text="{Binding DirectoryName}" Margin="4 2" VerticalAlignment="Center"/>
                                         </StackPanel>
                                     </HierarchicalDataTemplate>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -222,6 +222,7 @@
 
                 <!-- Local branch exists but is not checked out -->
                 <TextBlock TextWrapping="Wrap">
+                    <ui:OcticonImage Icon="alert" Foreground="Orange" Margin="0 0 0 -4"/>
                     <Run BaselineAlignment="Top">This branch is not currently checked out.</Run>
                     <Hyperlink Command="{Binding Checkout}" Style="{StaticResource HyperlinkHiddenWhenDisabled}">Switch branch</Hyperlink>
                     <TextBlock.Style>
@@ -270,7 +271,7 @@
                 </TextBlock>
 
                 <!-- Checkout disabled message -->
-                <TextBlock Margin="0 4" TextWrapping="Wrap">
+                <TextBlock Margin="0 0 0 4" TextWrapping="Wrap">
                     <Run Text="{Binding CheckoutDisabledMessage}"/>
                     <TextBlock.Style>
                         <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutErrorMessage}">


### PR DESCRIPTION
Cleans up a little more of the details pane:

- Update directory icon
   - Update color of folder to yellow (blue for dark theme)
- Use "alert" icon for status that requires action
- Remove "alert" icon for errors and use red instead.

![details-changes](https://cloud.githubusercontent.com/assets/1174461/19048498/69f1bb44-895b-11e6-8cbb-e00069652370.png)

/cc @grokys since this targets your branch