### PR TITLE
Fix LinkDropDown.

### DIFF
--- a/src/GitHub.UI/Controls/ComboBoxes/LinkDropDown.cs
+++ b/src/GitHub.UI/Controls/ComboBoxes/LinkDropDown.cs
@@ -9,14 +9,23 @@ namespace GitHub.UI
     public class LinkDropDown : ComboBox
     {
         /// <summary>
-        /// Defines the <see cref="LinkText"/> property.
+        /// Defines the <see cref="LinkItem"/> property.
         /// </summary>
-        static readonly DependencyPropertyKey LinkTextPropertyKey =
+        static readonly DependencyPropertyKey LinkItemPropertyKey =
             DependencyProperty.RegisterReadOnly(
-                "LinkText",
-                typeof(string),
+                "LinkItem",
+                typeof(object),
                 typeof(LinkDropDown),
                 new FrameworkPropertyMetadata(string.Empty));
+
+        /// <summary>
+        /// Defines the <see cref="LinkItemTemplate"/> property.
+        /// </summary>
+        public static readonly DependencyProperty LinkItemTemplateProperty =
+            DependencyProperty.Register(
+                "LinkItemTemplate",
+                typeof(DataTemplate),
+                typeof(LinkDropDown));
 
         /// <summary>
         /// Defines the <see cref="Header"/> property.
@@ -27,10 +36,10 @@ namespace GitHub.UI
                 new FrameworkPropertyMetadata(typeof(LinkDropDown), HeaderChanged));
 
         /// <summary>
-        /// Defines the readonly <see cref="LinkText"/> property.
+        /// Defines the readonly <see cref="LinkItem"/> property.
         /// </summary>
-        public static readonly DependencyProperty LinkTextProperty =
-            LinkTextPropertyKey.DependencyProperty;
+        public static readonly DependencyProperty LinkItemProperty =
+            LinkItemPropertyKey.DependencyProperty;
 
         /// <summary>
         /// Initializes static members of the <see cref="LinkDropDown"/> class.
@@ -43,7 +52,7 @@ namespace GitHub.UI
         }
 
         /// <summary>
-        /// Gets or sets a header to use as the link text when no item is selected.
+        /// Gets or sets a header to use in the link when no item is selected.
         /// </summary>
         public object Header
         {
@@ -52,63 +61,37 @@ namespace GitHub.UI
         }
 
         /// <summary>
-        /// Gets the text to display in the link.
+        /// Gets the data to display in the link.
         /// </summary>
-        public string LinkText
+        public object LinkItem
         {
-            get { return (string)GetValue(LinkTextProperty); }
-            private set { SetValue(LinkTextPropertyKey, value); }
+            get { return (string)GetValue(LinkItemProperty); }
+            private set { SetValue(LinkItemPropertyKey, value); }
+        }
+
+        /// <summary>
+        /// Gets the template to use to display the link.
+        /// </summary>
+        public object LinkItemTemplate
+        {
+            get { return (string)GetValue(LinkItemTemplateProperty); }
+            set { SetValue(LinkItemTemplateProperty, value); }
         }
 
         protected override void OnSelectionChanged(SelectionChangedEventArgs e)
         {
-           UpdateLinkText();
+           UpdateLinkItem();
         }
 
         private static void HeaderChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var source = (LinkDropDown)d;
-            source.UpdateLinkText();
+            source.UpdateLinkItem();
         }
 
-        private void UpdateLinkText()
+        private void UpdateLinkItem()
         {
-            if (SelectedItem != null)
-            {
-                var item = SelectedItem;
-                
-                // HACK: The correct way to do this is to use a ContentPresenter in the control
-                // template to display the link text and do a:
-                //
-                //     ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                //
-                // to correctly display the DisplayMemberPath. However I couldn't work out how
-                // to do it like this and get the link text looking right. This is a hack that
-                // will work as long as DisplayMemberPath is just a property name, which is
-                // all we need right now.
-                if (string.IsNullOrWhiteSpace(DisplayMemberPath))
-                {                   
-                    if (ItemTemplate == null)
-                    {
-                        LinkText = item.ToString();
-                    }
-
-                    else
-                    {
-                        
-                    }
-                }
-
-                else
-                {
-                    var property = item.GetType().GetProperty(DisplayMemberPath);
-                    LinkText = property?.GetValue(item)?.ToString();
-                }
-            }
-            else
-            {
-                LinkText = Header.ToString();
-            }
+            LinkItem = SelectedItem ?? Header;
         }
     }
 }

--- a/src/GitHub.UI/Converters/BranchNameConverter.cs
+++ b/src/GitHub.UI/Converters/BranchNameConverter.cs
@@ -15,16 +15,24 @@ namespace GitHub.UI.Converters
 
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            var branch = (IBranch)values[0];
-            var repo = (IRemoteRepositoryModel)branch.Repository;
-            var activeRepo = (IRepositoryModel)values[1];
-           
-            if (repo.Parent == null && activeRepo.Owner != repo.Owner)
-            {
-                return repo.Owner + ":" + branch.Name;
-            }
+            var branch = values[0] as IBranch;
+            var activeRepo = values[1] as IRepositoryModel;
 
-            return branch.DisplayName;
+            if (branch != null && activeRepo != null)
+            {
+                var repo = (IRemoteRepositoryModel)branch.Repository;
+
+                if (repo.Parent == null && activeRepo.Owner != repo.Owner)
+                {
+                    return repo.Owner + ":" + branch.Name;
+                }
+
+                return branch.DisplayName;
+            }
+            else
+            {
+                return values[0]?.ToString();
+            }
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/src/GitHub.VisualStudio.UI/Styles/LinkDropDown.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/LinkDropDown.xaml
@@ -11,35 +11,37 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleButton">
-                    <TextBlock>
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
-                                <Style.Triggers>
-                                    <MultiDataTrigger>
-                                        <MultiDataTrigger.Conditions>
-                                            <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
-                                            <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="true"/>
-                                            <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource TemplatedParent}}" Value="false"/>
-                                        </MultiDataTrigger.Conditions>
-                                        <MultiDataTrigger.Setters>
-                                            <Setter Property="TextDecorations" Value="Underline"/>
+                    <Grid>
+                        <Border Background="Transparent"
+                                BorderBrush="{TemplateBinding Foreground}">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Style.Triggers>
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}" Value="true"/>
+                                                <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}" Value="true"/>
+                                                <Condition Binding="{Binding Path=IsChecked, RelativeSource={RelativeSource TemplatedParent}}" Value="false"/>
+                                            </MultiDataTrigger.Conditions>
+                                            <MultiDataTrigger.Setters>
+                                                <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                                                <Setter Property="FrameworkElement.Cursor" Value="Hand"/>
+                                            </MultiDataTrigger.Setters>
+                                        </MultiDataTrigger>
+                                        <DataTrigger Binding="{Binding Path=IsPressed, RelativeSource={RelativeSource TemplatedParent}}" Value="true">
+                                            <Setter Property="BorderThickness" Value="0,0,0,1"/>
                                             <Setter Property="FrameworkElement.Cursor" Value="Hand"/>
-                                        </MultiDataTrigger.Setters>
-                                    </MultiDataTrigger>
-                                    <Trigger Property="IsEnabled" Value="False">
-                                        <Setter Property="Foreground" Value="{StaticResource GHBlueLinkButtonDisabledBrush}"/>
-                                    </Trigger>
-                                    <DataTrigger Binding="{Binding Path=IsPressed, RelativeSource={RelativeSource TemplatedParent}}" Value="true">
-                                        <Setter Property="TextDecorations" Value="Underline"/>
-                                        <Setter Property="FrameworkElement.Cursor" Value="Hand"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                                <Setter Property="Cursor" Value="Hand"/>
-                            </Style>
-                        </TextBlock.Style>
-                        <Run Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}"/>
-                        <Polygon Margin="2,0,0,1" Fill="{TemplateBinding Foreground}" Points="0,0 8,0 4,4 0,0"/>
-                    </TextBlock>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+                        </Border>
+                        <Polygon Margin="2,0,0,3" 
+                                 HorizontalAlignment="Right"
+                                 VerticalAlignment="Bottom"
+                                 Fill="{TemplateBinding Foreground}"
+                                 Points="0,0 8,0 4,4 0,0"/>
+                    </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -51,11 +53,34 @@
             <Setter.Value>
                 <ControlTemplate TargetType="ui:LinkDropDown">
                     <Grid>
-                        <ToggleButton Content="{TemplateBinding LinkText}"
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="14"/>
+                        </Grid.ColumnDefinitions>
+
+                        <ToggleButton Grid.ColumnSpan="2"
                                       Foreground="{TemplateBinding Foreground}"
                                       IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                      IsTabStop="False"
-                                      Style="{StaticResource HyperLinkToggleButton}"/>
+                                      Style="{StaticResource HyperLinkToggleButton}"
+                                      Margin="0,0,0,1"/>
+                        <ContentPresenter ContentTemplate="{TemplateBinding LinkItemTemplate}"
+                                          Content="{TemplateBinding LinkItem}"
+                                          ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          IsHitTestVisible="false"
+                                          Margin="{TemplateBinding Padding}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                            <ContentPresenter.Style>
+                                <Style TargetType="ContentPresenter">
+                                    <Style.Triggers>
+                                        <Trigger Property="IsEnabled" Value="False">
+                                            <Setter Property="Opacity" Value="0.5"/>
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ContentPresenter.Style>
+                        </ContentPresenter>
                         <Popup Name="PART_Popup"
                                AllowsTransparency="True"
                                IsOpen="{TemplateBinding IsDropDownOpen}"

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestCreationView.xaml
@@ -115,6 +115,18 @@
                                 </TextBlock>
                             </DataTemplate>
                         </ui:LinkDropDown.ItemTemplate>
+                        <ui:LinkDropDown.LinkItemTemplate>
+                            <DataTemplate DataType="models:BranchModel">
+                                <TextBlock>
+                                    <TextBlock.Text>
+                                        <MultiBinding Converter="{StaticResource BranchNameConverter}">
+                                            <Binding/>
+                                            <Binding Path="ViewModel.GitHubRepository" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestCreationView}}" />
+                                        </MultiBinding>
+                                    </TextBlock.Text>
+                                </TextBlock>
+                            </DataTemplate>
+                        </ui:LinkDropDown.LinkItemTemplate>
                     </ui:LinkDropDown>
                     <ui:OcticonImage Height="13"
                                      Margin="5,2,3,0"


### PR DESCRIPTION
To allow it to work with data templates. This removes the previous hack in `UpdateLinkText` and adds a `LinkItemTemplate` property that can be used to supply a data template with which to display the selected item.

Also had to modify `BranchNameConverter` slightly to accept plain strings as input as when the `LinkDropDown` is using the `Header`
property as its `LinkItem` this will get passed through the converter too.