### PR TITLE
Pane Navigation & UIController

### DIFF
--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -877,33 +877,11 @@ namespace GitHub.Controllers
 
         void Fire(Trigger next, ViewWithData arg = null)
         {
-            log.Info(CultureInfo.InvariantCulture, "UIMachine Firing {0} from {1}", next, uiStateMachine.State);
-            StateMachineType.TriggerWithParameters<ViewWithData> viewWithDataTrigger = null;
-            if (arg != null)
-            {
-                if (next == Trigger.Next)
-                {
-                    switch (requestedTarget?.ViewType)
-                    {
-                        case UIViewType.PRDetail:
-                            viewWithDataTrigger = triggers[Trigger.PRDetail];
-                            break;
-                    }
-                }
-                else if (triggers.ContainsKey(next))
-                {
-                    viewWithDataTrigger = triggers[next];
-                }
-            }
-
-            if (viewWithDataTrigger != null)
-            {
-                uiStateMachine.Fire(viewWithDataTrigger, arg);
-            }
+            Debug.WriteLine("Firing {0} from {1} ({2})", next, uiStateMachine.State, GetHashCode());
+            if (arg != null && triggers.ContainsKey(next))
+                uiStateMachine.Fire(triggers[next], arg);
             else
-            {
                 uiStateMachine.Fire(next);
-            }
         }
 
         UIViewType Go(Trigger trigger)

--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -808,10 +808,33 @@ namespace GitHub.Controllers
         void Fire(Trigger next, ViewWithData arg = null)
         {
             Debug.WriteLine("Firing {0} from {1} ({2})", next, uiStateMachine.State, GetHashCode());
-            if (arg != null && triggers.ContainsKey(next))
-                uiStateMachine.Fire(triggers[next], arg);
+
+            StateMachineType.TriggerWithParameters<ViewWithData> viewWithDataTrigger = null;
+            if (arg != null)
+            {
+                if (next == Trigger.Next)
+                {
+                    switch (requestedTarget?.ViewType)
+                    {
+                        case UIViewType.PRDetail:
+                            viewWithDataTrigger = triggers[Trigger.PRDetail];
+                            break;
+                    }
+                }
+                else if (triggers.ContainsKey(next))
+                {
+                    viewWithDataTrigger = triggers[next];
+                }
+            }
+
+            if (viewWithDataTrigger != null)
+            {
+                uiStateMachine.Fire(viewWithDataTrigger, arg);
+            }
             else
+            {
                 uiStateMachine.Fire(next);
+            }
         }
 
         UIViewType Go(Trigger trigger)

--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -258,9 +258,15 @@ namespace GitHub.Controllers
 
         public void Jump(ViewWithData where)
         {
-            Debug.Assert(where.ActiveFlow == mainFlow, "Jump called for flow " + where.ActiveFlow + " but this is " + mainFlow);
             if (where.ActiveFlow != mainFlow)
-                return;
+            {
+                var message = string.Format(CultureInfo.CurrentCulture,
+                    "Jump called for flow {0} but this is {1}", 
+                    where.ActiveFlow, 
+                    mainFlow);
+
+                throw new ArgumentException(message);
+            }
 
             requestedTarget = where;
             if (activeFlow == where.ActiveFlow)

--- a/src/GitHub.VisualStudio/UI/Views/GitHubPaneViewModel.cs
+++ b/src/GitHub.VisualStudio/UI/Views/GitHubPaneViewModel.cs
@@ -184,13 +184,14 @@ namespace GitHub.VisualStudio.UI.Views
         void LoadView(UIControllerFlow flow, IConnection connection = null, ViewWithData data = null, UIViewType type = UIViewType.None)
         {
             // if we're loading a single view or a different flow, we need to stop the current controller
-            var restart = flow == UIControllerFlow.None || uiController?.SelectedFlow != flow;
+            var isSingleView = flow == UIControllerFlow.None;
+            var isSingleViewOrFlowChanging = isSingleView || uiController?.SelectedFlow != flow;
 
-            if (restart)
+            if (isSingleViewOrFlowChanging)
                 Stop();
 
             // if there's no selected flow, then just load a view directly
-            if (flow == UIControllerFlow.None)
+            if (isSingleView)
             {
                 var factory = ServiceProvider.GetExportedValue<IUIFactory>();
                 var c = factory.CreateViewAndViewModel(type);
@@ -198,7 +199,7 @@ namespace GitHub.VisualStudio.UI.Views
                 Control = c.View;
             }
             // it's a new flow!
-            else if (restart)
+            else if (isSingleViewOrFlowChanging)
             {
                 StartFlow(flow, connection, data);
             }

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestListView.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestListView.xaml.cs
@@ -28,7 +28,7 @@ namespace GitHub.VisualStudio.UI.Views
 
             OpenPR = new RelayCommand(x =>
             {
-                NotifyOpen(new ViewWithData { Data = x });
+                NotifyOpen(new ViewWithData(UIControllerFlow.PullRequests) { ViewType = UIViewType.PRDetail, Data = x});
             });
 
             OpenPROnGitHub = new RelayCommand(x =>

--- a/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
+++ b/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
@@ -606,6 +606,7 @@ public class UIControllerTests
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
+                    var pullRequestViewWithData = new ViewWithData(UIControllerFlow.PullRequests) { ViewType = GitHub.Exports.UIViewType.PRDetail, Data = 1 };
                     switch (++count)
                     {
                         case 1:
@@ -613,8 +614,7 @@ public class UIControllerTests
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Open a pull request
-                            TriggerDetailViewOpen(uc,
-                                new ViewWithData(UIControllerFlow.PullRequests) { ViewType = GitHub.Exports.UIViewType.PRDetail, Data = 1 });
+                            TriggerDetailViewOpen(uc, pullRequestViewWithData);
                             break;
                         case 2:
                             //Demonstate view is IPullRequestDetailViewModel
@@ -628,8 +628,7 @@ public class UIControllerTests
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Open a pull request
-                            TriggerDetailViewOpen(uc,
-                                new ViewWithData(UIControllerFlow.PullRequests) { ViewType = GitHub.Exports.UIViewType.PRDetail, Data = 1 });
+                            TriggerDetailViewOpen(uc, pullRequestViewWithData);
                             break;
                         case 4:
                             //Demonstate view is IPullRequestDetailViewModel
@@ -642,12 +641,12 @@ public class UIControllerTests
                             //Demonstate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
-                            //Creating a pull request
-                            TriggerCreationViewCreate(uc, null);
+                            //Jump to pull request
+                            uiController.Jump(pullRequestViewWithData);
                             break;
                         case 6:
-                            //Demonstate view is IPullRequestCreationViewModel
-                            Assert.IsAssignableFrom<IViewFor<IPullRequestCreationViewModel>>(uc);
+                            //Demonstate view is IPullRequestDetailViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
 
                             //Cancelling on the creation of a pull request
                             TriggerCancel(uc);
@@ -663,10 +662,24 @@ public class UIControllerTests
                             //Demonstate view is IPullRequestCreationViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestCreationViewModel>>(uc);
 
+                            //Cancelling on the creation of a pull request
+                            TriggerCancel(uc);
+                            break;
+                        case 9:
+                            //Demonstate view is IPullRequestListViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
+
+                            //Creating a pull request
+                            TriggerCreationViewCreate(uc, null);
+                            break;
+                        case 10:
+                            //Demonstate view is IPullRequestCreationViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestCreationViewModel>>(uc);
+
                             //Completing a pull request
                             TriggerDone(uc);
                             break;
-                        case 9:
+                        case 11:
                             //Demonstate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
@@ -677,7 +690,7 @@ public class UIControllerTests
                 });
 
                 uiController.Start(null);
-                Assert.Equal(9, count);
+                Assert.Equal(11, count);
                 Assert.True(uiController.IsStopped);
                 Assert.True(success.HasValue);
                 Assert.False(success);

--- a/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
+++ b/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
@@ -110,6 +110,16 @@ public class UIControllerTests
             return connection;
         }
 
+        protected void TriggerDetailViewOpen(IView uc, ViewWithData viewWithData)
+        {
+            ((ReplaySubject<ViewWithData>)((IHasDetailView)uc).Open).OnNext(viewWithData);
+        }
+
+        protected void TriggerCreationViewCreate(IView uc, ViewWithData viewWithData)
+        {
+            ((ReplaySubject<ViewWithData>)((IHasCreationView)uc).Create).OnNext(viewWithData);
+        }
+
         protected void TriggerCancel(IView view)
         {
             ((ReplaySubject<ViewWithData>)view.Cancel).OnNext(null);
@@ -118,6 +128,14 @@ public class UIControllerTests
         protected void TriggerDone(IView view)
         {
             ((ReplaySubject<ViewWithData>)view.Done).OnNext(null);
+        }
+    }
+
+    public class TheJumpMethod : UIControllerTestBase
+    {
+        [Fact]
+        public void Jump()
+        {
         }
     }
 
@@ -591,41 +609,68 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
-                            ((ReplaySubject<ViewWithData>)((IHasDetailView)uc).Open).OnNext(
+
+                            //Open a pull request
+                            TriggerDetailViewOpen(uc,
                                 new ViewWithData(UIControllerFlow.PullRequests) { ViewType = GitHub.Exports.UIViewType.PRDetail, Data = 1 });
                             break;
                         case 2:
+                            //Demonstate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
+
+                            //Completing a pull request
                             TriggerDone(uc);
                             break;
                         case 3:
+                            //Demonstate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
-                            ((ReplaySubject<ViewWithData>)((IHasDetailView)uc).Open).OnNext(
+
+                            //Open a pull request
+                            TriggerDetailViewOpen(uc,
                                 new ViewWithData(UIControllerFlow.PullRequests) { ViewType = GitHub.Exports.UIViewType.PRDetail, Data = 1 });
                             break;
                         case 4:
+                            //Demonstate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
+
+                            //Cancelling on a pull request
                             TriggerCancel(uc);
                             break;
                         case 5:
+                            //Demonstate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
-                            ((ReplaySubject<ViewWithData>)((IHasCreationView)uc).Create).OnNext(null);
+
+                            //Creating a pull request
+                            TriggerCreationViewCreate(uc, null);
                             break;
                         case 6:
+                            //Demonstate view is IPullRequestCreationViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestCreationViewModel>>(uc);
+
+                            //Cancelling on the creation of a pull request
                             TriggerCancel(uc);
                             break;
                         case 7:
+                            //Demonstate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
-                            ((ReplaySubject<ViewWithData>)((IHasCreationView)uc).Create).OnNext(null);
+
+                            //Creating a pull request
+                            TriggerCreationViewCreate(uc, null);
                             break;
                         case 8:
+                            //Demonstate view is IPullRequestCreationViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestCreationViewModel>>(uc);
+
+                            //Completing a pull request
                             TriggerDone(uc);
                             break;
                         case 9:
+                            //Demonstate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
+
+                            //Cancelling PullRequests flow
                             TriggerCancel(uc);
                             break;
                     }
@@ -671,7 +716,7 @@ public class UIControllerTests
                     {
                         case 1:
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
-                            ((ReplaySubject<ViewWithData>)((IHasDetailView)uc).Open).OnNext(
+                            TriggerDetailViewOpen(uc,
                                 new ViewWithData(UIControllerFlow.PullRequests) { ViewType = GitHub.Exports.UIViewType.PRDetail, Data = 1 });
                             break;
                         case 2:
@@ -680,7 +725,7 @@ public class UIControllerTests
                             break;
                         case 3:
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
-                            ((ReplaySubject<ViewWithData>)((IHasDetailView)uc).Open).OnNext(
+                            TriggerDetailViewOpen(uc,
                                 new ViewWithData(UIControllerFlow.PullRequests) { ViewType = GitHub.Exports.UIViewType.PRDetail, Data = 1 });
                             break;
                         case 4:

--- a/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
+++ b/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
@@ -131,14 +131,6 @@ public class UIControllerTests
         }
     }
 
-    public class TheJumpMethod : UIControllerTestBase
-    {
-        [Fact]
-        public void Jump()
-        {
-        }
-    }
-
     public class AuthFlow : UIControllerTestBase
     {
         [Fact]
@@ -153,23 +145,48 @@ public class UIControllerTests
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 1;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Clone flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Clone);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
+
+                            //Cancelling Clone flow
                             TriggerCancel(uc);
                             break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(1, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.False(success);
             }
         }
 
@@ -188,23 +205,48 @@ public class UIControllerTests
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 1;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Clone flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Clone);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is IRepositoryCloneViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
+
+                            //Cancelling Clone flow
                             TriggerCancel(uc);
                             break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(1, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.False(success);
             }
         }
 
@@ -220,23 +262,48 @@ public class UIControllerTests
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 1;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Authentication flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Authentication);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
+
+                            //Cancelling Authentication flow
                             TriggerCancel(uc);
                             break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(1, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.False(success);
             }
         }
 
@@ -256,23 +323,48 @@ public class UIControllerTests
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 1;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Authentication flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Authentication);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
+
+                            //Cancelling Authentication flow
                             TriggerCancel(uc);
                             break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(1, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.False(success);
             }
         }
 
@@ -288,29 +380,57 @@ public class UIControllerTests
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 2;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Clone flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Clone);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
-                            // login
+                          
+                            //Login
                             cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost));
+
                             TriggerDone(uc);
                             break;
                         case 2:
+                            //Demonstate view is IRepositoryCloneViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
+
+                            //Cancelling Clone flow
                             TriggerCancel(uc);
                             break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(2, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.True(success);
             }
         }
 
@@ -326,37 +446,71 @@ public class UIControllerTests
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 3;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Clone flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Clone);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
+
+                            //Displaying the TwoFactorView
                             var vm = factory.CreateViewAndViewModel(GitHub.Exports.UIViewType.TwoFactor).ViewModel;
                             vm.IsShowing.Returns(true);
                             RaisePropertyChange(vm, "IsShowing");
+
                             break;
                         case 2:
+                            //Demonstate view is ITwoFactorDialogViewModel
                             Assert.IsAssignableFrom<IViewFor<ITwoFactorDialogViewModel>>(uc);
-                            // login
+
+                            //Login
                             cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost));
-                            // continue by triggering done on login view
+                            
+                            //Continue by triggering done on login view
                             var v = factory.CreateViewAndViewModel(GitHub.Exports.UIViewType.Login).View;
                             TriggerDone(v);
+
                             break;
                         case 3:
+                            //Demonstate view is IRepositoryCloneViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
+
+                            //Cancelling Clone flow
                             TriggerCancel(uc);
+
+                            break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
                             break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(3, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.True(success);
             }
         }
 
@@ -372,54 +526,100 @@ public class UIControllerTests
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 5;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Clone flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Clone);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
-                        case 1: {
-                            Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
-                            var vm = factory.CreateViewAndViewModel(GitHub.Exports.UIViewType.TwoFactor).ViewModel;
-                            vm.IsShowing.Returns(true);
-                            RaisePropertyChange(vm, "IsShowing");
-                            break;
-                        }
-                        case 2: {
-                            Assert.IsAssignableFrom<IViewFor<ITwoFactorDialogViewModel>>(uc);
-                            var vm = factory.CreateViewAndViewModel(GitHub.Exports.UIViewType.TwoFactor).ViewModel;
-                            vm.IsShowing.Returns(false);
-                            RaisePropertyChange(vm, "IsShowing");
-                            TriggerCancel(uc);
-                            break;
-                        }
-                        case 3: {
-                            Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
-                            var vm = factory.CreateViewAndViewModel(GitHub.Exports.UIViewType.TwoFactor).ViewModel;
-                            vm.IsShowing.Returns(true);
-                            RaisePropertyChange(vm, "IsShowing");
-                            break;
-                        }
-                        case 4: {
-                            Assert.IsAssignableFrom<IViewFor<ITwoFactorDialogViewModel>>(uc);
-                            // login
-                            cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost));
-                            var v = factory.CreateViewAndViewModel(GitHub.Exports.UIViewType.Login).View;
-                            TriggerDone(v);
-                            break;
-                        }
-                        case 5: {
-                            Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
-                            uiController.Stop();
-                            break;
-                        }
+                        case 1:
+                            {
+                                //Demonstate view is ILoginControlViewModel
+                                Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
+
+                                //Displaying the TwoFactorView
+                                var vm = factory.CreateViewAndViewModel(GitHub.Exports.UIViewType.TwoFactor).ViewModel;
+                                vm.IsShowing.Returns(true);
+                                RaisePropertyChange(vm, "IsShowing");
+
+                                break;
+                            }
+                        case 2:
+                            {
+                                //Demonstate view is ITwoFactorDialogViewModel
+                                Assert.IsAssignableFrom<IViewFor<ITwoFactorDialogViewModel>>(uc);
+
+                                //Hiding the TwoFactorView
+                                var vm = factory.CreateViewAndViewModel(GitHub.Exports.UIViewType.TwoFactor).ViewModel;
+                                vm.IsShowing.Returns(false);
+                                RaisePropertyChange(vm, "IsShowing");
+
+                                //Cancelling the TwoFactorDialog
+                                TriggerCancel(uc);
+
+                                break;
+                            }
+                        case 3:
+                            {
+                                //Demonstate view is ILoginControlViewModel
+                                Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
+
+                                //Displaying the TwoFactorView
+                                var vm = factory.CreateViewAndViewModel(GitHub.Exports.UIViewType.TwoFactor).ViewModel;
+                                vm.IsShowing.Returns(true);
+                                RaisePropertyChange(vm, "IsShowing");
+
+                                break;
+                            }
+                        case 4:
+                            {
+                                //Demonstate view is ITwoFactorDialogViewModel
+                                Assert.IsAssignableFrom<IViewFor<ITwoFactorDialogViewModel>>(uc);
+                             
+                                //Login
+                                cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost));
+
+                                //Completing the TwoFactorDialog
+                                var v = factory.CreateViewAndViewModel(GitHub.Exports.UIViewType.Login).View;
+                                TriggerDone(v);
+
+                                break;
+                            }
+                        case 5:
+                            {
+                                //Demonstate view is IRepositoryCloneViewModel
+                                Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
+
+                                //Stopping UIController
+                                uiController.Stop();
+
+                                break;
+                            }
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(5, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.True(success);
             }
         }
     }
@@ -436,28 +636,53 @@ public class UIControllerTests
             var cons = new ObservableCollection<IConnection>();
             cm.Connections.Returns(cons);
 
-            // simulate being logged in
+            //Simulate being logged in
             cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost));
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 1;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Clone flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Clone);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is IRepositoryCloneViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
+
+                            //Completing Create flow
                             TriggerDone(uc);
                             break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(1, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.True(success);
             }
         }
     }
@@ -474,28 +699,53 @@ public class UIControllerTests
             var cons = new ObservableCollection<IConnection>();
             cm.Connections.Returns(cons);
 
-            // simulate being logged in
+            //Simulate being logged in
             cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost));
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 1;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Create flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Create);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is IRepositoryCreationViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryCreationViewModel>>(uc);
+
+                            //Completing Create flow
                             TriggerDone(uc);
                             break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(1, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.True(success);
             }
         }
     }
@@ -505,7 +755,7 @@ public class UIControllerTests
         [Fact]
         public void FlowWithConnection()
         {
-            var provider = Substitutes.GetFullyMockedServiceProvider();
+            var provider = (IUIProvider)Substitutes.GetFullyMockedServiceProvider();
             var hosts = provider.GetRepositoryHosts();
             var factory = SetupFactory(provider);
             var cm = provider.GetConnectionManager();
@@ -513,36 +763,62 @@ public class UIControllerTests
             cm.Connections.Returns(cons);
             var connection = SetupConnection(provider, hosts, hosts.GitHubHost);
 
-            // simulate being logged in
+            //Simulate being logged in
             cons.Add(connection);
 
-            using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
+            using (var uiController = new UIController(provider, hosts, factory, cm))
             {
+                const int testViewCount = 1;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Publish flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Publish);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is IRepositoryPublishViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryPublishViewModel>>(uc);
-                            ((IUIProvider)provider).Received().AddService(uiController, connection);
+
+                            provider.Received().AddService(uiController, connection);
+
+                            //Completing Publish flow
                             TriggerDone(uc);
                             break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(connection);
-                Assert.Equal(1, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.True(success);
             }
         }
 
         [Fact]
         public void FlowWithoutConnection()
         {
-            var provider = Substitutes.GetFullyMockedServiceProvider();
+            var provider = (IUIProvider)Substitutes.GetFullyMockedServiceProvider();
             var hosts = provider.GetRepositoryHosts();
             var factory = SetupFactory(provider);
             var cm = provider.GetConnectionManager();
@@ -550,32 +826,57 @@ public class UIControllerTests
             cm.Connections.Returns(cons);
             var connection = SetupConnection(provider, hosts, hosts.GitHubHost);
 
-            // simulate being logged in
+            //Simulate being logged in
             cons.Add(connection);
 
-            using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
+            using (var uiController = new UIController(provider, hosts, factory, cm))
             {
+                const int testViewCount = 1;
+
                 var count = 0;
+                bool? success = null;
+
+                //Starting Publish flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Publish);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is IRepositoryPublishViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryPublishViewModel>>(uc);
-                            ((IUIProvider)provider).Received().AddService(uiController, connection);
+
+                            provider.Received().AddService(uiController, connection);
+                         
+                            //Completing Publish flow
                             TriggerDone(uc);
                             break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(1, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.True(success);
             }
         }
-
     }
 
     public class PullRequestsFlow : UIControllerTestBase
@@ -590,23 +891,33 @@ public class UIControllerTests
             var cons = new ObservableCollection<IConnection>();
             cm.Connections.Returns(cons);
 
-            // simulate being logged in
+            //Simulate being logged in
             cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost));
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 11;
+                var testPullRequestViewWithData = new ViewWithData(UIControllerFlow.PullRequests)
+                {
+                    ViewType = GitHub.Exports.UIViewType.PRDetail,
+                    Data = 1
+                };
+
                 var count = 0;
                 bool? success = null;
+
+                //Starting PullRequests flow
                 var flow = uiController.SelectFlow(UIControllerFlow.PullRequests);
                 uiController.ListenToCompletionState()
                     .Subscribe(s =>
                     {
                         success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
                     });
                 flow.Subscribe(data =>
                 {
                     var uc = data.View;
-                    var pullRequestViewWithData = new ViewWithData(UIControllerFlow.PullRequests) { ViewType = GitHub.Exports.UIViewType.PRDetail, Data = 1 };
                     switch (++count)
                     {
                         case 1:
@@ -614,7 +925,7 @@ public class UIControllerTests
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Open a pull request
-                            TriggerDetailViewOpen(uc, pullRequestViewWithData);
+                            TriggerDetailViewOpen(uc, testPullRequestViewWithData);
                             break;
                         case 2:
                             //Demonstate view is IPullRequestDetailViewModel
@@ -628,7 +939,7 @@ public class UIControllerTests
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Open a pull request
-                            TriggerDetailViewOpen(uc, pullRequestViewWithData);
+                            TriggerDetailViewOpen(uc, testPullRequestViewWithData);
                             break;
                         case 4:
                             //Demonstate view is IPullRequestDetailViewModel
@@ -642,7 +953,7 @@ public class UIControllerTests
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Jump to pull request
-                            uiController.Jump(pullRequestViewWithData);
+                            uiController.Jump(testPullRequestViewWithData);
                             break;
                         case 6:
                             //Demonstate view is IPullRequestDetailViewModel
@@ -686,11 +997,19 @@ public class UIControllerTests
                             //Cancelling PullRequests flow
                             TriggerCancel(uc);
                             break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
                     }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(11, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
                 Assert.True(success.HasValue);
                 Assert.False(success);
@@ -707,19 +1026,28 @@ public class UIControllerTests
             var cons = new ObservableCollection<IConnection>();
             cm.Connections.Returns(cons);
 
-            // simulate being logged in
+            //Simulate being logged in
             cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost));
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 4;
+                var testPullRequestViewWithData = new ViewWithData(UIControllerFlow.PullRequests)
+                {
+                    ViewType = GitHub.Exports.UIViewType.PRDetail,
+                    Data = 1
+                };
+
                 var count = 0;
                 bool? success = null;
+
+                //Starting PullRequests flow
                 var flow = uiController.SelectFlow(UIControllerFlow.PullRequests);
                 uiController.ListenToCompletionState()
                     .Subscribe(s =>
                     {
                         success = s;
-                        Assert.Equal(4, count);
+                        Assert.Equal(testViewCount, count);
                         count++;
                     });
                 flow.Subscribe(data =>
@@ -728,32 +1056,46 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
-                            TriggerDetailViewOpen(uc,
-                                new ViewWithData(UIControllerFlow.PullRequests) { ViewType = GitHub.Exports.UIViewType.PRDetail, Data = 1 });
+
+                            //Open a pull request
+                            TriggerDetailViewOpen(uc, testPullRequestViewWithData);
                             break;
                         case 2:
+                            //Demonstate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
+
+                            //Completing a pull request
                             TriggerDone(uc);
                             break;
                         case 3:
+                            //Demonstate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
-                            TriggerDetailViewOpen(uc,
-                                new ViewWithData(UIControllerFlow.PullRequests) { ViewType = GitHub.Exports.UIViewType.PRDetail, Data = 1 });
+
+                            //Open a pull request
+                            TriggerDetailViewOpen(uc, testPullRequestViewWithData);
                             break;
                         case 4:
+                            //Demonstate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
+
+                            //Stopping UIController
                             uiController.Stop();
+                            break;
+
+                        default:
+                            Assert.True(false, "Received more views than expected");
                             break;
                     }
                 }, () =>
                 {
-                    Assert.Equal(5, count);
+                    Assert.Equal(testViewCount + 1, count);
                     count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(6, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
                 Assert.True(success.HasValue);
                 Assert.True(success);
@@ -774,19 +1116,24 @@ public class UIControllerTests
             cm.Connections.Returns(cons);
 
             var host = hosts.GitHubHost;
-            // simulate being logged in
-            cons.Add(SetupConnection(provider, hosts, host, true, false));
+            //Simulate being logged in without gist support
+            const bool supportsGist = false;
+            cons.Add(SetupConnection(provider, hosts, host, true, supportsGist));
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 3;
+
                 var count = 0;
                 bool? success = null;
+
+                //Starting Gist flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Gist);
                 uiController.ListenToCompletionState()
                     .Subscribe(s =>
                     {
                         success = s;
-                        Assert.Equal(3, count);
+                        Assert.Equal(testViewCount, count);
                         count++;
                     });
 
@@ -796,33 +1143,43 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is ILogoutRequiredViewModel
                             Assert.IsAssignableFrom<IViewFor<ILogoutRequiredViewModel>>(uc);
                             host.IsLoggedIn.Returns(false);
+
+                            //Completing View
                             TriggerDone(uc);
                             break;
                         case 2:
+                            //Demonstate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
+                            
                             // login
                             host.IsLoggedIn.Returns(true);
                             host.SupportsGist.Returns(true);
+
+                            //Completing View
                             TriggerDone(uc);
                             break;
                         case 3:
+                            //Demonstate view is IGistCreationViewModel
                             Assert.IsAssignableFrom<IViewFor<IGistCreationViewModel>>(uc);
+
+                            //Completing PullRequests flow
                             TriggerDone(uc);
                             break;
+
                         default:
-                            Assert.True(false, "Received more views than expected");
-                            break;
+                            throw new Exception("Received more views than expected");
                     }
                 }, () =>
                 {
-                    Assert.Equal(4, count);
+                    Assert.Equal(testViewCount + 1, count);
                     count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(5, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
                 Assert.True(success.HasValue);
                 Assert.True(success);
@@ -839,19 +1196,24 @@ public class UIControllerTests
             var cons = new ObservableCollection<IConnection>();
             cm.Connections.Returns(cons);
 
-            // simulate being logged in
-            cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost, true, true));
+            //Simulate being logged in with gist support
+            const bool supportsGist = true;
+            cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost, true, supportsGist));
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
+                const int testViewCount = 1;
+
                 var count = 0;
                 bool? success = null;
+
+                //Starting Gist flow
                 var flow = uiController.SelectFlow(UIControllerFlow.Gist);
                 uiController.ListenToCompletionState()
                     .Subscribe(s =>
                     {
                         success = s;
-                        Assert.Equal(1, count);
+                        Assert.Equal(testViewCount, count);
                         count++;
                     });
 
@@ -861,21 +1223,25 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
+                            //Demonstate view is IGistCreationViewModel
                             Assert.IsAssignableFrom<IViewFor<IGistCreationViewModel>>(uc);
+                     
+                            //Completing PullRequests flow
                             TriggerDone(uc);
                             break;
+
                         default:
                             Assert.True(false, "Received more views than expected");
                             break;
                     }
                 }, () =>
                 {
-                    Assert.Equal(2, count);
+                    Assert.Equal(testViewCount + 1, count);
                     count++;
                 });
 
                 uiController.Start(null);
-                Assert.Equal(3, count);
+                Assert.Equal(testViewCount + 2, count);
                 Assert.True(uiController.IsStopped);
                 Assert.True(success.HasValue);
                 Assert.True(success);

--- a/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
+++ b/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
@@ -1018,7 +1018,7 @@ public class UIControllerTests
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
-                const int testViewCount = 6;
+                const int testViewCount = 7;
 
                 var testPullRequestViewWithData = new ViewWithData(UIControllerFlow.PullRequests)
                 {
@@ -1078,7 +1078,7 @@ public class UIControllerTests
                             //Demonstrate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
-                            //Demonstrate jump to current view
+                            //Demonstrate jump to current view, pull request list
                             uiController.Jump(testPullRequestListViewWithData);
                             break;
                         case 4:
@@ -1092,10 +1092,17 @@ public class UIControllerTests
                             //Demonstrate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
 
+                            //Demonstrate jump to current view, pull request
+                            uiController.Jump(testPullRequestListViewWithData);
+                            break;
+                        case 6:
+                            //Demonstrate view is IPullRequestDetailViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
+
                             //Cancelling the pull request
                             TriggerCancel(uc);
                             break;
-                        case 6:
+                        case 7:
                             //Demonstrate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 

--- a/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
+++ b/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
@@ -1064,8 +1064,8 @@ public class UIControllerTests
                             //Demonstrate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
 
-                            //Jump to Publish View
-                            uiController.Jump(testPublishViewWithData);
+                            //Attempt Jump to Publish View
+                            Assert.Throws<ArgumentException>(()=> uiController.Jump(testPublishViewWithData));
 
                             //Demonstrate nothing happens when jump attempted to view outside of UIControllerFlow.PullRequests
                             //Demonstrate view is IPullRequestDetailViewModel
@@ -1078,16 +1078,17 @@ public class UIControllerTests
                             //Demonstrate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
-                            //Demonstrate cannot jump to same view
+                            //Demonstrate jump to current view
                             uiController.Jump(testPullRequestListViewWithData);
-
+                            break;
+                        case 4:
                             //Demonstrate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Jump back to pull request
                             uiController.Jump(testPullRequestViewWithData);
                             break;
-                        case 4:
+                        case 5:
                             //Demonstrate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
 

--- a/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
+++ b/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
@@ -1120,7 +1120,6 @@ public class UIControllerTests
             }
         }
 
-
         [Fact]
         public void ShuttingDown()
         {

--- a/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
+++ b/src/UnitTests/GitHub.App/Controllers/UIControllerTests.cs
@@ -165,7 +165,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is ILoginControlViewModel
+                            //Demonstrate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
 
                             //Cancelling Clone flow
@@ -225,7 +225,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is IRepositoryCloneViewModel
+                            //Demonstrate view is IRepositoryCloneViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
 
                             //Cancelling Clone flow
@@ -282,7 +282,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is ILoginControlViewModel
+                            //Demonstrate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
 
                             //Cancelling Authentication flow
@@ -343,7 +343,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is ILoginControlViewModel
+                            //Demonstrate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
 
                             //Cancelling Authentication flow
@@ -400,7 +400,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is ILoginControlViewModel
+                            //Demonstrate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
                           
                             //Login
@@ -409,7 +409,7 @@ public class UIControllerTests
                             TriggerDone(uc);
                             break;
                         case 2:
-                            //Demonstate view is IRepositoryCloneViewModel
+                            //Demonstrate view is IRepositoryCloneViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
 
                             //Cancelling Clone flow
@@ -466,7 +466,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is ILoginControlViewModel
+                            //Demonstrate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
 
                             //Displaying the TwoFactorView
@@ -476,7 +476,7 @@ public class UIControllerTests
 
                             break;
                         case 2:
-                            //Demonstate view is ITwoFactorDialogViewModel
+                            //Demonstrate view is ITwoFactorDialogViewModel
                             Assert.IsAssignableFrom<IViewFor<ITwoFactorDialogViewModel>>(uc);
 
                             //Login
@@ -488,7 +488,7 @@ public class UIControllerTests
 
                             break;
                         case 3:
-                            //Demonstate view is IRepositoryCloneViewModel
+                            //Demonstrate view is IRepositoryCloneViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
 
                             //Cancelling Clone flow
@@ -547,7 +547,7 @@ public class UIControllerTests
                     {
                         case 1:
                             {
-                                //Demonstate view is ILoginControlViewModel
+                                //Demonstrate view is ILoginControlViewModel
                                 Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
 
                                 //Displaying the TwoFactorView
@@ -559,7 +559,7 @@ public class UIControllerTests
                             }
                         case 2:
                             {
-                                //Demonstate view is ITwoFactorDialogViewModel
+                                //Demonstrate view is ITwoFactorDialogViewModel
                                 Assert.IsAssignableFrom<IViewFor<ITwoFactorDialogViewModel>>(uc);
 
                                 //Hiding the TwoFactorView
@@ -574,7 +574,7 @@ public class UIControllerTests
                             }
                         case 3:
                             {
-                                //Demonstate view is ILoginControlViewModel
+                                //Demonstrate view is ILoginControlViewModel
                                 Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
 
                                 //Displaying the TwoFactorView
@@ -586,7 +586,7 @@ public class UIControllerTests
                             }
                         case 4:
                             {
-                                //Demonstate view is ITwoFactorDialogViewModel
+                                //Demonstrate view is ITwoFactorDialogViewModel
                                 Assert.IsAssignableFrom<IViewFor<ITwoFactorDialogViewModel>>(uc);
                              
                                 //Login
@@ -600,7 +600,7 @@ public class UIControllerTests
                             }
                         case 5:
                             {
-                                //Demonstate view is IRepositoryCloneViewModel
+                                //Demonstrate view is IRepositoryCloneViewModel
                                 Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
 
                                 //Stopping UIController
@@ -661,7 +661,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is IRepositoryCloneViewModel
+                            //Demonstrate view is IRepositoryCloneViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryCloneViewModel>>(uc);
 
                             //Completing Create flow
@@ -724,7 +724,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is IRepositoryCreationViewModel
+                            //Demonstrate view is IRepositoryCreationViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryCreationViewModel>>(uc);
 
                             //Completing Create flow
@@ -788,7 +788,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is IRepositoryPublishViewModel
+                            //Demonstrate view is IRepositoryPublishViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryPublishViewModel>>(uc);
 
                             provider.Received().AddService(uiController, connection);
@@ -851,7 +851,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is IRepositoryPublishViewModel
+                            //Demonstrate view is IRepositoryPublishViewModel
                             Assert.IsAssignableFrom<IViewFor<IRepositoryPublishViewModel>>(uc);
 
                             provider.Received().AddService(uiController, connection);
@@ -896,7 +896,8 @@ public class UIControllerTests
 
             using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
             {
-                const int testViewCount = 11;
+                const int testViewCount = 9;
+
                 var testPullRequestViewWithData = new ViewWithData(UIControllerFlow.PullRequests)
                 {
                     ViewType = GitHub.Exports.UIViewType.PRDetail,
@@ -921,77 +922,63 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is IPullRequestListViewModel
+                            //Demonstrate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Open a pull request
                             TriggerDetailViewOpen(uc, testPullRequestViewWithData);
                             break;
                         case 2:
-                            //Demonstate view is IPullRequestDetailViewModel
+                            //Demonstrate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
 
                             //Completing a pull request
                             TriggerDone(uc);
                             break;
                         case 3:
-                            //Demonstate view is IPullRequestListViewModel
+                            //Demonstrate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Open a pull request
                             TriggerDetailViewOpen(uc, testPullRequestViewWithData);
                             break;
                         case 4:
-                            //Demonstate view is IPullRequestDetailViewModel
+                            //Demonstrate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
 
                             //Cancelling on a pull request
                             TriggerCancel(uc);
                             break;
                         case 5:
-                            //Demonstate view is IPullRequestListViewModel
+                            //Demonstrate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
-                            //Jump to pull request
-                            uiController.Jump(testPullRequestViewWithData);
+                            //Creating a pull request
+                            TriggerCreationViewCreate(uc, null);
                             break;
                         case 6:
-                            //Demonstate view is IPullRequestDetailViewModel
-                            Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
+                            //Demonstrate view is IPullRequestCreationViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestCreationViewModel>>(uc);
 
                             //Cancelling on the creation of a pull request
                             TriggerCancel(uc);
                             break;
                         case 7:
-                            //Demonstate view is IPullRequestListViewModel
+                            //Demonstrate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Creating a pull request
                             TriggerCreationViewCreate(uc, null);
                             break;
                         case 8:
-                            //Demonstate view is IPullRequestCreationViewModel
-                            Assert.IsAssignableFrom<IViewFor<IPullRequestCreationViewModel>>(uc);
-
-                            //Cancelling on the creation of a pull request
-                            TriggerCancel(uc);
-                            break;
-                        case 9:
-                            //Demonstate view is IPullRequestListViewModel
-                            Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
-
-                            //Creating a pull request
-                            TriggerCreationViewCreate(uc, null);
-                            break;
-                        case 10:
-                            //Demonstate view is IPullRequestCreationViewModel
+                            //Demonstrate view is IPullRequestCreationViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestCreationViewModel>>(uc);
 
                             //Completing a pull request
                             TriggerDone(uc);
                             break;
-                        case 11:
-                            //Demonstate view is IPullRequestListViewModel
+                        case 9:
+                            //Demonstrate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Cancelling PullRequests flow
@@ -1015,6 +1002,123 @@ public class UIControllerTests
                 Assert.False(success);
             }
         }
+
+        [Fact]
+        public void Jump()
+        {
+            var provider = Substitutes.GetFullyMockedServiceProvider();
+            var hosts = provider.GetRepositoryHosts();
+            var factory = SetupFactory(provider);
+            var cm = provider.GetConnectionManager();
+            var cons = new ObservableCollection<IConnection>();
+            cm.Connections.Returns(cons);
+
+            //Simulate being logged in
+            cons.Add(SetupConnection(provider, hosts, hosts.GitHubHost));
+
+            using (var uiController = new UIController((IUIProvider)provider, hosts, factory, cm))
+            {
+                const int testViewCount = 6;
+
+                var testPullRequestViewWithData = new ViewWithData(UIControllerFlow.PullRequests)
+                {
+                    ViewType = GitHub.Exports.UIViewType.PRDetail,
+                    Data = 1
+                };
+
+                var testPullRequestListViewWithData = new ViewWithData(UIControllerFlow.PullRequests)
+                {
+                    ViewType = GitHub.Exports.UIViewType.PRList,
+                };
+
+                var testPublishViewWithData = new ViewWithData(UIControllerFlow.Publish)
+                {
+                    ViewType = GitHub.Exports.UIViewType.Publish,
+                };
+
+                var count = 0;
+                bool? success = null;
+
+                //Starting PullRequests flow
+                var flow = uiController.SelectFlow(UIControllerFlow.PullRequests);
+                uiController.ListenToCompletionState()
+                    .Subscribe(s =>
+                    {
+                        success = s;
+                        Assert.Equal(testViewCount, count);
+                        count++;
+                    });
+                flow.Subscribe(data =>
+                {
+                    var uc = data.View;
+                    switch (++count)
+                    {
+                        case 1:
+                            //Demonstrate view is IPullRequestListViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
+                            
+                            //Open a pull request
+                            TriggerDetailViewOpen(uc, testPullRequestViewWithData);
+                            break;
+                        case 2:
+                            //Demonstrate view is IPullRequestDetailViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
+
+                            //Jump to Publish View
+                            uiController.Jump(testPublishViewWithData);
+
+                            //Demonstrate nothing happens when jump attempted to view outside of UIControllerFlow.PullRequests
+                            //Demonstrate view is IPullRequestDetailViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
+
+                            //Jump to pull request list
+                            uiController.Jump(testPullRequestListViewWithData);
+                            break;
+                        case 3:
+                            //Demonstrate view is IPullRequestListViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
+
+                            //Demonstrate cannot jump to same view
+                            uiController.Jump(testPullRequestListViewWithData);
+
+                            //Demonstrate view is IPullRequestDetailViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
+
+                            //Jump back to pull request
+                            uiController.Jump(testPullRequestViewWithData);
+                            break;
+                        case 4:
+                            //Demonstrate view is IPullRequestDetailViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
+
+                            //Cancelling the pull request
+                            TriggerCancel(uc);
+                            break;
+                        case 6:
+                            //Demonstrate view is IPullRequestDetailViewModel
+                            Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
+
+                            //Cancelling PullRequests flow
+                            TriggerCancel(uc);
+                            break;
+                        default:
+                            Assert.True(false, "Received more views than expected");
+                            break;
+                    }
+                }, () =>
+                {
+                    Assert.Equal(testViewCount + 1, count);
+                    count++;
+                });
+
+                uiController.Start(null);
+                Assert.Equal(testViewCount + 2, count);
+                Assert.True(uiController.IsStopped);
+                Assert.True(success.HasValue);
+                Assert.False(success);
+            }
+        }
+
 
         [Fact]
         public void ShuttingDown()
@@ -1056,28 +1160,28 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is IPullRequestListViewModel
+                            //Demonstrate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Open a pull request
                             TriggerDetailViewOpen(uc, testPullRequestViewWithData);
                             break;
                         case 2:
-                            //Demonstate view is IPullRequestDetailViewModel
+                            //Demonstrate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
 
                             //Completing a pull request
                             TriggerDone(uc);
                             break;
                         case 3:
-                            //Demonstate view is IPullRequestListViewModel
+                            //Demonstrate view is IPullRequestListViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestListViewModel>>(uc);
 
                             //Open a pull request
                             TriggerDetailViewOpen(uc, testPullRequestViewWithData);
                             break;
                         case 4:
-                            //Demonstate view is IPullRequestDetailViewModel
+                            //Demonstrate view is IPullRequestDetailViewModel
                             Assert.IsAssignableFrom<IViewFor<IPullRequestDetailViewModel>>(uc);
 
                             //Stopping UIController
@@ -1143,7 +1247,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is ILogoutRequiredViewModel
+                            //Demonstrate view is ILogoutRequiredViewModel
                             Assert.IsAssignableFrom<IViewFor<ILogoutRequiredViewModel>>(uc);
                             host.IsLoggedIn.Returns(false);
 
@@ -1151,7 +1255,7 @@ public class UIControllerTests
                             TriggerDone(uc);
                             break;
                         case 2:
-                            //Demonstate view is ILoginControlViewModel
+                            //Demonstrate view is ILoginControlViewModel
                             Assert.IsAssignableFrom<IViewFor<ILoginControlViewModel>>(uc);
                             
                             // login
@@ -1162,7 +1266,7 @@ public class UIControllerTests
                             TriggerDone(uc);
                             break;
                         case 3:
-                            //Demonstate view is IGistCreationViewModel
+                            //Demonstrate view is IGistCreationViewModel
                             Assert.IsAssignableFrom<IViewFor<IGistCreationViewModel>>(uc);
 
                             //Completing PullRequests flow
@@ -1223,7 +1327,7 @@ public class UIControllerTests
                     switch (++count)
                     {
                         case 1:
-                            //Demonstate view is IGistCreationViewModel
+                            //Demonstrate view is IGistCreationViewModel
                             Assert.IsAssignableFrom<IViewFor<IGistCreationViewModel>>(uc);
                      
                             //Completing PullRequests flow


### PR DESCRIPTION
Attempting to resolve #628

In `UIController` When `Jump()` uses `Fire()` to change states, `Fire()` does not correctly determine if the requested state in `requestedTarget` requires an argument.