### PR TITLE
Clean up unused remotes.

### DIFF
--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -104,6 +104,18 @@ namespace GitHub.Services
             });
         }
 
+        public Task<T> GetConfig<T>(IRepository repository, string key)
+        {
+            Guard.ArgumentNotNull(repository, nameof(repository));
+            Guard.ArgumentNotEmptyString(key, nameof(key));
+
+            return Task.Factory.StartNew(() =>
+            {
+                var result = repository.Config.Get<T>(key);
+                return result != null ? result.Value : default(T);
+            });
+        }
+
         public Task SetConfig(IRepository repository, string key, string value)
         {
             Guard.ArgumentNotNull(repository, nameof(repository));

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -24,6 +24,9 @@ namespace GitHub.Services
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class PullRequestService : IPullRequestService
     {
+        const string SettingCreatedByGHfVS = "created-by-ghfvs";
+        const string SettingGHfVSPullRequest = "ghfvs-pr";
+
         static readonly Regex InvalidBranchCharsRegex = new Regex(@"[^0-9A-Za-z\-]", RegexOptions.ECMAScript);
         static readonly Regex BranchCapture = new Regex(@"branch\.(?<branch>.+)\.ghfvs-pr", RegexOptions.ECMAScript);
 
@@ -128,11 +131,9 @@ namespace GitHub.Services
                 else
                 {
                     var refSpec = $"{pullRequest.Head.Ref}:{localBranchName}";
-                    var prConfigKey = $"branch.{localBranchName}.ghfvs-pr";
-                    var remoteName = pullRequest.Head.RepositoryCloneUrl.Owner;
-                    var remoteUri = pullRequest.Head.RepositoryCloneUrl;
+                    var prConfigKey = $"branch.{localBranchName}.{SettingGHfVSPullRequest}";
+                    var remoteName = await CreateRemote(repo, pullRequest.Head.RepositoryCloneUrl);
 
-                    await gitClient.SetRemote(repo, remoteName, new Uri(remoteUri));
                     await gitClient.Fetch(repo, remoteName);
                     await gitClient.Fetch(repo, remoteName, new[] { refSpec });
                     await gitClient.Checkout(repo, localBranchName);
@@ -257,6 +258,60 @@ namespace GitHub.Services
                 var right = await gitClient.ExtractFile(repo, pullRequest.Head.Sha, fileName);
                 return Observable.Return(Tuple.Create(left, right));
             });
+        }
+
+        public IObservable<Unit> RemoteUnusedRemotes(ILocalRepositoryModel repository)
+        {
+            return Observable.Defer(async () =>
+            {
+                var repo = gitService.GetRepository(repository.LocalPath);
+                var usedRemotes = new HashSet<string>(
+                    repo.Branches
+                        .Where(x => !x.IsRemote && x.Remote != null)
+                        .Select(x => x.Remote?.Name));
+
+                foreach (var remote in repo.Network.Remotes)
+                {
+                    var key = $"remote.{remote.Name}.{SettingCreatedByGHfVS}";
+                    var createdByUs = await gitClient.GetConfig<bool>(repo, key);
+
+                    if (createdByUs && !usedRemotes.Contains(remote.Name))
+                    {
+                        repo.Network.Remotes.Remove(remote.Name);
+                    }
+                }
+
+                return Observable.Return(Unit.Default);
+            });
+        }
+
+        async Task<string> CreateRemote(IRepository repo, UriString cloneUri)
+        {
+            foreach (var remote in repo.Network.Remotes)
+            {
+                if (remote.Url == cloneUri)
+                {
+                    return remote.Name;
+                }
+            }
+
+            var remoteName = CreateUniqueRemoteName(repo, cloneUri.Owner);
+            await gitClient.SetRemote(repo, remoteName, new Uri(cloneUri));
+            await gitClient.SetConfig(repo, $"remote.{remoteName}.{SettingCreatedByGHfVS}", "true");
+            return remoteName;
+        }
+
+        string CreateUniqueRemoteName(IRepository repo, string name)
+        {
+            var uniqueName = name;
+            var number = 1;
+
+            while (repo.Network.Remotes[uniqueName] != null)
+            {
+                uniqueName = name + number++;
+            }
+
+            return uniqueName;
         }
 
         IEnumerable<string> GetLocalBranchesInternal(

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -331,6 +331,8 @@ namespace GitHub.ViewModels
             }
 
             IsBusy = false;
+
+            pullRequestsService.RemoteUnusedRemotes(repository).Subscribe(_ => { });
         }
 
         /// <summary>

--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -56,6 +56,14 @@ namespace GitHub.Services
         Task CreateBranch(IRepository repository, string branchName);
 
         /// <summary>
+        /// Gets the value of a configuration key.
+        /// </summary>
+        /// <param name="repository">The repository.</param>
+        /// <param name="key">The configuration key. Keys are in the form 'section.name'.</param>
+        /// <returns></returns>
+        Task<T> GetConfig<T>(IRepository repository, string key);
+
+        /// <summary>
         /// Sets the configuration key to the specified value in the local config.
         /// </summary>
         /// <param name="repository">The repository</param>

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
@@ -106,6 +106,14 @@ namespace GitHub.Services
         /// <returns>The filenames of the left and right files for the diff.</returns>
         IObservable<Tuple<string, string>> ExtractDiffFiles(ILocalRepositoryModel repository, IPullRequestModel pullRequest, string fileName);
 
+        /// <summary>
+        /// Remotes all unused remotes that were created by GitHub for Visual Studio to track PRs
+        /// from forks.
+        /// </summary>
+        /// <param name="repository">The repository.</param>
+        /// <returns></returns>
+        IObservable<Unit> RemoteUnusedRemotes(ILocalRepositoryModel repository);
+
         IObservable<string> GetPullRequestTemplate(ILocalRepositoryModel repository);
     }
 }


### PR DESCRIPTION
When checking out a PR branch from a fork, we create a named remote. This means that we'll slowly accumulate unused remotes over time, which isn't ideal.

This PR:

- Adds a config key to identify remotes created by us
- Removes unused remotes created by us each time a PR details page is shown

Fixes #714 