### PR TITLE
Use BitmapImageMoniker instead of BitmapResourceID to reference logo

### DIFF
--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -110,6 +110,9 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>True</Private>

--- a/src/GitHub.VisualStudio/Settings/Guids.cs
+++ b/src/GitHub.VisualStudio/Settings/Guids.cs
@@ -8,10 +8,11 @@ namespace GitHub.VisualStudio
         public const string guidGitHubCmdSetString = "c4c91892-8881-4588-a5d9-b41e8f540f5a";
         public const string guidGitHubToolbarCmdSetString = "C5F1193E-F300-41B3-B4C4-5A703DD3C1C6";
         public const string guidContextMenuSetString = "31057D08-8C3C-4C5B-9F91-8682EA08EC27";
-        public const string guidImageMoniker = "27841f47-070a-46d6-90be-a5cbbfc724ac";
+        public const string guidImageMonikerString = "27841f47-070a-46d6-90be-a5cbbfc724ac";
 
         public static readonly Guid guidGitHubCmdSet = new Guid(guidGitHubCmdSetString);
         public static readonly Guid guidGitHubToolbarCmdSet = new Guid(guidGitHubToolbarCmdSetString);
         public static readonly Guid guidContextMenuSet = new Guid(guidContextMenuSetString);
+        public static readonly Guid guidImageMoniker = new Guid(guidImageMonikerString);
     }
 }

--- a/src/GitHub.VisualStudio/UI/GitHubPane.cs
+++ b/src/GitHub.VisualStudio/UI/GitHubPane.cs
@@ -44,14 +44,12 @@ namespace GitHub.VisualStudio.UI
         public GitHubPane() : base(null)
         {
             Caption = "GitHub";
-
-            // Set the image that will appear on the tab of the window frame
-            // when docked with an other window
-            // The resource ID correspond to the one defined in the resx file
-            // while the Index is the offset in the bitmap strip. Each image in
-            // the strip being 16x16.
-            BitmapResourceID = 301;
-            BitmapIndex = 1;
+            
+            BitmapImageMoniker = new Microsoft.VisualStudio.Imaging.Interop.ImageMoniker()
+            {
+                Guid = GuidList.guidImageMoniker,
+                Id = 1
+            };
             ToolBar = new CommandID(GuidList.guidGitHubToolbarCmdSet, PkgCmdIDList.idGitHubToolbar);
             ToolBarLocation = (int)VSTWT_LOCATION.VSTWT_TOP;
 


### PR DESCRIPTION
If we use an `ImageMoniker` instead of setting the `BitmapResourceID`  on the `ToolWindowPane` then the icon displays correctly.

https://msdn.microsoft.com/en-us/library/mt628927.aspx was an interesting read on `ImageMoniker`'s which led me to this fix.

![image](https://cloud.githubusercontent.com/assets/166440/19739235/10dffb7e-9bb2-11e6-9040-e93372bb5b7c.png)

### Warning
I had to add a dependency on  `Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime` to get access to the `ImageMoniker` class not sure what effect that might have in terms of compatibility with other versions of VS.

fixes #642