### PR TITLE
Create Git Avatar Fix

### DIFF
--- a/src/GitHub.App/Models/Account.cs
+++ b/src/GitHub.App/Models/Account.cs
@@ -32,7 +32,7 @@ namespace GitHub.Models
             HasMaximumPrivateRepositories = OwnedPrivateRepos >= PrivateReposInPlan;
 
             bitmapSource.ObserveOn(RxApp.MainThreadScheduler)
-                .Subscribe(x => avatar = x);
+                .Subscribe(x => Avatar = x);
         }
 
         public Account(Octokit.Account account)


### PR DESCRIPTION
The bug mentioned in #403 is fixed by making sure `RaisePropertyChanged()` gets called.
This fix is also contained in #561 