### PR TITLE
Fixes/tracking collection newer comparer

### DIFF
--- a/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
+++ b/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
@@ -539,7 +539,7 @@ namespace GitHub.Collections
                 var old = list[idx];
                 if (newer != null)
                 {
-                    // the object is "older" than the one we have, ignore it
+                    // the object is not "newer" than the one we have, ignore it
                     if (newer(item, old) >= 0)
                         return new ActionData(TheAction.Ignore, list, item, null, idx, idx);
                 }

--- a/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
+++ b/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
@@ -540,7 +540,7 @@ namespace GitHub.Collections
                 if (newer != null)
                 {
                     // the object is "older" than the one we have, ignore it
-                    if (newer(item, old) > 0)
+                    if (newer(item, old) >= 0)
                         return new ActionData(TheAction.Ignore, list, item, null, idx, idx);
                 }
 

--- a/src/TrackingCollectionTests/TrackingCollectionTests.cs
+++ b/src/TrackingCollectionTests/TrackingCollectionTests.cs
@@ -429,8 +429,8 @@ public class TrackingTests : TestBase
         var count = 0;
         var total = 1000;
 
-        var list1 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, i, "Run 1")).ToList());
-        var list2 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, i + 1, "Run 2")).ToList());
+        var list1 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, i, "Run 1")).Reverse().ToList());
+        var list2 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, i + 1, "Run 2")).Reverse().ToList());
 
         ITrackingCollection<Thing> col = new TrackingCollection<Thing>(
             list1.ToObservable(),
@@ -464,7 +464,7 @@ public class TrackingTests : TestBase
 
         Assert.AreEqual(total, count);
         Assert.AreEqual(total, col.Count);
-        CollectionAssert.AreEqual(col, list2.Reverse<Thing>());
+        CollectionAssert.AreEqual(col, list2);
 
         col.Dispose();
     }

--- a/src/TrackingCollectionTests/TrackingCollectionTests.cs
+++ b/src/TrackingCollectionTests/TrackingCollectionTests.cs
@@ -333,7 +333,7 @@ public class TrackingTests : TestBase
         var total = 1000;
 
         var list1 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, i, "Run 1")).ToList());
-        var list2 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, i, "Run 2")).ToList());
+        var list2 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, i + 1, "Run 2")).ToList());
 
         ITrackingCollection<Thing> col = new TrackingCollection<Thing>(
             list1.ToObservable(),
@@ -429,8 +429,8 @@ public class TrackingTests : TestBase
         var count = 0;
         var total = 1000;
 
-        var list1 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, total - i, "Run 1")).ToList());
-        var list2 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, total - i, "Run 2")).ToList());
+        var list1 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, i, "Run 1")).ToList());
+        var list2 = new List<Thing>(Enumerable.Range(1, total).Select(i => GetThing(i, i, i + 1, "Run 2")).ToList());
 
         ITrackingCollection<Thing> col = new TrackingCollection<Thing>(
             list1.ToObservable(),
@@ -464,7 +464,7 @@ public class TrackingTests : TestBase
 
         Assert.AreEqual(total, count);
         Assert.AreEqual(total, col.Count);
-        CollectionAssert.AreEqual(col, list2);
+        CollectionAssert.AreEqual(col, list2.Reverse<Thing>());
 
         col.Dispose();
     }


### PR DESCRIPTION
Edited from #561 as per @grokys request.

While debugging #408 I discovered that `CopyFrom()` is called a quite often for objects that I thought were equivalent.

After some digging I noticed that with the `NewerComparer` property set, objects that are older/newer were being correctly ignored/copied, but objects that were created at the same time were being incorrectly copied.