### PR TITLE
Set default info panel icon color and type 

### DIFF
--- a/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml.cs
@@ -34,7 +34,7 @@ namespace GitHub.VisualStudio.UI.Controls
 
         public MessageType MessageType
         {
-            get { return (MessageType)GetValue(MessageProperty); }
+            get { return (MessageType)GetValue(MessageTypeProperty); }
             set { SetValue(MessageTypeProperty, value); }
         }
 
@@ -80,7 +80,9 @@ namespace GitHub.VisualStudio.UI.Controls
         {
             InitializeComponent();
 
-            this.DataContext = this;
+            DataContext = this;
+            Icon = Octicon.info;
+            IconColor = InfoColorBrush;
 
             LinkCommand = new RelayCommand(x =>
             {


### PR DESCRIPTION
Since `Information` is the default type, set it as the information icon and style in the `InfoPanel`'s constructor.

Fixes #692 