### PR TITLE
Handle PRs from deleted repositories.

### DIFF
--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -325,9 +325,17 @@ namespace GitHub.ViewModels
                 var caption = localBranches.Count > 0 ?
                     "Checkout " + localBranches.First().DisplayName :
                     "Checkout to " + (await pullRequestsService.GetDefaultLocalBranchName(repository, Model.Number, Model.Title));
-                var disabled = await pullRequestsService.IsWorkingDirectoryClean(repository) ?
-                    null :
-                    "Cannot checkout as your working directory has uncommitted changes.";
+                var clean = await pullRequestsService.IsWorkingDirectoryClean(repository);
+                string disabled = null;
+
+                if (!pullRequest.Head.RepositoryCloneUrl.IsValidUri)
+                {
+                    disabled = "The source repository is no longer available.";
+                }
+                else if (!clean)
+                {
+                    disabled = "Cannot checkout as your working directory has uncommitted changes.";
+                }
 
                 CheckoutState = new CheckoutCommandState(caption, disabled);
                 UpdateState = null;

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -328,7 +328,7 @@ namespace GitHub.ViewModels
                 var clean = await pullRequestsService.IsWorkingDirectoryClean(repository);
                 string disabled = null;
 
-                if (!pullRequest.Head.RepositoryCloneUrl.IsValidUri)
+                if (pullRequest.Head == null || !pullRequest.Head.RepositoryCloneUrl.IsValidUri)
                 {
                     disabled = "The source repository is no longer available.";
                 }

--- a/src/GitHub.Exports/Models/GitReferenceModel.cs
+++ b/src/GitHub.Exports/Models/GitReferenceModel.cs
@@ -13,7 +13,6 @@ namespace GitHub.Models
         public GitReferenceModel(string @ref, string label, string sha, UriString repositoryCloneUri)
         {
             Guard.ArgumentNotEmptyString(@ref, nameof(@ref));
-            Guard.ArgumentNotEmptyString(label, nameof(label));
             Guard.ArgumentNotEmptyString(sha, nameof(sha));
 
             Ref = @ref;

--- a/src/GitHub.Exports/Primitives/UriString.cs
+++ b/src/GitHub.Exports/Primitives/UriString.cs
@@ -248,7 +248,7 @@ namespace GitHub.Primitives
 
         bool IEquatable<UriString>.Equals(UriString other)
         {
-            return other != null && ToString().Equals(other.ToString());
+            return other != null && Equals(ToString(), other.ToString());
         }
     }
 }

--- a/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
@@ -261,6 +261,22 @@ namespace UnitTests.GitHub.App.ViewModels
                 var target = CreateTarget(
                     currentBranch: "master",
                     existingPrBranch: "pr/123");
+                var pr = CreatePullRequest();
+
+                pr.Head = new GitReferenceModel("source", null, "sha", (string)null);
+
+                await target.Load(pr);
+
+                Assert.False(target.Checkout.CanExecute(null));
+                Assert.Equal("The source repository is no longer available.", target.CheckoutState.DisabledMessage);
+            }
+
+            [Fact]
+            public async Task PullRequestFromGhostAccount()
+            {
+                var target = CreateTarget(
+                    currentBranch: "master",
+                    existingPrBranch: "pr/123");
                 await target.Load(CreatePullRequest());
 
                 await Assert.ThrowsAsync<Exception>(() => target.Checkout.ExecuteAsyncTask(null));


### PR DESCRIPTION
If a PR was submitted from a fork and that repository subsequently deleted, we previously asserted in the PR list. Handle this case and disable the checkout button in the PR details view.

This PR builds on #720 so that should be merged first.

Fixes #721 