### PR TITLE
Fix the remote handling and tweak the threading a bit

### DIFF
--- a/src/GitHub.App/Extensions/AwaitExtensions.cs
+++ b/src/GitHub.App/Extensions/AwaitExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GitHub.Extensions
+{
+    [NullGuard.NullGuard(NullGuard.ValidationFlags.None)]
+    public static class AwaitExtensions
+    {
+        public static TaskSchedulerAwaiter GetAwaiter(this TaskScheduler scheduler)
+        {
+            Guard.ArgumentNotNull(scheduler, nameof(scheduler));
+            return new TaskSchedulerAwaiter(scheduler);
+        }
+
+        public struct TaskSchedulerAwaiter : INotifyCompletion
+        {
+            readonly TaskScheduler scheduler;
+
+            public bool IsCompleted
+            {
+                get
+                {
+                    bool isThreadPoolThread = Thread.CurrentThread.IsThreadPoolThread;
+                    return (scheduler == TaskScheduler.Default & isThreadPoolThread) || (scheduler == TaskScheduler.Current && TaskScheduler.Current != TaskScheduler.Default);
+                }
+            }
+
+            public TaskSchedulerAwaiter(TaskScheduler scheduler)
+            {
+                Guard.ArgumentNotNull(scheduler, nameof(scheduler));
+                this.scheduler = scheduler;
+            }
+
+            public void OnCompleted(Action continuation)
+            {
+                Task.Factory.StartNew(continuation, CancellationToken.None, TaskCreationOptions.None, scheduler);
+            }
+
+            public void GetResult()
+            {
+            }
+        }
+    }
+}

--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Caches\CacheItem.cs" />
     <Compile Include="Caches\ImageCache.cs" />
     <Compile Include="Extensions\AkavacheExtensions.cs" />
+    <Compile Include="Extensions\AwaitExtensions.cs" />
     <Compile Include="Extensions\EnvironmentExtensions.cs" />
     <Compile Include="Factories\UIFactory.cs" />
     <Compile Include="GlobalSuppressions.cs" />

--- a/src/GitHub.App/GlobalSuppressions.cs
+++ b/src/GitHub.App/GlobalSuppressions.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Naming", "CA1703:ResourceStringsShouldBeSpelledCorrectly", MessageId = "Git", Scope = "resource", Target = "GitHub.Resources.resources")]
 [assembly: SuppressMessage("Microsoft.Performance", "CA1800:DoNotCastUnnecessarily", Scope = "member", Target = "GitHub.Caches.CredentialCache.#InsertObject`1(System.String,!!0,System.Nullable`1<System.DateTimeOffset>)")]
 [assembly: SuppressMessage("Microsoft.Naming", "CA1703:ResourceStringsShouldBeSpelledCorrectly", MessageId = "Git", Scope = "resource", Target = "GitHub.App.Resources.resources")]
+[assembly: SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Scope = "type", Target = "GitHub.Extensions.AwaitExtensions+TaskSchedulerAwaiter")]
 // This file is used by Code Analysis to maintain SuppressMessage 
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given 

--- a/src/GitHub.Extensions/Guard.cs
+++ b/src/GitHub.Extensions/Guard.cs
@@ -15,11 +15,12 @@ namespace GitHub.Extensions
             string message = String.Format(CultureInfo.InvariantCulture, "Failed Null Check on '{0}'", name);
 #if DEBUG
             if (!InUnitTestRunner())
-            {
                 Debug.Fail(message);
-            }
-#endif
+            else
+                throw new ArgumentNullException(name, message);
+#else
             throw new ArgumentNullException(name, message);
+#endif
         }
 
         public static void ArgumentNonNegative(int value, string name)
@@ -29,11 +30,12 @@ namespace GitHub.Extensions
             var message = String.Format(CultureInfo.InvariantCulture, "The value for '{0}' must be non-negative", name);
 #if DEBUG
             if (!InUnitTestRunner())
-            {
                 Debug.Fail(message);
-            }
-#endif
+            else
+                throw new ArgumentException(message, name);
+#else
             throw new ArgumentException(message, name);
+#endif
         }
 
         /// <summary>
@@ -47,11 +49,12 @@ namespace GitHub.Extensions
             string message = String.Format(CultureInfo.InvariantCulture, "The value for '{0}' must not be empty", name);
 #if DEBUG
             if (!InUnitTestRunner())
-            {
                 Debug.Fail(message);
-            }
-#endif
+            else
+                throw new ArgumentException(message, name);
+#else
             throw new ArgumentException(message, name);
+#endif
         }
 
         public static void ArgumentInRange(int value, int minValue, string name)
@@ -64,11 +67,12 @@ namespace GitHub.Extensions
                 minValue);
 #if DEBUG
             if (!InUnitTestRunner())
-            {
                 Debug.Fail(message);
-            }
-#endif
+            else
+                throw new ArgumentOutOfRangeException(name, message);
+#else
             throw new ArgumentOutOfRangeException(name, message);
+#endif
         }
 
         public static void ArgumentInRange(int value, int minValue, int maxValue, string name)
@@ -82,11 +86,12 @@ namespace GitHub.Extensions
                 maxValue);
 #if DEBUG
             if (!InUnitTestRunner())
-            {
                 Debug.Fail(message);
-            }
-#endif
+            else
+                throw new ArgumentOutOfRangeException(name, message);
+#else
             throw new ArgumentOutOfRangeException(name, message);
+#endif
         }
 
         // Borrowed from Splat.


### PR DESCRIPTION
@grokys 

The branch is blowing up on the `VisualStudio` repo because some of the PRs we have have had their original repos deleted, and the `GitReferenceModel` code can't handle that. I've tweaked the `Guard` methods so that they don't actually throw in debug mode outside of unit tests, so we don't crash while we test (they're already asserting, throwing is useless).

We should probably be storing the `IRepositoryModel` itself in `GitReferenceModel`, instead of the clone url, that would make things a lot easier. ~~As is, we probably need to use `UriString? RepositoryCloneUrl` to work around the nullness there.~~ This is on the target branch already.

In the meantime, I got another crash due to my clone using ssh urls, and none of the `GitClient` new methods calling `GetHttpRemote` to make sure they're using http urls that we can handle, so I went ahead and did that for all of them. Since `GetHttpRemote` is an async call, we can switch to a background thread from it for "free" by doing `ConfigureAwait`, so we don't have to manually do `Task.Factory.StartNew`.

And while I was at it, following the comment on https://github.com/github/VisualStudio/pull/528#discussion_r81361057 which I think is a pretty neat way of switching to background threads if you're in the main thread, I added an extension method to do it so we don't have to take a dependency on `Microsoft.VisualStudio.Threading` for it.

This is targeting the diff branch for now, once that's in master I'll retarget it.
