### PR TITLE
Prevent AuthorizationException crashing VS in PullRequestListViewModel

### DIFF
--- a/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
@@ -108,6 +108,10 @@ namespace GitHub.ViewModels
 
             pullRequests.OriginalCompleted
                 .ObserveOn(RxApp.MainThreadScheduler)
+                .Catch<System.Reactive.Unit, Octokit.AuthorizationException>(ex => {
+                    //TODO handle the auth exception here
+                    return Observable.Empty<System.Reactive.Unit>();
+                })
                 .Subscribe(_ =>
                 {
                     if (listSettings.SelectedAuthor != null)

--- a/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
@@ -109,8 +109,7 @@ namespace GitHub.ViewModels
             pullRequests.OriginalCompleted
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Catch<System.Reactive.Unit, Octokit.AuthorizationException>(ex => {
-                    //TODO handle the auth exception here
-                    return Observable.Empty<System.Reactive.Unit>();
+                    return repositoryHost.LogOut();
                 })
                 .Subscribe(_ =>
                 {

--- a/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
@@ -108,7 +108,9 @@ namespace GitHub.ViewModels
 
             pullRequests.OriginalCompleted
                 .ObserveOn(RxApp.MainThreadScheduler)
-                .Catch<System.Reactive.Unit, Octokit.AuthorizationException>(ex => {
+                .Catch<System.Reactive.Unit, Octokit.AuthorizationException>(ex =>
+                {
+                    // TODO: Do some decent logging here
                     return repositoryHost.LogOut();
                 })
                 .Subscribe(_ =>


### PR DESCRIPTION
Just catching the Exception in OriginalCompleted is enough to prevent VS crash.

This does not do anything with the exception for the moment it just swallows it. 

Maybe there needs to be some central way of announcing Signed in/Signed out? (unless there is and I've missed it. :) )

Fixes #633
