### PR TITLE
Make ScrollViewer hack reusable.

### DIFF
--- a/src/GitHub.UI/GitHub.UI.csproj
+++ b/src/GitHub.UI/GitHub.UI.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Converters\CountToVisibilityConverter.cs" />
     <Compile Include="Converters\DefaultValueConverter.cs" />
     <Compile Include="Converters\StickieListItemConverter.cs" />
+    <Compile Include="Helpers\ScrollViewerUtilities.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/GitHub.UI/Helpers/ScrollViewerUtilities.cs
+++ b/src/GitHub.UI/Helpers/ScrollViewerUtilities.cs
@@ -4,7 +4,7 @@ using System.Windows.Input;
 namespace GitHub.VisualStudio.UI.Helpers
 {
     /// <summary>
-    /// Utilties for fixing WPF's broken ScrollViewer.
+    /// Utilities for fixing WPF's broken ScrollViewer.
     /// </summary>
     public static class ScrollViewerUtilities
     {

--- a/src/GitHub.UI/Helpers/ScrollViewerUtilities.cs
+++ b/src/GitHub.UI/Helpers/ScrollViewerUtilities.cs
@@ -1,0 +1,46 @@
+﻿using System.Windows;
+using System.Windows.Input;
+
+namespace GitHub.VisualStudio.UI.Helpers
+{
+    /// <summary>
+    /// Utilties for fixing WPF's broken ScrollViewer.
+    /// </summary>
+    public static class ScrollViewerUtilities
+    {
+        /// <summary>
+        /// Fixes mouse wheel scrolling in controls that have a ScrollViewer.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="e">The event arguments.</param>
+        /// <remarks>
+        /// WPF's ScrollViewer is broken in that it doesn't pass scroll events to the parent
+        /// control when it can't scroll any more. Add this method as an event handler to a
+        /// control which has a ScrollViewer in its template to fix this.
+        /// </remarks>
+        public static void FixMouseWheelScroll(object sender, MouseWheelEventArgs e)
+        {
+            try
+            {
+                if (!e.Handled)
+                {
+                    var control = sender as FrameworkElement;
+                    var parent = control.Parent as UIElement;
+
+                    if (parent != null)
+                    {
+                        e.Handled = true;
+                        parent.RaiseEvent(new MouseWheelEventArgs(e.MouseDevice, e.Timestamp, e.Delta)
+                        {
+                            RoutedEvent = UIElement.MouseWheelEvent,
+                            Source = control,
+                        });
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/src/GitHub.VisualStudio.UI/UI/Views/GitHubConnectContent.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/UI/Views/GitHubConnectContent.xaml.cs
@@ -7,6 +7,7 @@ using GitHub.Services;
 using GitHub.Models;
 using System;
 using System.Windows.Input;
+using GitHub.VisualStudio.UI.Helpers;
 
 namespace GitHub.VisualStudio.UI.Views
 {
@@ -17,33 +18,9 @@ namespace GitHub.VisualStudio.UI.Views
             InitializeComponent();
 
             DataContextChanged += (s, e) => ViewModel = e.NewValue as IGitHubConnectSection;
-            repositories.PreviewMouseWheel += Repositories_PreviewMouseWheel;
+            repositories.PreviewMouseWheel += ScrollViewerUtilities.FixMouseWheelScroll;
         }
 
-        void Repositories_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
-        {
-            try
-            {
-                if (!e.Handled)
-                {
-                    var uIElement = base.Parent as UIElement;
-
-                    if (uIElement != null)
-                    {
-                        e.Handled = true;
-                        uIElement.RaiseEvent(new MouseWheelEventArgs(e.MouseDevice, e.Timestamp, e.Delta)
-                        {
-                            RoutedEvent = UIElement.MouseWheelEvent,
-                            Source = this
-                        });
-                    }
-                }
-            }
-            catch
-            {
-                // TODO: Add trace logging: event handler called - who knows what can happen!
-            }
-        }
         void cloneLink_Click(object sender, RoutedEventArgs e)
         {
             cloneLink.IsEnabled = false;


### PR DESCRIPTION
WPF's ScrollViewer is broken, so we need to hack around it. We already had this hack in GitHubConnectContent, so moved the hack to a central place that can be used wherever it's needed.