### PR TITLE
Tweak start page clone dialog layout

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/Controls/StartPageCloneView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/StartPageCloneView.xaml
@@ -67,31 +67,6 @@
           <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
-        <ui:PromptTextBox x:Name="clonePath"
-                          Grid.Column="1"
-                          Margin="0,2"
-                          Text="{Binding BaseRepositoryPath, UpdateSourceTrigger=PropertyChanged}"
-                          />
-        <Button x:Name="browsePathButton"
-                Grid.Column="2"
-                Margin="4,0,4,0"
-                VerticalContentAlignment="Center"
-                Content="{x:Static prop:Resources.browsePathButtonContent}"
-                Padding="0"
-                Style="{StaticResource GitHubBlueLinkButton}"
-                Command="{Binding BrowseForDirectory}"
-                />
-        <Label Grid.Row="3"
-               Grid.Column="0"
-               Margin="4,0"
-               Content="{x:Static prop:Resources.pathText}"
-               Target="{Binding ElementName=clonePath}" />
-        <uirx:ValidationMessage x:Name="pathValidationMessage"
-                                Grid.Row="4"
-                                Grid.Column="1"
-                                ValidatesControl="{Binding ElementName=clonePath}"
-                                ReactiveValidator="{Binding BaseRepositoryPathValidator, Mode=OneWay}"
-                                />
       </Grid>
     </Border>
 
@@ -136,11 +111,19 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
           </Grid.RowDefinitions>
             
           <Label Style="{StaticResource Light}" Grid.Row="0" HorizontalAlignment="Left" Margin="6,0,0,0">Repo Name</Label>
           <Label Style="{StaticResource Light}" Grid.Row="1" HorizontalAlignment="Right">Organization</Label>
           <Label Style="{StaticResource Light}" Grid.Row="2" HorizontalAlignment="Right">Source</Label>
+          <Label Grid.Row="3"
+                 Grid.Column="0"
+                 Style="{StaticResource Light}" 
+                 HorizontalAlignment="Right"
+                 Margin="4,0"
+                 Content="{x:Static prop:Resources.pathText}"
+                 Target="{Binding ElementName=clonePath}" />
             
           <ui:OcticonImage Grid.Row="0" Grid.Column="1" Icon="repo"/>
           <ui:OcticonImage Grid.Row="1" Grid.Column="1" Icon="organization"/>
@@ -154,6 +137,39 @@
                    VerticalAlignment="Center"
                    Text="{Binding SelectedRepository.CloneUrl, Mode=OneWay}"
                    Style="{StaticResource FlatReadOnlyTextBox}"/>
+
+          <Grid Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <ui:PromptTextBox x:Name="clonePath"
+                              Grid.Column="0"
+                              Margin="0,2"
+                              Text="{Binding BaseRepositoryPath, UpdateSourceTrigger=PropertyChanged}" />
+
+            <Button x:Name="browsePathButton"
+                    Grid.Column="1"
+                    Margin="4,0,4,0"
+                    VerticalContentAlignment="Center"
+                    Content="{x:Static prop:Resources.browsePathButtonContent}"
+                    Padding="0"
+                    Style="{StaticResource GitHubBlueLinkButton}"
+                    Command="{Binding BrowseForDirectory}" />
+
+            <uirx:ValidationMessage x:Name="pathValidationMessage"
+                                    Grid.Row="1"
+                                    Grid.ColumnSpan="2" 
+                                    Grid.Column="1"
+                                    ValidatesControl="{Binding ElementName=clonePath}"
+                                    ReactiveValidator="{Binding BaseRepositoryPathValidator, Mode=OneWay}" />
+          </Grid>
         </Grid>
       </StackPanel>
     </Border>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/StartPageCloneView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/StartPageCloneView.xaml
@@ -115,7 +115,8 @@
         </Style>
       </Border.Resources>
       <StackPanel>
-        <ui:OcticonImage Icon="logo_github" Width="100" Height="100" VerticalAlignment="Top" Margin="0,0,0,-10"/>
+        <ui:OcticonImage Icon="logo_github" Width="100" Height="100" VerticalAlignment="Top" Margin="0,20,0,10"/>
+        <ui:HorizontalShadowDivider />
         <Grid HorizontalAlignment="Center" Margin="0,60,0,0" MaxWidth="400">
           <Grid.Resources>
             <Style x:Key="Light" TargetType="Label">

--- a/src/GitHub.VisualStudio/UI/Views/Controls/StartPageCloneView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/StartPageCloneView.xaml
@@ -92,7 +92,7 @@
       <StackPanel>
         <ui:OcticonImage Icon="logo_github" Width="100" Height="100" VerticalAlignment="Top" Margin="0,20,0,10"/>
         <ui:HorizontalShadowDivider />
-        <Grid HorizontalAlignment="Center" Margin="0,60,0,0" MaxWidth="400">
+        <Grid HorizontalAlignment="Center" Margin="0,20,0,0" MaxWidth="400">
           <Grid.Resources>
             <Style x:Key="Light" TargetType="Label">
                 <Setter Property="Opacity" Value="0.6"/>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/StartPageCloneView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/StartPageCloneView.xaml
@@ -59,17 +59,6 @@
       <TextBlock Text="{x:Static prop:Resources.CloneLink}" />
     </ui:OcticonCircleButton>
 
-    <Border DockPanel.Dock="Bottom" Style="{StaticResource repositoryBorderStyle}">
-      <Grid>
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="*" />
-          <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-
-      </Grid>
-    </Border>
-
     <Border x:Name="repositoriesListPane"
             Margin="0"
             BorderBrush="#EAEAEA"

--- a/src/GitHub.VisualStudio/UI/Views/Controls/StartPageCloneView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/StartPageCloneView.xaml
@@ -105,7 +105,7 @@
             
           <Label Style="{StaticResource Light}" Grid.Row="0" HorizontalAlignment="Left" Margin="6,0,0,0">Repo Name</Label>
           <Label Style="{StaticResource Light}" Grid.Row="1" HorizontalAlignment="Right">Organization</Label>
-          <Label Style="{StaticResource Light}" Grid.Row="2" HorizontalAlignment="Right">Source</Label>
+          <Label Style="{StaticResource Light}" Grid.Row="2" VerticalAlignment="Center" HorizontalAlignment="Right">Source</Label>
           <Label Grid.Row="3"
                  Grid.Column="0"
                  Style="{StaticResource Light}" 
@@ -116,12 +116,12 @@
             
           <ui:OcticonImage Grid.Row="0" Grid.Column="1" Icon="repo"/>
           <ui:OcticonImage Grid.Row="1" Grid.Column="1" Icon="organization"/>
-          <ui:OcticonImage Grid.Row="2" Grid.Column="1" Icon="link"/>
+          <ui:OcticonImage Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Icon="link"/>
             
           <TextBlock Grid.Row="0" Grid.Column="2" Text="{Binding SelectedRepository.CloneUrl.RepositoryName}"/>
           <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding SelectedRepository.CloneUrl.Owner}"/>
           <TextBox Grid.Row="2" Grid.Column="2"
-                   Margin="3 0"
+                   Margin="3"
                    TextWrapping="Wrap"
                    VerticalAlignment="Center"
                    Text="{Binding SelectedRepository.CloneUrl, Mode=OneWay}"


### PR DESCRIPTION
Updates the layout so that it's closer to my comment in https://github.com/github/VisualStudio/issues/684#issuecomment-261604319

Not sure what it looks like when it's compiled because I used mostly Xaml designer as my visual aid and my Visual Studio 2017 RC keeps crashing when I try to open up the project with it 😢 

However, here's what it looks like in Xaml designer

<img width="438" alt="screen shot 2016-12-06 at 2 17 43 pm" src="https://cloud.githubusercontent.com/assets/1174461/20946651/6f56fb70-bbc0-11e6-9d44-4bfb5f611b78.png">

An example with a longer URL:

<img width="447" alt="screen shot 2016-12-06 at 2 17 10 pm" src="https://cloud.githubusercontent.com/assets/1174461/20946652/6f5a0310-bbc0-11e6-908b-3073baa20167.png">

/cc @grokys since this targets your branch