### PR TITLE
Fixed branch name in PR created succesfully message

### DIFF
--- a/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
@@ -108,6 +108,7 @@ namespace GitHub.ViewModels
                         notifications.ShowError(error?.Message ?? ex.Message);
                         return Observable.Empty<IPullRequestModel>();
                     }))
+                    
             .OnExecuteCompleted(pr =>
             {
                 notifications.ShowMessage(String.Format(CultureInfo.CurrentCulture, Resources.PRCreatedUpstream, TargetBranch.Repository.Owner + "/" + TargetBranch.Repository.Name,

--- a/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
@@ -111,9 +111,9 @@ namespace GitHub.ViewModels
 
             .OnExecuteCompleted(pr =>
             {
-                notifications.ShowMessage(String.Format(CultureInfo.CurrentCulture, Resources.PRCreatedUpstream, TargetBranch.Id,
-                    TargetBranch.Repository.CloneUrl.ToRepositoryUrl().Append("pull/" + pr.Number)));
-            });
+				notifications.ShowMessage(String.Format(CultureInfo.CurrentCulture, Resources.PRCreatedUpstream, TargetBranch.Repository.Owner + "/" + TargetBranch.Repository.Name,
+					TargetBranch.Repository.CloneUrl.ToRepositoryUrl().Append("pull/" + pr.Number)));
+			});
 
             isExecuting = CreatePullRequest.IsExecuting.ToProperty(this, x => x.IsExecuting);
 

--- a/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
@@ -108,12 +108,11 @@ namespace GitHub.ViewModels
                         notifications.ShowError(error?.Message ?? ex.Message);
                         return Observable.Empty<IPullRequestModel>();
                     }))
-
             .OnExecuteCompleted(pr =>
             {
-				notifications.ShowMessage(String.Format(CultureInfo.CurrentCulture, Resources.PRCreatedUpstream, TargetBranch.Repository.Owner + "/" + TargetBranch.Repository.Name,
-					TargetBranch.Repository.CloneUrl.ToRepositoryUrl().Append("pull/" + pr.Number)));
-			});
+                notifications.ShowMessage(String.Format(CultureInfo.CurrentCulture, Resources.PRCreatedUpstream, TargetBranch.Repository.Owner + "/" + TargetBranch.Repository.Name,
+                    TargetBranch.Repository.CloneUrl.ToRepositoryUrl().Append("pull/" + pr.Number)));
+            });
 
             isExecuting = CreatePullRequest.IsExecuting.ToProperty(this, x => x.IsExecuting);
 


### PR DESCRIPTION
Changed target name of successful PR creation message from <owner>/<target_branch_name> (e.g. jswietek/master) to <owner>/<repo_name> (e.g. jswietek/VisualStudio)
