### PR TITLE
Polish pull request details view

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -39,8 +39,8 @@ namespace GitHub.SampleData
                 CommitCount = 9,
             };
 
-            SourceBranchDisplayName = "shana/error-handling";
-            TargetBranchDisplayName = "master";
+            SourceBranchDisplayName = "shana/error-handling-a-ridiculously-long-branch-name-because-why-not";
+            TargetBranchDisplayName = "master-is-always-stable";
             Body = @"Adds a way to surface errors from the view model to the view so that view hosts can get to them.
 
 ViewModels are responsible for handling the UI on the view they control, but they shouldn't be handling UI for things outside of the view. In this case, we're showing errors in VS outside the view, and that should be handled by the section that is hosting the view.

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeBlue.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeBlue.xaml
@@ -53,4 +53,6 @@
   <SolidColorBrush x:Key="GitHubTabItemSelectedBorder" Color="#FFD0D7E4" />
 
   <SolidColorBrush x:Key="GitHubDirectoryIconForeground" Color="#FFF5D367" />
+
+  <SolidColorBrush x:Key="GitHubBranchNameBackgroundBrush" Color="#FFE8F0F8" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeDark.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeDark.xaml
@@ -53,4 +53,6 @@
   <SolidColorBrush x:Key="GitHubTabItemSelectedBorder" Color="#FF3F3F46" />
 
   <SolidColorBrush x:Key="GitHubDirectoryIconForeground" Color="#FF87C3FC" />
+
+  <SolidColorBrush x:Key="GitHubBranchNameBackgroundBrush" Color="#FF4B4D50" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeDesignTime.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeDesignTime.xaml
@@ -4,7 +4,7 @@
   xmlns:PresentationOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
 
   <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Styles/ThemeLight.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Styles/ThemeBlue.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
   <!-- Design time colors taken from the VS dark theme

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeDesignTime.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeDesignTime.xaml
@@ -4,7 +4,7 @@
   xmlns:PresentationOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
 
   <ResourceDictionary.MergedDictionaries>
-    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Styles/ThemeBlue.xaml" />
+    <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Styles/ThemeLight.xaml" />
   </ResourceDictionary.MergedDictionaries>
 
   <!-- Design time colors taken from the VS dark theme
@@ -16,9 +16,11 @@
   <SolidColorBrush x:Key="GitHubVsSearchBoxBackground" Color="#FF333337" />
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FFF1F1F1" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FF3F3F46" />
+  <SolidColorBrush x:Key="GitHubBranchNameBackgroundBrush" Color="#FF4B4D50" />
   -->
 
   <!-- Design time colors taken from the VS light theme
+  -->
   <SolidColorBrush x:Key="GitHubVsToolWindowText" Color="#FF1E1E1E" />
   <SolidColorBrush x:Key="GitHubVsToolWindowBackground" Color="#FFF5F5F5" />
   <SolidColorBrush x:Key="GitHubVsGrayText" Color="#FF717171" />
@@ -28,10 +30,10 @@
   <SolidColorBrush x:Key="GitHubVsWindowText" Color="#FF1E1E1E" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FFCCCEBD" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FFEEEEF2" />
-  -->
+  <SolidColorBrush x:Key="GitHubDirectoryIconForeground" Color="#FFF5D367" />
+  <SolidColorBrush x:Key="GitHubBranchNameBackgroundBrush" Color="#FFDAE8F6" />
 
   <!-- Design time colors taken from the VS blue theme
-  -->
   <SolidColorBrush x:Key="GitHubVsToolWindowText" Color="#FF000000" />
   <SolidColorBrush x:Key="GitHubVsToolWindowBackground" Color="#FFFFFFFF" />
   <SolidColorBrush x:Key="GitHubVsGrayText" Color="#FF6d6d6d" />
@@ -42,4 +44,6 @@
   <SolidColorBrush x:Key="GitHubVsBrandedUIBorder" Color="#FF8591A2" />
   <SolidColorBrush x:Key="GitHubVsBrandedUIBackground" Color="#FFFFFFFF" />
   <SolidColorBrush x:Key="GitHubDirectoryIconForeground" Color="#FFF5D367" />
+  <SolidColorBrush x:Key="GitHubBranchNameBackgroundBrush" Color="#FFE8F0F8" />
+  -->
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeLight.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeLight.xaml
@@ -53,4 +53,6 @@
   <SolidColorBrush x:Key="GitHubTabItemSelectedBorder" Color="#FFCCCEBD" />
 
   <SolidColorBrush x:Key="GitHubDirectoryIconForeground" Color="#FFF5D367" />
+
+  <SolidColorBrush x:Key="GitHubBranchNameBackgroundBrush" Color="#FFDAE8F6" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/UI/Controls/AccountAvatar.xaml
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/AccountAvatar.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:GitHub.VisualStudio.UI.Controls"
-             MinWidth="20" MinHeight="20">
+             MinWidth="16" MinHeight="16">
     <Grid>
         <Grid.OpacityMask>
             <VisualBrush Visual="{Binding ElementName=avatarMask}"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -17,6 +17,7 @@
                                     d:DesignWidth="356"
                                     d:DesignHeight="800"
                                     mc:Ignorable="d"
+                                    xmlns:vsui="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
                                     Style="{DynamicResource BusyStateView}">
     <d:DesignProperties.DataContext>
         <Binding>
@@ -100,14 +101,13 @@
             </Grid.ColumnDefinitions>
 
             <TextBlock Grid.Column="0"
-                       FontSize="14px"
+                       Style="{DynamicResource {x:Static vsui:VsResourceKeys.TextBlockEnvironment122PercentFontSizeStyleKey}}"
                        TextWrapping="Wrap"
                        Margin="0 0 5 3"
                        Text="{Binding Model.Title}"/>
 
             <TextBlock Grid.Column="1"
                        FontWeight="Bold"
-                       FontSize="11px"
                        Margin="10 4 0 0"
                        Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
                        Style="{StaticResource StateIndicator}"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -108,7 +108,7 @@
             <TextBlock Grid.Column="1"
                        FontWeight="Bold"
                        FontSize="11px"
-                       Margin="0 4 0 0"
+                       Margin="10 4 0 0"
                        Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
                        Style="{StaticResource StateIndicator}"/>
         </Grid>
@@ -128,12 +128,18 @@
 
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
                 <!-- source and target branches -->
-                <TextBlock TextWrapping="Wrap" Margin="0 0 0 3">
-                    <ui:OcticonImage Icon="git_branch" Height="15" Opacity="0.6" />
-                    <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}"/>
-                    <Run>to</Run>
-                    <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}"/>
-                </TextBlock>
+                <StackPanel Orientation="Horizontal" Margin="0 -3">
+                    <ui:OcticonImage VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.6" Margin="0 0 5 0" />
+                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 2" Background="#e8f0f8">
+                        <TextBlock Foreground="#2e3031" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" /> 
+                    </Border>
+
+                    <TextBlock VerticalAlignment="Center" Margin="5" Text="to" />
+
+                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 2" Background="#e8f0f8">
+                        <TextBlock Foreground="#2e3031" FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" /> 
+                    </Border>
+                </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Opacity="0.7" VerticalAlignment="Center"

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -143,14 +143,14 @@
                     </Grid.ColumnDefinitions>
 
                     <ui:OcticonImage Grid.Column="0" VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.5" Margin="0 0 3 0" />
-                    <Border Grid.Column="1" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
-                        <TextBlock FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" /> 
+                    <Border Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                        <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding SourceBranchDisplayName, Mode=OneWay}" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" /> 
                     </Border>
 
                     <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5" Text="into" />
 
-                    <Border Grid.Column="3" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
-                        <TextBlock FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" /> 
+                    <Border Grid.Column="3" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                        <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding TargetBranchDisplayName, Mode=OneWay}" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" /> 
                     </Border>
                 </Grid>
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -119,8 +119,12 @@
                     <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}"/>
                 </TextBlock>
 
-                <TextBlock Opacity="0.7"
-                           Text="{Binding Model.UpdatedAt, StringFormat={}updated {0}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Opacity="0.7"
+                               Text="{Binding Model.UpdatedAt, StringFormat={}updated {0}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
+
+                    <Rectangle Margin="5" Width="1" Style="{DynamicResource Separator}" />
+                </StackPanel>
             </StackPanel>
 
             <TextBlock Grid.Column="2"

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -129,6 +129,7 @@
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
                 <!-- source and target branches -->
                 <TextBlock TextWrapping="Wrap" Margin="0 0 0 3">
+                    <ui:OcticonImage Icon="git_branch" Height="15" Opacity="0.6" />
                     <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}"/>
                     <Run>to</Run>
                     <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -134,18 +134,25 @@
 
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
                 <!-- source and target branches -->
-                <StackPanel Orientation="Horizontal" Margin="0 -3">
-                    <ui:OcticonImage VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.5" Margin="0 0 3 0" />
-                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                <Grid Margin="0 -3">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <ui:OcticonImage Grid.Column="0" VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.5" Margin="0 0 3 0" />
+                    <Border Grid.Column="1" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
                         <TextBlock FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" /> 
                     </Border>
 
-                    <TextBlock VerticalAlignment="Center" Margin="5" Text="into" />
+                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5" Text="into" />
 
-                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                    <Border Grid.Column="3" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
                         <TextBlock FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" /> 
                     </Border>
-                </StackPanel>
+                </Grid>
 
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -206,10 +206,10 @@
             </StackPanel>
         </Grid>
 
-        <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,10,-8,10"/>
+        <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,10,-8,0"/>
 
-        <ScrollViewer VerticalScrollBarVisibility="Auto">
-            <Grid>
+        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,0,-8,0">
+            <Grid Margin="0 5 0 0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -95,8 +95,6 @@
     <DockPanel Grid.IsSharedSizeScope="True" Margin="8">
         <!-- Commit count, source and target branches -->
         <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap">
-            <Run FontWeight="Bold" Text="{Binding Model.Author.Login}"/>
-            <Run>wants to merge</Run>
             <Run Text="{Binding Model.CommitCount}"/>
             <Run>commits from </Run>
             <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}"/>
@@ -117,11 +115,6 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <controls:AccountAvatar Account="{Binding Model.Author}"
-                                    Margin="0,4,0,0"
-                                    VerticalAlignment="Top"
-                                    Width="32"
-                                    Height="32"/>
             <StackPanel Grid.Column="1" Margin="6,0" Orientation="Vertical">
                 <TextBlock Grid.Column="1"
                            FontSize="10pt"
@@ -225,6 +218,19 @@
                     <RowDefinition Height="Auto"/> <!-- View on github link -->
                     <RowDefinition Height="Auto"/> <!-- Files changed -->
                 </Grid.RowDefinitions>
+
+                <!-- Author and open time -->
+                <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
+                    <controls:AccountAvatar Account="{Binding Model.Author}"
+                                            VerticalAlignment="Top"
+                                            Width="16"
+                                            Height="16"/>
+
+                    <TextBlock VerticalAlignment="Center" Margin="4 0" TextWrapping="Wrap">
+                        <Run FontWeight="Bold" Text="{Binding Model.Author.Login}" />
+                        <Run Text="wrote" />
+                    </TextBlock>
+                </StackPanel>
 
                 <!-- PR Body -->
                 <ui:MarkdownViewer Name="bodyMarkdown"

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -93,6 +93,26 @@
     </Control.Resources>
 
     <DockPanel Grid.IsSharedSizeScope="True" Margin="8 0">
+        <Grid DockPanel.Dock="Top">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Column="0"
+                       FontSize="14px"
+                       TextWrapping="Wrap"
+                       Margin="0 0 5 3"
+                       Text="{Binding Model.Title}"/>
+
+            <TextBlock Grid.Column="1"
+                       FontWeight="Bold"
+                       FontSize="11px"
+                       Margin="0 4 0 0"
+                       Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
+                       Style="{StaticResource StateIndicator}"/>
+        </Grid>
+
         <!-- Avatar, PR Title, Open/Merged/Closed state and actions area -->
         <Grid DockPanel.Dock="Top">
             <Grid.ColumnDefinitions>
@@ -100,18 +120,13 @@
                 <ColumnDefinition Width="1*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
+
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
-                <TextBlock Grid.Column="1"
-                           FontSize="14px"
-                           TextWrapping="Wrap"
-                           Margin="0 0 0 3"
-                           Text="{Binding Model.Title}"/>
-
                 <!-- source and target branches -->
                 <TextBlock TextWrapping="Wrap" Margin="0 0 0 3">
                     <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}"/>
@@ -202,13 +217,6 @@
                              Visibility="{Binding OperationError, Converter={ui:NullToVisibilityConverter}}"/>
                 </StackPanel>
             </StackPanel>
-
-            <TextBlock Grid.Column="2"
-                       FontWeight="Bold"
-                       FontSize="11px"
-                       Margin="0 4 0 0"
-                       Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
-                       Style="{StaticResource StateIndicator}"/>
         </Grid>
 
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,10,-8,0"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -147,9 +147,6 @@
 
                     <Rectangle Margin="5" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />
 
-
-                    <!-- Actions area (checkout, pull, push) -->
-
                     <!-- Checkout pull request button -->
                     <ui:GitHubActionLink Command="{Binding Checkout}"
                                          Content="{Binding CheckoutState.Caption}"

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -129,6 +129,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
@@ -224,18 +225,21 @@
                             </Style>
                         </TextBlock.Style>
                     </TextBlock>
-
-                    <!-- Git operation error message -->
-                    <TextBox Grid.Column="2"
-                             Foreground="Red" 
-                             Margin="0 4"
-                             Text="{Binding OperationError}"
-                             VerticalAlignment="Center"
-                             TextWrapping="Wrap"
-                             Style="{StaticResource FlatReadOnlyTextBox}"
-                             Visibility="{Binding OperationError, Converter={ui:NullToVisibilityConverter}}"/>
                 </Grid>
             </StackPanel>
+
+            <!-- Git operation error message -->
+
+            <TextBox Grid.Column="0"
+                     Grid.ColumnSpan="3"
+                     Grid.Row="2"
+                     Foreground="Red" 
+                     Margin="0 0 0 0"
+                     Text="{Binding OperationError}"
+                     VerticalAlignment="Center"
+                     TextWrapping="Wrap"
+                     Style="{StaticResource FlatReadOnlyTextBox}"
+                     Visibility="{Binding OperationError, Converter={ui:NullToVisibilityConverter}}"/>
         </Grid>
 
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,5,-8,0"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -123,7 +123,83 @@
                     <TextBlock Opacity="0.7"
                                Text="{Binding Model.UpdatedAt, StringFormat={}updated {0}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
 
-                    <Rectangle Margin="5" Width="1" Style="{DynamicResource Separator}" />
+                    <Rectangle Margin="5" Width="1" Height="10" VerticalAlignment="Center" Style="{DynamicResource Separator}" />
+
+
+                    <!-- Actions area (checkout, pull, push) -->
+
+                    <!-- Checkout pull request button -->
+                    <ui:GitHubActionLink Command="{Binding Checkout}"
+                                         Content="{Binding CheckoutState.Caption}"
+                                         TextWrapping="Wrap"
+                                         Visibility="{Binding CheckoutState, Converter={ui:NullToVisibilityConverter}}"
+                                         ToolTip="{Binding CheckoutState.DisabledMessage}"
+                                         ToolTipService.ShowOnDisabled="True"/>
+
+                    <!-- Pull/push buttons -->
+                    <StackPanel Orientation="Horizontal" 
+                                Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToInverseVisibilityConverter}}">
+                        <ui:OcticonImage Icon="arrow_down"/>
+                        <TextBlock Text="{Binding UpdateState.CommitsBehind}" VerticalAlignment="Center"/>
+                        <ui:GitHubActionLink Content="Pull"
+                                             Command="{Binding Pull}"
+                                             Margin="4,0"
+                                             ToolTip="{Binding UpdateState.PullDisabledMessage}"
+                                             ToolTipService.ShowOnDisabled="True"
+                                             VerticalAlignment="Center"/>
+                        <ui:OcticonImage Icon="arrow_up"/>
+                        <TextBlock Text="{Binding UpdateState.CommitsAhead}" VerticalAlignment="Center"/>
+                        <ui:GitHubActionLink Content="Push"
+                                             Command="{Binding Push}"
+                                             Margin="4,0"
+                                             ToolTip="{Binding UpdateState.PushDisabledMessage}"
+                                             ToolTipService.ShowOnDisabled="True"
+                                             VerticalAlignment="Center"/>
+                    </StackPanel>
+
+                    <!-- Branch checked out and up-to-date -->
+                    <TextBlock TextWrapping="Wrap" Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
+                        <ui:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
+                        <Run>Pull request checked out and up-to-date.</Run>
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutMessage}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding UpdateState.CommitsAhead}" Value="0"/>
+                                            <Condition Binding="{Binding UpdateState.CommitsBehind}" Value="0"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <MultiDataTrigger.Setters>
+                                            <Setter Property="Visibility" Value="Visible"/>
+                                        </MultiDataTrigger.Setters>
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <!-- Checkout disabled message -->
+                    <TextBlock Margin="0 0 0 4" TextWrapping="Wrap">
+                        <Run Text="{Binding CheckoutDisabledMessage}"/>
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutErrorMessage}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CheckoutDisabledMessage}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <!-- Git operation error message -->
+                    <TextBox Foreground="Red" 
+                             Margin="0 4"
+                             Text="{Binding OperationError}"
+                             TextWrapping="Wrap"
+                             Style="{StaticResource FlatReadOnlyTextBox}"
+                             Visibility="{Binding OperationError, Converter={ui:NullToVisibilityConverter}}"/>
                 </StackPanel>
             </StackPanel>
 
@@ -133,82 +209,6 @@
                        Margin="0 4 0 0"
                        Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
                        Style="{StaticResource StateIndicator}"/>
-
-            <!-- Actions area (checkout, pull, push) -->
-            <StackPanel Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="2" Margin="6 10 0 0">
-                <!-- Checkout pull request button -->
-                <ui:GitHubActionLink Command="{Binding Checkout}"
-                                     Content="{Binding CheckoutState.Caption}"
-                                     TextWrapping="Wrap"
-                                     Visibility="{Binding CheckoutState, Converter={ui:NullToVisibilityConverter}}"
-                                     ToolTip="{Binding CheckoutState.DisabledMessage}"
-                                     ToolTipService.ShowOnDisabled="True"/>
-
-                <!-- Pull/push buttons -->
-                <StackPanel Orientation="Horizontal" 
-                            Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToInverseVisibilityConverter}}">
-                    <ui:OcticonImage Icon="arrow_down"/>
-                    <TextBlock Text="{Binding UpdateState.CommitsBehind}" VerticalAlignment="Center"/>
-                    <ui:GitHubActionLink Content="Pull"
-                                         Command="{Binding Pull}"
-                                         Margin="4,0"
-                                         ToolTip="{Binding UpdateState.PullDisabledMessage}"
-                                         ToolTipService.ShowOnDisabled="True"
-                                         VerticalAlignment="Center"/>
-                    <ui:OcticonImage Icon="arrow_up"/>
-                    <TextBlock Text="{Binding UpdateState.CommitsAhead}" VerticalAlignment="Center"/>
-                    <ui:GitHubActionLink Content="Push"
-                                         Command="{Binding Push}"
-                                         Margin="4,0"
-                                         ToolTip="{Binding UpdateState.PushDisabledMessage}"
-                                         ToolTipService.ShowOnDisabled="True"
-                                         VerticalAlignment="Center"/>
-                </StackPanel>
-
-                <!-- Branch checked out and up-to-date -->
-                <TextBlock TextWrapping="Wrap" Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
-                    <ui:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
-                    <Run>Pull request checked out and up-to-date.</Run>
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutMessage}">
-                            <Setter Property="Visibility" Value="Collapsed"/>
-                            <Style.Triggers>
-                                <MultiDataTrigger>
-                                    <MultiDataTrigger.Conditions>
-                                        <Condition Binding="{Binding UpdateState.CommitsAhead}" Value="0"/>
-                                        <Condition Binding="{Binding UpdateState.CommitsBehind}" Value="0"/>
-                                    </MultiDataTrigger.Conditions>
-                                    <MultiDataTrigger.Setters>
-                                        <Setter Property="Visibility" Value="Visible"/>
-                                    </MultiDataTrigger.Setters>
-                                </MultiDataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
-
-                <!-- Checkout disabled message -->
-                <TextBlock Margin="0 0 0 4" TextWrapping="Wrap">
-                    <Run Text="{Binding CheckoutDisabledMessage}"/>
-                    <TextBlock.Style>
-                        <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutErrorMessage}">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding CheckoutDisabledMessage}" Value="{x:Null}">
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </TextBlock.Style>
-                </TextBlock>
-
-                <!-- Git operation error message -->
-                <TextBox Foreground="Red" 
-                         Margin="0 4"
-                         Text="{Binding OperationError}"
-                         TextWrapping="Wrap"
-                         Style="{StaticResource FlatReadOnlyTextBox}"
-                         Visibility="{Binding OperationError, Converter={ui:NullToVisibilityConverter}}"/>
-            </StackPanel>
         </Grid>
 
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,10,-8,0"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -126,6 +126,7 @@
             <TextBlock Grid.Column="2"
                        FontWeight="Bold"
                        FontSize="11px"
+                       Margin="0 4 0 0"
                        Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
                        Style="{StaticResource StateIndicator}"/>
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -129,15 +129,15 @@
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
                 <!-- source and target branches -->
                 <StackPanel Orientation="Horizontal" Margin="0 -3">
-                    <ui:OcticonImage VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.6" Margin="0 0 3 0" />
-                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="#e8f0f8">
-                        <TextBlock Foreground="#2e3031" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" /> 
+                    <ui:OcticonImage VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.5" Margin="0 0 3 0" />
+                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                        <TextBlock FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" /> 
                     </Border>
 
                     <TextBlock VerticalAlignment="Center" Margin="5" Text="into" />
 
-                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="#e8f0f8">
-                        <TextBlock Foreground="#2e3031" FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" /> 
+                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                        <TextBlock FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" /> 
                     </Border>
                 </StackPanel>
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -92,18 +92,7 @@
         </ResourceDictionary>
     </Control.Resources>
 
-    <DockPanel Grid.IsSharedSizeScope="True" Margin="8">
-        <!-- Commit count, source and target branches -->
-        <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap">
-            <Run Text="{Binding Model.CommitCount}"/>
-            <Run>commits from </Run>
-            <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}"/>
-            <Run>to</Run>
-            <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}"/>
-        </TextBlock>
-
-        <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,10,-8,10"/>
-
+    <DockPanel Grid.IsSharedSizeScope="True" Margin="8 0">
         <!-- Avatar, PR Title, Open/Merged/Closed state and actions area -->
         <Grid DockPanel.Dock="Top">
             <Grid.ColumnDefinitions>
@@ -115,14 +104,24 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
-            <StackPanel Grid.Column="1" Margin="6,0" Orientation="Vertical">
+
+            <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
                 <TextBlock Grid.Column="1"
                            FontSize="10pt"
                            TextWrapping="Wrap"
                            Text="{Binding Model.Title}"/>
+
+                <!-- source and target branches -->
+                <TextBlock TextWrapping="Wrap">
+                    <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}"/>
+                    <Run>to</Run>
+                    <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}"/>
+                </TextBlock>
+
                 <TextBlock Opacity="0.7"
                            Text="{Binding Model.UpdatedAt, StringFormat={}updated {0}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
             </StackPanel>
+
             <TextBlock Grid.Column="2"
                        FontWeight="Bold"
                        FontSize="10pt"
@@ -130,7 +129,7 @@
                        Style="{StaticResource StateIndicator}"/>
 
             <!-- Actions area (checkout, pull, push) -->
-            <StackPanel Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="1" Margin="6 10 0 0">
+            <StackPanel Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="2" Margin="6 10 0 0">
                 <!-- Checkout pull request button -->
                 <ui:GitHubActionLink Command="{Binding Checkout}"
                                      Content="{Binding CheckoutState.Caption}"
@@ -205,6 +204,8 @@
                          Visibility="{Binding OperationError, Converter={ui:NullToVisibilityConverter}}"/>
             </StackPanel>
         </Grid>
+
+        <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,10,-8,10"/>
 
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <Grid>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -146,15 +146,22 @@
                     </Border>
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Opacity="0.5" VerticalAlignment="Center"
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0" Opacity="0.5" Margin="0 2 0 0" VerticalAlignment="Top"
                                Text="{Binding Model.UpdatedAt, StringFormat={}updated {0}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
 
-                    <Rectangle Margin="5" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />
+                    <Rectangle Grid.Column="1" Margin="5" Width="1" Height="12" VerticalAlignment="Top" Style="{DynamicResource Separator}" />
 
                     <!-- Checkout pull request button -->
                     <ui:GitHubActionLink Command="{Binding Checkout}"
                                          Content="{Binding CheckoutState.Caption}"
+                                         Grid.Column="2"
                                          VerticalAlignment="Center"
                                          TextWrapping="Wrap"
                                          Visibility="{Binding CheckoutState, Converter={ui:NullToVisibilityConverter}}"
@@ -162,7 +169,7 @@
                                          ToolTipService.ShowOnDisabled="True"/>
 
                     <!-- Pull/push buttons -->
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center"
                                 Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToInverseVisibilityConverter}}">
                         <ui:OcticonImage Icon="arrow_down"/>
                         <TextBlock Text="{Binding UpdateState.CommitsBehind}" VerticalAlignment="Center"/>
@@ -183,7 +190,7 @@
                     </StackPanel>
 
                     <!-- Branch checked out and up-to-date -->
-                    <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
+                    <TextBlock Grid.Column="2" VerticalAlignment="Center" TextWrapping="Wrap" Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
                         <ui:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
                         <Run>Local branch up to date</Run>
                         <TextBlock.Style>
@@ -205,7 +212,7 @@
                     </TextBlock>
 
                     <!-- Checkout disabled message -->
-                    <TextBlock Margin="0 0 0 4" VerticalAlignment="Center" TextWrapping="Wrap">
+                    <TextBlock Grid.Column="2" Margin="0 0 0 4" VerticalAlignment="Center" TextWrapping="Wrap">
                         <Run Text="{Binding CheckoutDisabledMessage}"/>
                         <TextBlock.Style>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutErrorMessage}">
@@ -219,14 +226,15 @@
                     </TextBlock>
 
                     <!-- Git operation error message -->
-                    <TextBox Foreground="Red" 
+                    <TextBox Grid.Column="2"
+                             Foreground="Red" 
                              Margin="0 4"
                              Text="{Binding OperationError}"
                              VerticalAlignment="Center"
                              TextWrapping="Wrap"
                              Style="{StaticResource FlatReadOnlyTextBox}"
                              Visibility="{Binding OperationError, Converter={ui:NullToVisibilityConverter}}"/>
-                </StackPanel>
+                </Grid>
             </StackPanel>
         </Grid>
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -228,7 +228,7 @@
             </StackPanel>
         </Grid>
 
-        <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,10,-8,0"/>
+        <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,5,-8,0"/>
 
         <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,0,-8,0">
             <Grid Margin="0 5 0 0">

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -135,10 +135,10 @@
                 </TextBlock>
 
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Opacity="0.7"
+                    <TextBlock Opacity="0.7" VerticalAlignment="Center"
                                Text="{Binding Model.UpdatedAt, StringFormat={}updated {0}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
 
-                    <Rectangle Margin="5" Width="1" Height="10" VerticalAlignment="Center" Style="{DynamicResource Separator}" />
+                    <Rectangle Margin="5" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />
 
 
                     <!-- Actions area (checkout, pull, push) -->
@@ -146,13 +146,14 @@
                     <!-- Checkout pull request button -->
                     <ui:GitHubActionLink Command="{Binding Checkout}"
                                          Content="{Binding CheckoutState.Caption}"
+                                         VerticalAlignment="Center"
                                          TextWrapping="Wrap"
                                          Visibility="{Binding CheckoutState, Converter={ui:NullToVisibilityConverter}}"
                                          ToolTip="{Binding CheckoutState.DisabledMessage}"
                                          ToolTipService.ShowOnDisabled="True"/>
 
                     <!-- Pull/push buttons -->
-                    <StackPanel Orientation="Horizontal" 
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
                                 Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToInverseVisibilityConverter}}">
                         <ui:OcticonImage Icon="arrow_down"/>
                         <TextBlock Text="{Binding UpdateState.CommitsBehind}" VerticalAlignment="Center"/>
@@ -173,7 +174,7 @@
                     </StackPanel>
 
                     <!-- Branch checked out and up-to-date -->
-                    <TextBlock TextWrapping="Wrap" Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
+                    <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
                         <ui:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
                         <Run>Pull request checked out and up-to-date.</Run>
                         <TextBlock.Style>
@@ -195,7 +196,7 @@
                     </TextBlock>
 
                     <!-- Checkout disabled message -->
-                    <TextBlock Margin="0 0 0 4" TextWrapping="Wrap">
+                    <TextBlock Margin="0 0 0 4" VerticalAlignment="Center" TextWrapping="Wrap">
                         <Run Text="{Binding CheckoutDisabledMessage}"/>
                         <TextBlock.Style>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutErrorMessage}">
@@ -212,6 +213,7 @@
                     <TextBox Foreground="Red" 
                              Margin="0 4"
                              Text="{Binding OperationError}"
+                             VerticalAlignment="Center"
                              TextWrapping="Wrap"
                              Style="{StaticResource FlatReadOnlyTextBox}"
                              Visibility="{Binding OperationError, Converter={ui:NullToVisibilityConverter}}"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -23,12 +23,17 @@
         <Binding>
             <Binding.Source>
                 <sampleData:PullRequestDetailViewModelDesigner>
+                    <!--
                     <sampleData:PullRequestDetailViewModelDesigner.CheckoutState>
-                        <sampleData:PullRequestCheckoutStateDesigner Caption="Checkout error-handling"/>
+                        <sampleData:PullRequestCheckoutStateDesigner Caption="Checkout error-handling/>
                     </sampleData:PullRequestDetailViewModelDesigner.CheckoutState>
+                    -->
                     <!--<sampleData:PullRequestDetailViewModelDesigner.UpdateState>
                         <sampleData:PullRequestUpdateStateDesigner CommitsAhead="2" CommitsBehind="4" UpToDate="False"/>
                     </sampleData:PullRequestDetailViewModelDesigner.UpdateState>-->
+                    <sampleData:PullRequestDetailViewModelDesigner.OperationError>
+                        Unable to connect to the internets over here!
+                    </sampleData:PullRequestDetailViewModelDesigner.OperationError>
                 </sampleData:PullRequestDetailViewModelDesigner>
             </Binding.Source>
         </Binding>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -137,7 +137,7 @@
                 <Grid Margin="0 -3">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -183,7 +183,7 @@
                     <!-- Branch checked out and up-to-date -->
                     <TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
                         <ui:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
-                        <Run>Pull request checked out and up-to-date.</Run>
+                        <Run>Local branch up to date</Run>
                         <TextBlock.Style>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutMessage}">
                                 <Setter Property="Visibility" Value="Collapsed"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -107,12 +107,13 @@
 
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
                 <TextBlock Grid.Column="1"
-                           FontSize="10pt"
+                           FontSize="14px"
                            TextWrapping="Wrap"
+                           Margin="0 0 0 3"
                            Text="{Binding Model.Title}"/>
 
                 <!-- source and target branches -->
-                <TextBlock TextWrapping="Wrap">
+                <TextBlock TextWrapping="Wrap" Margin="0 0 0 3">
                     <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}"/>
                     <Run>to</Run>
                     <Run Background="#e8f0f8" FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}"/>
@@ -124,7 +125,7 @@
 
             <TextBlock Grid.Column="2"
                        FontWeight="Bold"
-                       FontSize="10pt"
+                       FontSize="11px"
                        Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
                        Style="{StaticResource StateIndicator}"/>
 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -134,7 +134,7 @@
                         <TextBlock Foreground="#2e3031" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" /> 
                     </Border>
 
-                    <TextBlock VerticalAlignment="Center" Margin="5" Text="to" />
+                    <TextBlock VerticalAlignment="Center" Margin="5" Text="into" />
 
                     <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="#e8f0f8">
                         <TextBlock Foreground="#2e3031" FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" /> 

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -129,20 +129,20 @@
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
                 <!-- source and target branches -->
                 <StackPanel Orientation="Horizontal" Margin="0 -3">
-                    <ui:OcticonImage VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.6" Margin="0 0 5 0" />
-                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 2" Background="#e8f0f8">
+                    <ui:OcticonImage VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.6" Margin="0 0 3 0" />
+                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="#e8f0f8">
                         <TextBlock Foreground="#2e3031" FontFamily="Consolas" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" /> 
                     </Border>
 
                     <TextBlock VerticalAlignment="Center" Margin="5" Text="to" />
 
-                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 2" Background="#e8f0f8">
+                    <Border VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="#e8f0f8">
                         <TextBlock Foreground="#2e3031" FontFamily="Consolas" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" /> 
                     </Border>
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Opacity="0.7" VerticalAlignment="Center"
+                    <TextBlock Opacity="0.5" VerticalAlignment="Center"
                                Text="{Binding Model.UpdatedAt, StringFormat={}updated {0}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
 
                     <Rectangle Margin="5" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />


### PR DESCRIPTION
Fixes https://github.com/github/VisualStudio/issues/709 https://github.com/github/VisualStudio/issues/713 https://github.com/github/VisualStudio/issues/625 https://github.com/github/VisualStudio/issues/302

This pull request reworks the details view. I reworked around the information so that it's quicker to parse than before.

**Before**

<img width="344" alt="screen shot 2016-12-12 at 3 48 31 pm" src="https://cloud.githubusercontent.com/assets/1174461/21121714/be09e73e-c082-11e6-9b71-f5137044cabe.png">

**After**

<img width="345" alt="screen shot 2016-12-12 at 2 44 50 pm" src="https://cloud.githubusercontent.com/assets/1174461/21121723/cfbc564c-c082-11e6-851a-c700b63c9580.png">

**Push / Pull branch actions**

<img width="345" alt="screen shot 2016-12-12 at 3 53 59 pm" src="https://cloud.githubusercontent.com/assets/1174461/21121785/4afc0280-c083-11e6-85fa-c1ee5feb2e8f.png">

**Shorter title and checkout branch action**

<img width="342" alt="screen shot 2016-12-12 at 3 54 19 pm" src="https://cloud.githubusercontent.com/assets/1174461/21121812/67b88a9c-c083-11e6-855c-142ccd98e430.png">

**Themes!**

<img width="345" alt="screen shot 2016-12-12 at 2 44 35 pm" src="https://cloud.githubusercontent.com/assets/1174461/21121845/8a5f5c1a-c083-11e6-89d0-5f3fcd56f723.png">
<img width="344" alt="screen shot 2016-12-12 at 2 44 14 pm" src="https://cloud.githubusercontent.com/assets/1174461/21121844/8a5d0aaa-c083-11e6-8cb1-1a18e1e135ca.png">

### TODO

- [x] Dark theme
- [x] Light theme
- [x] Don't hardcode font sizes
- [x] Double check design for error messages
- [ ] Handle long branch names (wrap or truncate perhaps?)

