### PR TITLE
Don't use RxUI for Repositories binding.

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
@@ -243,7 +243,7 @@
       <Grid Margin="0">
         <ListBox x:Name="repositoryList"
                  HorizontalContentAlignment="Stretch"
-                 ItemsSource="{Binding Repositories}"
+                 ItemsSource="{Binding Path=RepositoriesView, RelativeSource={RelativeSource AncestorType={x:Type local:GenericRepositoryCloneControl}}}"
                  SelectedItem="{Binding SelectedRepository}"
                  Style="{DynamicResource LightListBox}">
           <ListBox.GroupStyle>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml.cs
@@ -33,25 +33,45 @@ namespace GitHub.VisualStudio.UI.Views.Controls
     {
         readonly Dictionary<string, RepositoryGroup> groups = new Dictionary<string, RepositoryGroup>();
 
+        static readonly DependencyPropertyKey RepositoriesViewPropertyKey =
+            DependencyProperty.RegisterReadOnly(
+                nameof(RepositoriesView),
+                typeof(ICollectionView),
+                typeof(RepositoryCloneControl),
+                new PropertyMetadata(null));
+
+        public static readonly DependencyProperty RepositoriesViewProperty = RepositoriesViewPropertyKey.DependencyProperty;
+
         public RepositoryCloneControl()
         {
             InitializeComponent();
 
             this.WhenActivated(d =>
             {
-                d(this.OneWayBind(ViewModel, vm => vm.Repositories, v => v.repositoryList.ItemsSource, CreateRepositoryListCollectionView));
                 d(repositoryList.Events().MouseDoubleClick.InvokeCommand(this, x => x.ViewModel.CloneCommand));
                 d(ViewModel.CloneCommand.Subscribe(_ => NotifyDone()));
             });
+
             IsVisibleChanged += (s, e) =>
             {
                 if (IsVisible)
                     this.TryMoveFocus(FocusNavigationDirection.First).Subscribe();
             };
+
+            this.WhenAnyValue(x => x.ViewModel.Repositories, CreateRepositoryListCollectionView).Subscribe(x => RepositoriesView = x);
+        }
+
+        public ICollectionView RepositoriesView
+        {
+            get { return (ICollectionView)GetValue(RepositoriesViewProperty); }
+            private set { SetValue(RepositoriesViewPropertyKey, value); }
         }
 
         ListCollectionView CreateRepositoryListCollectionView(IEnumerable<IRepositoryModel> repositories)
         {
+            if (repositories == null)
+                return null;
+
             var view = new ListCollectionView((IList)repositories);
             Debug.Assert(view.GroupDescriptions != null, "view.GroupDescriptions is null");
             view.GroupDescriptions.Add(new RepositoryGroupDescription(this));


### PR DESCRIPTION
As it was sometimes setting the selection on the `ListBox` without user interaction. Instead, use XAML bindings. Unfortunately this required binding to a dependency property on the view itself. Better solutions
moving forward would be:

- Declare the collection view in XAML. This would require the Group classes to be made public, but they have a dependency on state in the view.
- Declate the collection view in the view model.

I didn't implement either of these solutions as I felt the changes would be too impactful on the codebase at this point in time.