### PR TITLE
Reiterate project title in templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-## Contributing
+## Contributing to the _GitHub Extensions for Visual Studio_
 
 [fork]: https://github.com/github/VisualStudio/fork
 [pr]: https://github.com/github/VisualStudio/compare
 [code-of-conduct]: http://todogroup.org/opencodeofconduct/#VisualStudio/opensource@github.com
 [readme]: https://github.com/github/VisualStudio#build
 
-Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
+Hi there! We're thrilled that you'd like to contribute to the __GitHub Extension for Visual Studio__. Your help is essential for keeping it great.
 
 This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing to the _GitHub Extension for Visual Studio_
+## Contributing to the GitHub Extension for Visual Studio
 
 [fork]: https://github.com/github/VisualStudio/fork
 [pr]: https://github.com/github/VisualStudio/compare

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing to the GitHub Extension for Visual Studio
+## Contributing to the _GitHub Extension for Visual Studio_
 
 [fork]: https://github.com/github/VisualStudio/fork
 [pr]: https://github.com/github/VisualStudio/compare

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing to the _GitHub Extensions for Visual Studio_
+## Contributing to the _GitHub Extension for Visual Studio_
 
 [fork]: https://github.com/github/VisualStudio/fork
 [pr]: https://github.com/github/VisualStudio/compare

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
-Hello! Please read the contributing guidelines before submitting an issue.
+Hello! Please read the _contributing guidelines_ before submitting an issue regarding the __GitHub Extension for Visusal Studio__.
 
-- GitHub Extension version:
+- GitHub Extension for Visusal Studio  version:
 - Visual Studio version:
 
 __What happened__ (with steps, logs and screenshots, if possible)

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
-Hello! Please read the _contributing guidelines_ before submitting an issue regarding the __GitHub Extension for Visusal Studio__.
+Hello! Please read the contributing guidelines before submitting an issue regarding the GitHub Extension for Visual Studio.
 
-- GitHub Extension for Visusal Studio  version:
+- GitHub Extension for Visual Studio  version:
 - Visual Studio version:
 
 __What happened__ (with steps, logs and screenshots, if possible)


### PR DESCRIPTION
Added the full project title into ISSUE_TEMPLATE.md and CONTRIBUTING.md to help discourage people erroneously reporting issues unrelated to GHfVS.