### PR TITLE
Allow wrapping in GitHubActionLink.

### DIFF
--- a/src/GitHub.UI/Controls/Buttons/GitHubActionLink.cs
+++ b/src/GitHub.UI/Controls/Buttons/GitHubActionLink.cs
@@ -11,6 +11,9 @@ namespace GitHub.UI
         public static readonly DependencyProperty TextTrimmingProperty =
             TextBlock.TextTrimmingProperty.AddOwner(typeof(GitHubActionLink));
 
+        public static readonly DependencyProperty TextWrappingProperty =
+            TextBlock.TextWrappingProperty.AddOwner(typeof(GitHubActionLink));
+
         public bool HasDropDown
         {
             get { return (bool)GetValue(HasDropDownProperty); }
@@ -21,6 +24,12 @@ namespace GitHub.UI
         {
             get { return (TextTrimming)GetValue(TextTrimmingProperty); }
             set { SetValue(TextTrimmingProperty, value); }
+        }
+
+        public TextWrapping TextWrapping
+        {
+            get { return (TextWrapping)GetValue(TextWrappingProperty); }
+            set { SetValue(TextWrappingProperty, value); }
         }
 
         public GitHubActionLink()

--- a/src/GitHub.VisualStudio.UI/Styles/GitHubActionLink.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/GitHubActionLink.xaml
@@ -12,7 +12,7 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ui:GitHubActionLink}">
-          <TextBlock TextTrimming="{TemplateBinding TextTrimming}">
+          <TextBlock TextTrimming="{TemplateBinding TextTrimming}" TextWrapping="{TemplateBinding TextWrapping}">
             <Hyperlink Command="{TemplateBinding Command}"
                        CommandParameter="{TemplateBinding CommandParameter}"
                        Foreground="{TemplateBinding Foreground}">


### PR DESCRIPTION
`GitHubActionLink` already had a `TextTrimming` property - this PR add the associated `TextWrapping` property so that text in the can be word-wrap.