### PR TITLE
Catch exceptions thrown in GitHubConnectSection.

### DIFF
--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -216,8 +216,13 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                         HandleClonedRepo(newrepo);
 
                     isCreating = isCloning = false;
-                    var repo = await ApiFactory.Create(newrepo.CloneUrl).GetRepository();
-                    newrepo.SetIcon(repo.Private, repo.Fork);
+
+                    try
+                    {
+                        var repo = await ApiFactory.Create(newrepo.CloneUrl).GetRepository();
+                        newrepo.SetIcon(repo.Private, repo.Fork);
+                    }
+                    catch { }
                 }
                 // looks like it's just a refresh with new stuff on the list, update the icons
                 else
@@ -228,8 +233,12 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                     {
                         if (Equals(Holder.ActiveRepo, r))
                             SelectedRepository = r;
-                        var repo = await ApiFactory.Create(r.CloneUrl).GetRepository();
-                        r.SetIcon(repo.Private, repo.Fork);
+
+                        try
+                        {
+                            var repo = await ApiFactory.Create(r.CloneUrl).GetRepository();
+                            r.SetIcon(repo.Private, repo.Fork);
+                        } catch { }
                     });
                 }
             }

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -219,6 +219,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
                     try
                     {
+                        // TODO: Cache the icon state.
                         var repo = await ApiFactory.Create(newrepo.CloneUrl).GetRepository();
                         newrepo.SetIcon(repo.Private, repo.Fork);
                     }
@@ -242,6 +243,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
                         try
                         {
+                            // TODO: Cache the icon state.
                             var repo = await ApiFactory.Create(r.CloneUrl).GetRepository();
                             r.SetIcon(repo.Private, repo.Fork);
                         }

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -222,7 +222,13 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                         var repo = await ApiFactory.Create(newrepo.CloneUrl).GetRepository();
                         newrepo.SetIcon(repo.Private, repo.Fork);
                     }
-                    catch { }
+                    catch
+                    {
+                        // GetRepository() may throw if the user doesn't have permissions to access the repo
+                        // (because the repo no longer exists, or because the user has logged in on a different
+                        // profile, or their permissions have changed remotely)
+                        // TODO: Log
+                    }
                 }
                 // looks like it's just a refresh with new stuff on the list, update the icons
                 else
@@ -238,7 +244,14 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                         {
                             var repo = await ApiFactory.Create(r.CloneUrl).GetRepository();
                             r.SetIcon(repo.Private, repo.Fork);
-                        } catch { }
+                        }
+                        catch
+                        {
+                            // GetRepository() may throw if the user doesn't have permissions to access the repo
+                            // (because the repo no longer exists, or because the user has logged in on a different
+                            // profile, or their permissions have changed remotely)
+                            // TODO: Log
+                        }
                     });
                 }
             }


### PR DESCRIPTION
Trying to get the info for the icon in the repo list can throw if the repository has been deleted. Handle this.

Fixes #682.