### PR TITLE
added .editorconfig to help prevent wrong indent types Tabs vs Spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# top-most EditorConfig file
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Must have editor config plugin installed to have any effect otherwise it has zero effect and doesn't harm anything.

Can be installed from https://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328
