### PR TITLE
Switch to main thread on repository creation.

### DIFF
--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -72,6 +72,10 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.14.1.131\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -3,9 +3,10 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Reactive;
 using System.Reactive.Linq;
-using Rothko;
 using GitHub.Extensions;
+using Microsoft.VisualStudio.Shell;
 using NLog;
+using Rothko;
 
 namespace GitHub.Services
 {
@@ -39,11 +40,15 @@ namespace GitHub.Services
             Guard.ArgumentNotEmptyString(repositoryName, nameof(repositoryName));
             Guard.ArgumentNotEmptyString(repositoryPath, nameof(repositoryPath));
 
-            return Observable.Start(() =>
+            return Observable.StartAsync(async () =>
             {
                 string path = Path.Combine(repositoryPath, repositoryName);
 
                 operatingSystem.Directory.CreateDirectory(path);
+
+                // Once we've done IO switch to the main thread to call vsGitServices.Clone() as this must be
+                // called on the main thread.
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 try
                 {


### PR DESCRIPTION
Before checking out created repository, this is needed because `vsGitServices.Clone` ends up calling into `AsyncPackage.GetService` which cannot be called from a background thread.