### PR TITLE
Fix submodule url to be public

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = git@github.com:github/VisualStudioBuildScripts
 [submodule "submodules/externalpackages/StartPage"]
 	path = submodules/externalpackages/StartPage
-	url = git@github.com:editor-tools/StartPage.git
+	url = https://github.com/editor-tools/StartPage.git


### PR DESCRIPTION
The external submodule with the start page extension uses an ssh url, which means anonymous users cannot check it out.

Fixes #571