### PR TITLE
Use 'Sign in' rather than 'Login'

### DIFF
--- a/src/GitHub.App/Resources.Designer.cs
+++ b/src/GitHub.App/Resources.Designer.cs
@@ -151,7 +151,7 @@ namespace GitHub.App {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Make sure to use your password and not a Personal Access token to log in..
+        ///   Looks up a localized string similar to Make sure to use your password and not a Personal Access token to sign in..
         /// </summary>
         internal static string LoginFailedForbiddenMessage {
             get {
@@ -169,7 +169,7 @@ namespace GitHub.App {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Login failed..
+        ///   Looks up a localized string similar to Sign in failed..
         /// </summary>
         internal static string LoginFailedText {
             get {
@@ -412,7 +412,7 @@ namespace GitHub.App {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enter a login authentication code here.
+        ///   Looks up a localized string similar to Enter a sign in authentication code here.
         /// </summary>
         internal static string TwoFactorUnknown {
             get {

--- a/src/GitHub.App/Resources.resx
+++ b/src/GitHub.App/Resources.resx
@@ -148,13 +148,13 @@
     <value>(forgot your password?)</value>
   </data>
   <data name="LoginFailedForbiddenMessage" xml:space="preserve">
-    <value>Make sure to use your password and not a Personal Access token to log in.</value>
+    <value>Make sure to use your password and not a Personal Access token to sign in.</value>
   </data>
   <data name="LoginFailedMessage" xml:space="preserve">
     <value>Check your username and password, then try again</value>
   </data>
   <data name="LoginFailedText" xml:space="preserve">
-    <value>Login failed.</value>
+    <value>Sign in failed.</value>
   </data>
   <data name="LoginTitle" xml:space="preserve">
     <value>Connect To GitHub</value>
@@ -235,7 +235,7 @@
     <value>Two-Factor authentication required</value>
   </data>
   <data name="TwoFactorUnknown" xml:space="preserve">
-    <value>Enter a login authentication code here</value>
+    <value>Enter a sign in authentication code here</value>
   </data>
   <data name="UsernameOrEmailValidatorEmpty" xml:space="preserve">
     <value>Please enter your username or email address</value>

--- a/src/GitHub.VisualStudio.UI/Resources.Designer.cs
+++ b/src/GitHub.VisualStudio.UI/Resources.Designer.cs
@@ -412,7 +412,7 @@ namespace GitHub.VisualStudio.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Login failed..
+        ///   Looks up a localized string similar to Sign in failed..
         /// </summary>
         public static string LoginFailedText {
             get {
@@ -421,7 +421,7 @@ namespace GitHub.VisualStudio.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Login.
+        ///   Looks up a localized string similar to Sign in.
         /// </summary>
         public static string LoginLink {
             get {
@@ -502,7 +502,7 @@ namespace GitHub.VisualStudio.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You are not logged in to {0}, so certain git operations may fail. [Login now]({1}).
+        ///   Looks up a localized string similar to You are not signed in to {0}, so certain git operations may fail. [Sign in now]({1}).
         /// </summary>
         public static string NotLoggedInMessage {
             get {
@@ -673,7 +673,7 @@ namespace GitHub.VisualStudio.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sign In.
+        ///   Looks up a localized string similar to Sign in.
         /// </summary>
         public static string SignInLink {
             get {

--- a/src/GitHub.VisualStudio.UI/Resources.resx
+++ b/src/GitHub.VisualStudio.UI/Resources.resx
@@ -184,7 +184,7 @@
     <value>File Name</value>
   </data>
   <data name="NotLoggedInMessage" xml:space="preserve">
-    <value>You are not logged in to {0}, so certain git operations may fail. [Login now]({1})</value>
+    <value>You are not signed in to {0}, so certain git operations may fail. [Sign in now]({1})</value>
   </data>
   <data name="WikiNavigationItemText" xml:space="preserve">
     <value>Wiki</value>
@@ -259,7 +259,7 @@
     <value>Private Repository</value>
   </data>
   <data name="LoginFailedText" xml:space="preserve">
-    <value>Login failed.</value>
+    <value>Sign in failed.</value>
   </data>
   <data name="localPathText" xml:space="preserve">
     <value>Local path</value>
@@ -298,7 +298,7 @@
     <value>Check your username and password, then try again</value>
   </data>
   <data name="LoginLink" xml:space="preserve">
-    <value>Login</value>
+    <value>Sign in</value>
   </data>
   <data name="ForgotPasswordLink" xml:space="preserve">
     <value>(forgot your password?)</value>
@@ -343,6 +343,6 @@
     <value>Get Started</value>
   </data>
   <data name="SignInLink" xml:space="preserve">
-    <value>Sign In</value>
+    <value>Sign in</value>
   </data>
 </root>

--- a/src/UnitTests/GitHub.App/ViewModels/LoginToGitHubViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/LoginToGitHubViewModelTests.cs
@@ -37,7 +37,7 @@ public class LoginToGitHubViewModelTests
                 loginViewModel.Login.Execute(null);
             }
 
-            Assert.Equal("Make sure to use your password and not a Personal Access token to log in.",
+            Assert.Equal("Make sure to use your password and not a Personal Access token to sign in.",
                 message);
         }
     }


### PR DESCRIPTION
Replaced all instances of 'login' and equivalent with 'sign in'

fixes #657 
![image](https://cloud.githubusercontent.com/assets/166440/19985401/78a8c3e0-a20a-11e6-9c75-bf7a459c7b9d.png)

more in keeping with github.com (as proof)

![image](https://cloud.githubusercontent.com/assets/166440/19985430/970963b2-a20a-11e6-8ea3-f84230c4ee04.png)
