### PR TITLE
Fix the about version number to match release number.

### DIFF
--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -19,7 +19,7 @@ using Microsoft.VisualStudio.ComponentModelHost;
 namespace GitHub.VisualStudio
 {
     [PackageRegistration(UseManagedResourcesOnly = true)]
-    [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
+    [InstalledProductRegistration("#110", "#112", System.AssemblyVersionInformation.Version, IconResourceID = 400)]
     [Guid(GuidList.guidGitHubPkgString)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     // this is the Git service GUID, so we load whenever it loads


### PR DESCRIPTION
Makes the visual studio about screen show the same version number as the package.

fixes #619 and prevents it form coming out of sync as long as `AssemblyVersionInformation` is updated correctly.