### PR TITLE
Disable NullGuard on GitHubProviderDispatcher.

### DIFF
--- a/src/GitHub.VisualStudio/Services/UIProvider.cs
+++ b/src/GitHub.VisualStudio/Services/UIProvider.cs
@@ -29,6 +29,7 @@ namespace GitHub.VisualStudio
     /// </summary>
     [Export(typeof(IUIProvider))]
     [PartCreationPolicy(CreationPolicy.NonShared)]
+    [NullGuard(ValidationFlags.None)]
     public class GitHubProviderDispatcher : IUIProvider
     {
         readonly IUIProvider theRealProvider;


### PR DESCRIPTION
NullGuard shouldn't be applied to wrappers.