### PR TITLE
add ICanBeBusy and show indeterminate progress bar

### DIFF
--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -160,6 +160,7 @@
     <Compile Include="Settings\RepositoryUIState.cs" />
     <Compile Include="Settings\UIState.cs" />
     <Compile Include="SimpleJson.cs" />
+    <Compile Include="ViewModels\ICanBeBusy.cs" />
     <Compile Include="ViewModels\IInfoPanel.cs" />
     <Compile Include="ViewModels\IServiceProviderAware.cs" />
     <Compile Include="UI\IView.cs" />

--- a/src/GitHub.Exports/ViewModels/ICanBeBusy.cs
+++ b/src/GitHub.Exports/ViewModels/ICanBeBusy.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GitHub.ViewModels
+{
+    public interface ICanBeBusy
+    {
+        bool IsBusy { get; }
+    }
+}

--- a/src/GitHub.VisualStudio/UI/Views/GitHubPaneView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/GitHubPaneView.xaml
@@ -8,6 +8,7 @@
                             xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI"
                             xmlns:sampleData="clr-namespace:GitHub.SampleData;assembly=GitHub.App"
                             xmlns:uirx="clr-namespace:GitHub.UI;assembly=GitHub.UI.Reactive"
+                            xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
                             xmlns:view="clr-namespace:GitHub.VisualStudio.UI.Views"
                             xmlns:control="clr-namespace:GitHub.VisualStudio.UI.Controls;assembly=GitHub.VisualStudio.UI"
                             Background="{DynamicResource GitHubVsToolWindowBackground}"
@@ -41,6 +42,7 @@
   </UserControl.Resources>
 
   <DockPanel>
+        <ProgressBar IsIndeterminate="True" Visibility="{Binding IsBusy, Converter={ui:BooleanToVisibilityConverter}}" VerticalAlignment="Top" DockPanel.Dock="Top"/>
         <control:InfoPanel x:Name="infoPanel" MessageType="{Binding MessageType}" Message="{Binding Message}" VerticalAlignment="Top" DockPanel.Dock="Top"></control:InfoPanel>
         <StackPanel Margin="6,9,9,5"
                 DockPanel.Dock="Top"
@@ -61,7 +63,7 @@
                DockPanel.Dock="Top"
                Style="{StaticResource PaneHorizontalSeparator}" />
 
-    <UserControl x:Name="container" Content="{Binding Control}" DockPanel.Dock="Top" />
+        <UserControl x:Name="container" Content="{Binding Control}" DockPanel.Dock="Top" IsEnabled="{Binding IsBusy, Converter={ui:InverseBooleanConverter}}" />
 
   </DockPanel>
 </view:GenericGitHubPaneView>

--- a/src/UnitTests/GitHub.VisualStudio/UI/Views/GitHubPaneViewModelTests.cs
+++ b/src/UnitTests/GitHub.VisualStudio/UI/Views/GitHubPaneViewModelTests.cs
@@ -16,6 +16,9 @@ using System.Linq;
 using System.Reactive.Linq;
 using UnitTests;
 using Xunit;
+using System.Windows.Input;
+using GitHub.ViewModels;
+using System.ComponentModel;
 
 public class GitHubPaneViewModelTests : TestBaseClass
 {
@@ -100,6 +103,40 @@ public class GitHubPaneViewModelTests : TestBaseClass
         Assert.Equal(UIViewType.PRList, lastUiControllerJump);
     }
 
+    [Fact]
+    public void ProxyIsBusyFromViewModel_WhenICanBeBusy()
+    {
+        var hostedViewModel = new CanBeBusyBasicViewModel();
+        var view = Substitute.For<IView>();
+        view.ViewModel.Returns(hostedViewModel);
+        viewModel.Control = view;
+
+        Assert.False(viewModel.IsBusy);
+
+        //ensure we make an change of value atleast once
+        hostedViewModel.IsBusy = false;
+        hostedViewModel.IsBusy = true;
+
+        Assert.True(viewModel.IsBusy);
+    }
+
+    [Fact]
+    public void DoNotProxyIsBusyFromViewModel_WhenNotICanBeBusy()
+    {
+        var hostedViewModel = new BasicViewModel();
+        var view = Substitute.For<IView>();
+        view.ViewModel.Returns(hostedViewModel);
+        viewModel.Control = view;
+
+        Assert.False(viewModel.IsBusy);
+
+        //ensure we make an change of value atleast once
+        hostedViewModel.IsBusy = false;
+        hostedViewModel.IsBusy = true;
+
+        Assert.False(viewModel.IsBusy);
+    }
+
     private void RunSteps(IEnumerable<NavStep> steps)
     {
         var observableSteps = steps
@@ -126,5 +163,44 @@ public class GitHubPaneViewModelTests : TestBaseClass
 
         public LoadDirection Direction { get; private set; }
         public UIViewType ViewType { get; private set; }
+    }
+
+    private class CanBeBusyBasicViewModel : BasicViewModel, GitHub.ViewModels.ICanBeBusy
+    {
+    }
+
+    private class BasicViewModel : NotificationAwareObject, GitHub.ViewModels.IViewModel
+    {
+        ICommand cancel;
+        public ICommand Cancel
+        {
+            get { return cancel; }
+            set { cancel = value; this.RaisePropertyChanged(); }
+        }
+
+        bool isBusy;
+        public bool IsBusy
+        {
+            get { return isBusy; }
+            set { isBusy = value; this.RaisePropertyChanged(); }
+        }
+
+        bool isShowing;
+        public bool IsShowing
+        {
+            get { return isShowing; }
+            set { isShowing = value; this.RaisePropertyChanged(); }
+        }
+
+        string title;
+        public string Title
+        {
+            get { return title; }
+            set { title = value; this.RaisePropertyChanged(); }
+        }
+
+        public void Initialize(ViewWithData data)
+        {
+        }
     }
 }


### PR DESCRIPTION
Wanted to help out and thought this issue looks like it shouldn't be too difficult or would require any sweeping changes to implement. 
### Gotchas

`ICanBeBusy` will only work when the class also implements `INotifyPropertyChanged` (basically if the ViewModel inherits from `NotificationAwareObject` then it'll work as expected)
### Overview of changes:
- Added a new interface `ICanBeBusy`
- Updated `GitHubPaneViewModel` to proxy `IsBusy` from hosted views whose VM implement `ICanBeBusy`. 
- I show an indeterminate progress bar on `GitHubPaneView` and disabled hosted view if `IsBusy` set to true.
- Proxy `IsBusy` from `ICanBeBusy` to the `IsBusy` Observable in `SimpleViewUserControl`. 
  _(not sure is this one wanted doing but it looked like it was there for a reason)_
### Other things of note

This PR doesn't actually enable any of the current viewmodels to use `ICanBeBusy` (yet), would prefer some guidance on which one should use this, didn't just want to be disabling any random views as I assumed they are already internally handling there own busy state UI.

What I could do is just stop disabling the view (let the view handle its own disabling if required) and then I feel pretty confident that I could just slap `ICanBeBusy` on anything that currently setting the `IsBusy` property on `BaseViewModel`. We can always add a second interface that explicitly opts into the view being disabled wholesale an `ICanBeReallyBusy` for example.

Fixes #554 
