### PR TITLE
Add renamed file status

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -52,9 +52,9 @@ This requires that errors be propagated from the viewmodel to the view and from 
             var gitHubDir = new PullRequestDirectoryNode("GitHub");
             var modelsDir = new PullRequestDirectoryNode("Models");
             var repositoriesDir = new PullRequestDirectoryNode("Repositories");
-            var itrackingBranch = new PullRequestFileNode(repoPath, @"GitHub\Models\ITrackingBranch.cs", PullRequestFileStatus.Modified);
-            var oldBranchModel = new PullRequestFileNode(repoPath, @"GitHub\Models\OldBranchModel.cs", PullRequestFileStatus.Removed);
-            var concurrentRepositoryConnection = new PullRequestFileNode(repoPath, @"GitHub\Repositories\ConcurrentRepositoryConnection.cs", PullRequestFileStatus.Added);
+            var itrackingBranch = new PullRequestFileNode(repoPath, @"GitHub\Models\ITrackingBranch.cs", PullRequestFileStatus.Modified, null);
+            var oldBranchModel = new PullRequestFileNode(repoPath, @"GitHub\Models\OldBranchModel.cs", PullRequestFileStatus.Removed, null);
+            var concurrentRepositoryConnection = new PullRequestFileNode(repoPath, @"GitHub\Repositories\ConcurrentRepositoryConnection.cs", PullRequestFileStatus.Added, "add");
 
             repositoriesDir.Files.Add(concurrentRepositoryConnection);
             modelsDir.Directories.Add(repositoriesDir);

--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -104,6 +104,30 @@ namespace GitHub.Services
             });
         }
 
+        public Task<TreeChanges> Compare(
+            IRepository repository,
+            string sha1,
+            string sha2,
+            bool detectRenames)
+        {
+            Guard.ArgumentNotNull(repository, nameof(repository));
+            Guard.ArgumentNotEmptyString(sha1, nameof(sha1));
+            Guard.ArgumentNotEmptyString(sha2, nameof(sha2));
+
+            return Task.Factory.StartNew(() =>
+            {
+                var options = new CompareOptions
+                {
+                    Similarity = detectRenames ? SimilarityOptions.Renames : SimilarityOptions.None
+                };
+
+                var commit1 = repository.Lookup<Commit>(sha1);
+                var commit2 = repository.Lookup<Commit>(sha2);
+                var changes = repository.Diff.Compare<TreeChanges>(commit1.Tree, commit2.Tree, options);
+                return changes;
+            });
+        }
+
         public Task SetConfig(IRepository repository, string key, string value)
         {
             Guard.ArgumentNotNull(repository, nameof(repository));

--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -123,8 +123,15 @@ namespace GitHub.Services
 
                 var commit1 = repository.Lookup<Commit>(sha1);
                 var commit2 = repository.Lookup<Commit>(sha2);
-                var changes = repository.Diff.Compare<TreeChanges>(commit1.Tree, commit2.Tree, options);
-                return changes;
+
+                if (commit1 != null && commit2 != null)
+                {
+                    return repository.Diff.Compare<TreeChanges>(commit1.Tree, commit2.Tree, options);
+                }
+                else
+                {
+                    return null;
+                }
             });
         }
 

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -172,6 +172,17 @@ namespace GitHub.Services
             });
         }
 
+        public IObservable<TreeChanges> GetTreeChanges(ILocalRepositoryModel repository, IPullRequestModel pullRequest)
+        {
+            return Observable.Defer(async () =>
+            {
+                var repo = gitService.GetRepository(repository.LocalPath);
+                await gitClient.Fetch(repo, "origin");
+                var changes = await gitClient.Compare(repo, pullRequest.Base.Sha, pullRequest.Head.Sha, detectRenames: true);
+                return Observable.Return(changes);
+            });
+        }
+
         public IObservable<IBranch> GetLocalBranches(ILocalRepositoryModel repository, IPullRequestModel pullRequest)
         {
             return Observable.Defer(() =>

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -272,6 +272,7 @@ namespace GitHub.ViewModels
             IsBusy = true;
 
             modelService.GetPullRequest(repository, prNumber)
+                .TakeLast(1)
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(x => Load(x).Forget());
         }
@@ -292,8 +293,10 @@ namespace GitHub.ViewModels
             ChangedFilesTree.Clear();
             ChangedFilesList.Clear();
 
+            var treeChanges = await pullRequestsService.GetTreeChanges(repository, pullRequest);
+
             // WPF doesn't support AddRange here so iterate through the changes.
-            foreach (var change in CreateChangedFilesList(pullRequest.ChangedFiles))
+            foreach (var change in CreateChangedFilesList(pullRequest, treeChanges))
             {
                 ChangedFilesList.Add(change);
             }
@@ -355,9 +358,10 @@ namespace GitHub.ViewModels
             return pullRequestsService.ExtractDiffFiles(repository, model, path).ToTask();
         }
 
-        IEnumerable<IPullRequestFileNode> CreateChangedFilesList(IEnumerable<IPullRequestFileModel> files)
+        IEnumerable<IPullRequestFileNode> CreateChangedFilesList(IPullRequestModel pullRequest, TreeChanges changes)
         {
-            return files.Select(x => new PullRequestFileNode(repository.LocalPath, x.FileName, x.Status, GetStatusDisplay(x)));
+            return pullRequest.ChangedFiles
+                .Select(x => new PullRequestFileNode(repository.LocalPath, x.FileName, x.Status, GetStatusDisplay(x, changes)));
         }
 
         static IPullRequestDirectoryNode CreateChangedFilesTree(IEnumerable<IPullRequestFileNode> files)
@@ -411,14 +415,25 @@ namespace GitHub.ViewModels
             }
         }
 
-        string GetStatusDisplay(IPullRequestFileModel file)
+        string GetStatusDisplay(IPullRequestFileModel file, TreeChanges changes)
         {
             switch (file.Status)
             {
                 case PullRequestFileStatus.Added:
                     return "add";
                 case PullRequestFileStatus.Renamed:
-                    return "rename";
+                    var fileName = file.FileName.Replace("/", "\\");
+                    var change = changes.Renamed.FirstOrDefault(x => x.Path == fileName);
+
+                    if (change != null)
+                    {
+                        return Path.GetDirectoryName(change.OldPath) == Path.GetDirectoryName(change.Path) ?
+                            Path.GetFileName(change.OldPath) : change.OldPath;
+                    }
+                    else
+                    {
+                        return "rename";
+                    }
                 default:
                     return null;
             }

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -423,7 +423,7 @@ namespace GitHub.ViewModels
                     return "add";
                 case PullRequestFileStatus.Renamed:
                     var fileName = file.FileName.Replace("/", "\\");
-                    var change = changes.Renamed.FirstOrDefault(x => x.Path == fileName);
+                    var change = changes?.Renamed.FirstOrDefault(x => x.Path == fileName);
 
                     if (change != null)
                     {

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -357,7 +357,7 @@ namespace GitHub.ViewModels
 
         IEnumerable<IPullRequestFileNode> CreateChangedFilesList(IEnumerable<IPullRequestFileModel> files)
         {
-            return files.Select(x => new PullRequestFileNode(repository.LocalPath, x.FileName, x.Status));
+            return files.Select(x => new PullRequestFileNode(repository.LocalPath, x.FileName, x.Status, GetStatusDisplay(x)));
         }
 
         static IPullRequestDirectoryNode CreateChangedFilesTree(IEnumerable<IPullRequestFileNode> files)
@@ -408,6 +408,19 @@ namespace GitHub.ViewModels
             else
             {
                 return "[Invalid]";
+            }
+        }
+
+        string GetStatusDisplay(IPullRequestFileModel file)
+        {
+            switch (file.Status)
+            {
+                case PullRequestFileStatus.Added:
+                    return "add";
+                case PullRequestFileStatus.Renamed:
+                    return "rename";
+                default:
+                    return null;
             }
         }
 

--- a/src/GitHub.App/ViewModels/PullRequestFileNode.cs
+++ b/src/GitHub.App/ViewModels/PullRequestFileNode.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using GitHub.Models;
+using NullGuard;
 
 namespace GitHub.ViewModels
 {
@@ -14,13 +15,15 @@ namespace GitHub.ViewModels
         /// </summary>
         /// <param name="repositoryPath">The absolute path to the repository.</param>
         /// <param name="path">The path to the file, relative to the repository.</param>
-        /// <param name="changeType">The way the file was changed.</param>
-        public PullRequestFileNode(string repositoryPath, string path, PullRequestFileStatus status)
+        /// <param name="status">The way the file was changed.</param>
+        /// <param name="statusDisplay">The string to display in the [message] box next to the filename.</param>
+        public PullRequestFileNode(string repositoryPath, string path, PullRequestFileStatus status, [AllowNull] string statusDisplay)
         {
             FileName = Path.GetFileName(path);
             DirectoryPath = Path.GetDirectoryName(path);
             DisplayPath = Path.Combine(Path.GetFileName(repositoryPath), DirectoryPath);
             Status = status;
+            StatusDisplay = statusDisplay;
         }
 
         /// <summary>
@@ -42,5 +45,10 @@ namespace GitHub.ViewModels
         /// Gets the type of change that was made to the file.
         /// </summary>
         public PullRequestFileStatus Status { get; }
+
+        /// <summary>
+        /// Gets the string to display in the [message] box next to the filename.
+        /// </summary>
+        public string StatusDisplay { [return: AllowNull] get; }
     }
 }

--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -56,6 +56,16 @@ namespace GitHub.Services
         Task CreateBranch(IRepository repository, string branchName);
 
         /// <summary>
+        /// Compares two commits.
+        /// </summary>
+        /// <param name="repository">The repository</param>
+        /// <param name="sha1">The SHA of the first commit.</param>
+        /// <param name="sha2">The SHA of the second commit.</param>
+        /// <param name="detectRenames">Whether to detect renames</param>
+        /// <returns></returns>
+        Task<TreeChanges> Compare(IRepository repository, string sha1, string sha2, bool detectRenames = false);
+
+        /// <summary>
         /// Sets the configuration key to the specified value in the local config.
         /// </summary>
         /// <param name="repository">The repository</param>

--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -62,7 +62,10 @@ namespace GitHub.Services
         /// <param name="sha1">The SHA of the first commit.</param>
         /// <param name="sha2">The SHA of the second commit.</param>
         /// <param name="detectRenames">Whether to detect renames</param>
-        /// <returns></returns>
+        /// <returns>
+        /// A <see cref="TreeChanges"/> object or null if one of the commits could not be found in the repository,
+        /// (e.g. it is from a fork).
+        /// </returns>
         Task<TreeChanges> Compare(IRepository repository, string sha1, string sha2, bool detectRenames = false);
 
         /// <summary>

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
@@ -82,6 +82,14 @@ namespace GitHub.Services
         IObservable<BranchTrackingDetails> CalculateHistoryDivergence(ILocalRepositoryModel repository, int pullRequestNumber);
 
         /// <summary>
+        /// Gets the changes between the pull request base and head.
+        /// </summary>
+        /// <param name="repository">The repository.</param>
+        /// <param name="pullRequest">The pull request details.</param>
+        /// <returns></returns>
+        IObservable<TreeChanges> GetTreeChanges(ILocalRepositoryModel repository, IPullRequestModel pullRequest);
+
+        /// <summary>
         /// Removes any association between the current branch and a pull request.
         /// </summary>
         /// <param name="repository">The repository.</param>

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestFileNode.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestFileNode.cs
@@ -18,5 +18,10 @@ namespace GitHub.ViewModels
         /// Gets the type of change that was made to the file.
         /// </summary>
         PullRequestFileStatus Status { get; }
+
+        /// <summary>
+        /// Gets the string to display in the [message] box next to the filename.
+        /// </summary>
+        string StatusDisplay { get; }
     }
 }

--- a/src/GitHub.Exports/Models/IPullRequestFileModel.cs
+++ b/src/GitHub.Exports/Models/IPullRequestFileModel.cs
@@ -5,6 +5,7 @@
         Modified,
         Added,
         Removed,
+        Renamed,
     }
 
     public interface IPullRequestFileModel

--- a/src/GitHub.Exports/Settings/UIState.cs
+++ b/src/GitHub.Exports/Settings/UIState.cs
@@ -11,6 +11,8 @@ namespace GitHub.Settings
     /// </summary>
     public class UIState
     {
+        PullRequestDetailUIState prState = new PullRequestDetailUIState();
+
         /// <summary>
         /// Gets or sets the UI state for the <see cref="IGitHubConnectSection"/>s in Team Explorer.
         /// </summary>
@@ -26,8 +28,17 @@ namespace GitHub.Settings
         /// <summary>
         /// Gets or sets global settings for the Pull Request detail view.
         /// </summary>
-        public PullRequestDetailUIState PullRequestDetailState { get; set; }
-            = new PullRequestDetailUIState();
+        public PullRequestDetailUIState PullRequestDetailState
+        {
+            get { return prState; }
+            set
+            {
+                if (value != null)
+                {
+                    prState = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or creates the UI state for a repository.

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -353,13 +353,12 @@
                                                     </Style>
                                                 </TextBlock.Style>
                                             </TextBlock>
-                                            <TextBlock Text="[add]" VerticalAlignment="Center" Opacity="0.5">
+                                            <TextBlock Text="{Binding StatusDisplay, StringFormat=[{0}]}" VerticalAlignment="Center" Opacity="0.5">
                                                 <TextBlock.Style>
                                                     <Style TargetType="TextBlock">
-                                                        <Setter Property="Visibility" Value="Collapsed"/>
                                                         <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding Status}" Value="Added">
-                                                                <Setter Property="Visibility" Value="Visible"/>
+                                                            <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Null}">
+                                                                <Setter Property="Visibility" Value="Collapsed"/>
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
@@ -408,13 +407,12 @@
                                                                 </Style>
                                                             </TextBlock.Style>
                                                         </TextBlock>
-                                                        <TextBlock Text="[add]" VerticalAlignment="Center" Opacity="0.5">
+                                                        <TextBlock Text="{Binding StatusDisplay, StringFormat=[{0}]}" VerticalAlignment="Center" Opacity="0.5">
                                                             <TextBlock.Style>
                                                                 <Style TargetType="TextBlock">
-                                                                    <Setter Property="Visibility" Value="Collapsed"/>
                                                                     <Style.Triggers>
-                                                                        <DataTrigger Binding="{Binding Status}" Value="Added">
-                                                                            <Setter Property="Visibility" Value="Visible"/>
+                                                                        <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Null}">
+                                                                            <Setter Property="Visibility" Value="Collapsed"/>
                                                                         </DataTrigger>
                                                                     </Style.Triggers>
                                                                 </Style>

--- a/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
@@ -48,6 +48,106 @@ namespace UnitTests.GitHub.App.ViewModels
             }
         }
 
+        public class TheChangedFilesListProperty
+        {
+            [Fact]
+            public async Task ShouldCreateChangesList()
+            {
+                var target = CreateTarget();
+                var pr = CreatePullRequest();
+
+                pr.ChangedFiles = new[]
+                {
+                    new PullRequestFileModel("readme.md", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/f1.cs", PullRequestFileStatus.Added),
+                    new PullRequestFileModel("dir1/f2.cs", PullRequestFileStatus.Removed),
+                    new PullRequestFileModel("dir1/dir1a/f3.cs", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir2/f4.cs", PullRequestFileStatus.Modified),
+                };
+
+                await target.Load(pr);
+
+                Assert.Equal(5, target.ChangedFilesList.Count);
+
+                var file = target.ChangedFilesList[0];
+                Assert.Equal("readme.md", file.FileName);
+                Assert.Equal(string.Empty, file.DirectoryPath);
+                Assert.Equal("ThisRepo", file.DisplayPath);
+                Assert.Equal(PullRequestFileStatus.Modified, file.Status);
+                Assert.Equal(null, file.StatusDisplay);
+
+                file = target.ChangedFilesList[1];
+                Assert.Equal("f1.cs", file.FileName);
+                Assert.Equal("dir1", file.DirectoryPath);
+                Assert.Equal(@"ThisRepo\dir1", file.DisplayPath);
+                Assert.Equal(PullRequestFileStatus.Added, file.Status);
+                Assert.Equal("add", file.StatusDisplay);
+
+                file = target.ChangedFilesList[2];
+                Assert.Equal("f2.cs", file.FileName);
+                Assert.Equal("dir1", file.DirectoryPath);
+                Assert.Equal(@"ThisRepo\dir1", file.DisplayPath);
+                Assert.Equal(PullRequestFileStatus.Removed, file.Status);
+                Assert.Equal(null, file.StatusDisplay);
+
+                file = target.ChangedFilesList[3];
+                Assert.Equal("f3.cs", file.FileName);
+                Assert.Equal(@"dir1\dir1a", file.DirectoryPath);
+                Assert.Equal(@"ThisRepo\dir1\dir1a", file.DisplayPath);
+                Assert.Equal(PullRequestFileStatus.Modified, file.Status);
+                Assert.Equal(null, file.StatusDisplay);
+
+                file = target.ChangedFilesList[4];
+                Assert.Equal("f4.cs", file.FileName);
+                Assert.Equal("dir2", file.DirectoryPath);
+                Assert.Equal(@"ThisRepo\dir2", file.DisplayPath);
+                Assert.Equal(PullRequestFileStatus.Modified, file.Status);
+                Assert.Equal(null, file.StatusDisplay);
+            }
+
+            [Fact]
+            public async Task ShouldDisplayRenamedFiles()
+            {
+                var targetAndSerivce = CreateTargetAndService();
+                var target = targetAndSerivce.Item1;
+                var service = targetAndSerivce.Item2;
+                var pr = CreatePullRequest();
+
+                pr.ChangedFiles = new[]
+                {
+                    new PullRequestFileModel(@"readme.md", PullRequestFileStatus.Renamed),
+                    new PullRequestFileModel(@"dir1/f1.cs", PullRequestFileStatus.Renamed),
+                    new PullRequestFileModel(@"dir1/f2.cs", PullRequestFileStatus.Renamed),
+                    new PullRequestFileModel(@"f3.cs", PullRequestFileStatus.Renamed),
+                };
+
+                var changes = Substitute.For<TreeChanges>();
+                var readmeRename = Substitute.For<TreeEntryChanges>();
+                var f1Rename = Substitute.For<TreeEntryChanges>();
+                var f2Rename = Substitute.For<TreeEntryChanges>();
+                var f3Rename = Substitute.For<TreeEntryChanges>();
+
+                readmeRename.Path.Returns(@"readme.md");
+                readmeRename.OldPath.Returns(@"oldreadme.md");
+                f1Rename.Path.Returns(@"dir1\f1.cs");
+                f1Rename.OldPath.Returns(@"dir1\oldf1.cs");
+                f2Rename.Path.Returns(@"dir1\f2.cs");
+                f2Rename.OldPath.Returns(@"f2.cs");
+                f3Rename.Path.Returns(@"f3.cs");
+                f3Rename.OldPath.Returns(@"dir1\f3.cs");
+                changes.Renamed.Returns(new[] { readmeRename, f1Rename, f2Rename, f3Rename });
+
+                service.GetTreeChanges(Arg.Any<ILocalRepositoryModel>(), pr).Returns(Observable.Return(changes));
+
+                await target.Load(pr);
+
+                Assert.Equal(@"oldreadme.md", target.ChangedFilesList[0].StatusDisplay);
+                Assert.Equal(@"oldf1.cs", target.ChangedFilesList[1].StatusDisplay);
+                Assert.Equal(@"f2.cs", target.ChangedFilesList[2].StatusDisplay);
+                Assert.Equal(@"dir1\f3.cs", target.ChangedFilesList[3].StatusDisplay);
+            }
+        }
+
         public class TheChangedFilesTreeProperty
         {
             [Fact]
@@ -58,12 +158,12 @@ namespace UnitTests.GitHub.App.ViewModels
 
                 pr.ChangedFiles = new[]
                 {
-                new PullRequestFileModel("readme.md", PullRequestFileStatus.Modified),
-                new PullRequestFileModel("dir1/f1.cs", PullRequestFileStatus.Modified),
-                new PullRequestFileModel("dir1/f2.cs", PullRequestFileStatus.Modified),
-                new PullRequestFileModel("dir1/dir1a/f3.cs", PullRequestFileStatus.Modified),
-                new PullRequestFileModel("dir2/f4.cs", PullRequestFileStatus.Modified),
-            };
+                    new PullRequestFileModel("readme.md", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/f1.cs", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/f2.cs", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/dir1a/f3.cs", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir2/f4.cs", PullRequestFileStatus.Modified),
+                };
 
                 await target.Load(pr);
 
@@ -356,6 +456,7 @@ namespace UnitTests.GitHub.App.ViewModels
             var currentBranchModel = new BranchModel(currentBranch, repository);
             repository.CurrentBranch.Returns(currentBranchModel);
             repository.CloneUrl.Returns(new UriString(Uri.ToString()));
+            repository.LocalPath.Returns(@"C:\projects\ThisRepo");
 
             var pullRequestService = Substitute.For<IPullRequestService>();
 


### PR DESCRIPTION
Handle renamed status in PR details view, and display the old filename/path following Team Explorer's behavior as described in #719.

Fixes #719.