### PR TITLE
Fix checking out PR branch from fork.

### DIFF
--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -399,7 +399,7 @@ namespace GitHub.ViewModels
                     break;
                 case CheckoutMode.Fetch:
                     operation = pullRequestsService
-                        .GetDefaultLocalBranchName(repository, Model.Number, Title)
+                        .GetDefaultLocalBranchName(repository, Model.Number, Model.Title)
                         .SelectMany(x => pullRequestsService.FetchAndCheckout(repository, Model.Number, x));
                     break;
                 case CheckoutMode.Switch:
@@ -408,7 +408,7 @@ namespace GitHub.ViewModels
                 case CheckoutMode.InvalidState:
                     operation = pullRequestsService
                         .UnmarkLocalBranch(repository)
-                        .SelectMany(_ => pullRequestsService.GetDefaultLocalBranchName(repository, Model.Number, Title))
+                        .SelectMany(_ => pullRequestsService.GetDefaultLocalBranchName(repository, Model.Number, Model.Title))
                         .SelectMany(x => pullRequestsService.FetchAndCheckout(repository, Model.Number, x));
                     break;
                 default:


### PR DESCRIPTION
Use the `Model.Title` property which contains the PR title rather than the `BaseViewModel.Title` property which is unused in PullRequestDetailsViewModel.

Fixes #635.