### PR TITLE
Added FlatReadOnlyTextBox style.

### DIFF
--- a/src/GitHub.VisualStudio.UI/Styles/TextBlocks.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/TextBlocks.xaml
@@ -58,4 +58,17 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <Style x:Key="FlatReadOnlyTextBox" TargetType="TextBox">
+        <Setter Property="IsReadOnly" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TextBox}">
+                    <Grid>
+                        <ScrollViewer Margin="0" x:Name="PART_ContentHost" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
For when we need to display a selectable piece of text, such as an error message that allows the user to copy the error text.