### PR TITLE
Handle diff/open of non-checked out files.

### DIFF
--- a/src/GitHub.App/Api/ApiClient.cs
+++ b/src/GitHub.App/Api/ApiClient.cs
@@ -279,5 +279,10 @@ namespace GitHub.Api
         {
             return gitHubClient.Repository.Get(owner, repo);
         }
+
+        public IObservable<RepositoryContent> GetFileContents(string owner, string name, string reference, string path)
+        {
+            return gitHubClient.Repository.Content.GetAllContentsByRef(owner, name, reference, path);
+        }
     }
 }

--- a/src/GitHub.App/Caches/CacheIndex.cs
+++ b/src/GitHub.App/Caches/CacheIndex.cs
@@ -14,6 +14,7 @@ namespace GitHub.Caches
         public const string RepoPrefix = "index:repos";
         public const string GitIgnoresPrefix = "index:ignores";
         public const string LicensesPrefix = "index:licenses";
+        public const string FileContentsPrefix = "index:filecontents";
 
         public static CacheIndex Create(string key)
         {

--- a/src/GitHub.App/Models/PullRequestFileModel.cs
+++ b/src/GitHub.App/Models/PullRequestFileModel.cs
@@ -4,13 +4,15 @@ namespace GitHub.Models
 {
     public class PullRequestFileModel : IPullRequestFileModel
     {
-        public PullRequestFileModel(string fileName, PullRequestFileStatus status)
+        public PullRequestFileModel(string fileName, string sha, PullRequestFileStatus status)
         {
             FileName = fileName;
+            Sha = sha;
             Status = status;
         }
 
         public string FileName { get; set; }
+        public string Sha { get; set; }
         public PullRequestFileStatus Status { get; set; }
     }
 }

--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -52,9 +52,9 @@ This requires that errors be propagated from the viewmodel to the view and from 
             var gitHubDir = new PullRequestDirectoryNode("GitHub");
             var modelsDir = new PullRequestDirectoryNode("Models");
             var repositoriesDir = new PullRequestDirectoryNode("Repositories");
-            var itrackingBranch = new PullRequestFileNode(repoPath, @"GitHub\Models\ITrackingBranch.cs", PullRequestFileStatus.Modified, null);
-            var oldBranchModel = new PullRequestFileNode(repoPath, @"GitHub\Models\OldBranchModel.cs", PullRequestFileStatus.Removed, null);
-            var concurrentRepositoryConnection = new PullRequestFileNode(repoPath, @"GitHub\Repositories\ConcurrentRepositoryConnection.cs", PullRequestFileStatus.Added, "add");
+            var itrackingBranch = new PullRequestFileNode(repoPath, @"GitHub\Models\ITrackingBranch.cs", "abc", PullRequestFileStatus.Modified, null);
+            var oldBranchModel = new PullRequestFileNode(repoPath, @"GitHub\Models\OldBranchModel.cs", "abc", PullRequestFileStatus.Removed, null);
+            var concurrentRepositoryConnection = new PullRequestFileNode(repoPath, @"GitHub\Repositories\ConcurrentRepositoryConnection.cs", "abc", PullRequestFileStatus.Added, "add");
 
             repositoriesDir.Files.Add(concurrentRepositoryConnection);
             modelsDir.Directories.Add(repositoriesDir);

--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using GitHub.Extensions;
 using GitHub.Primitives;
 using LibGit2Sharp;
+using NullGuard;
 
 namespace GitHub.Services
 {
@@ -202,11 +203,17 @@ namespace GitHub.Services
             });
         }
 
+        [return: AllowNull]
         public async Task<string> ExtractFile(IRepository repository, string commitSha, string fileName)
         {
             var commit = repository.Lookup<Commit>(commitSha);
-            var blob = commit[fileName]?.Target as Blob;
 
+            if (commit == null)
+            {
+                return null;
+            }
+
+            var blob = commit[fileName]?.Target as Blob;
             var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var tempFileName = $"{Path.GetFileNameWithoutExtension(fileName)}@{commitSha}{Path.GetExtension(fileName)}";
             var tempFile = Path.Combine(tempDir, tempFileName);

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
 using Akavache;
 using GitHub.Api;
 using GitHub.Caches;
@@ -24,6 +26,8 @@ namespace GitHub.Services
     public class ModelService : IModelService
     {
         public const string PRPrefix = "pr";
+        const string TempFilesDirectory = "GitHubVisualStudio";
+        const string CachedFilesDirectory = "CachedFiles";
         static readonly Logger log = LogManager.GetCurrentClassLogger();
 
         readonly IApiClient apiClient;
@@ -250,13 +254,23 @@ namespace GitHub.Services
             return hostCache.InvalidateAll().ContinueAfter(() => hostCache.Vacuum());
         }
 
-        public IObservable<byte[]> GetFileContents(IRepositoryModel repo, string commitSha, string fileName)
+        public IObservable<string> GetFileContents(IRepositoryModel repo, string commitSha, string path, string fileSha)
         {
-            return hostCache.GetAndRefresh($"{CacheIndex.PRPrefix}|{commitSha}",
-                () => apiClient.GetFileContents(repo.Owner, repo.Name, commitSha, fileName)
-                        .Select(x => Convert.FromBase64String(x.EncodedContent)),
-                TimeSpan.FromDays(14),
-                TimeSpan.FromDays(14));
+            return Observable.Defer(() => Task.Run(async () =>
+            {
+                // Store cached file contents a the temp directory so they can be deleted by disk cleanup etc.
+                var tempDir = Path.Combine(Path.GetTempPath(), TempFilesDirectory, CachedFilesDirectory, fileSha.Substring(0, 2));
+                var tempFile = Path.Combine(tempDir, Path.GetFileNameWithoutExtension(path) + '@' + fileSha + Path.GetExtension(path));
+
+                if (!File.Exists(tempFile))
+                {
+                    var contents = await apiClient.GetFileContents(repo.Owner, repo.Name, commitSha, path);
+                    Directory.CreateDirectory(tempDir);
+                    File.WriteAllBytes(tempFile, Convert.FromBase64String(contents.EncodedContent));
+                }
+
+                return Observable.Return(tempFile);
+            }));
         }
 
         IObservable<IReadOnlyList<IRemoteRepositoryModel>> GetUserRepositories(RepositoryType repositoryType)
@@ -380,7 +394,8 @@ namespace GitHub.Services
                 Assignee = prCacheItem.Assignee != null ? Create(prCacheItem.Assignee) : null,
                 Base = Create(prCacheItem.Base),
                 Body = prCacheItem.Body ?? string.Empty,
-                ChangedFiles = prCacheItem.ChangedFiles.Select(x => (IPullRequestFileModel)new PullRequestFileModel(x.FileName, x.Status)).ToList(),
+                ChangedFiles = prCacheItem.ChangedFiles.Select(x => 
+                    (IPullRequestFileModel)new PullRequestFileModel(x.FileName, x.Sha, x.Status)).ToList(),
                 CommentCount = prCacheItem.CommentCount,
                 CommitCount = prCacheItem.CommitCount,
                 CreatedAt = prCacheItem.CreatedAt,
@@ -565,10 +580,12 @@ namespace GitHub.Services
             public PullRequestFileCacheItem(PullRequestFile file)
             {
                 FileName = file.FileName;
+                Sha = file.Sha;
                 Status = (PullRequestFileStatus)Enum.Parse(typeof(PullRequestFileStatus), file.Status, true);
             }
 
             public string FileName { get; set; }
+            public string Sha { get; set; }
             public PullRequestFileStatus Status { get; set; }
         }
 

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -250,6 +250,15 @@ namespace GitHub.Services
             return hostCache.InvalidateAll().ContinueAfter(() => hostCache.Vacuum());
         }
 
+        public IObservable<byte[]> GetFileContents(IRepositoryModel repo, string commitSha, string fileName)
+        {
+            return hostCache.GetAndRefresh($"{CacheIndex.PRPrefix}|{commitSha}",
+                () => apiClient.GetFileContents(repo.Owner, repo.Name, commitSha, fileName)
+                        .Select(x => Convert.FromBase64String(x.EncodedContent)),
+                TimeSpan.FromDays(14),
+                TimeSpan.FromDays(14));
+        }
+
         IObservable<IReadOnlyList<IRemoteRepositoryModel>> GetUserRepositories(RepositoryType repositoryType)
         {
             return Observable.Defer(() => GetUserFromCache().SelectMany(user =>

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -377,7 +377,7 @@ namespace GitHub.Services
             };
         }
 
-        private GitReferenceModel Create(GitReferenceCacheItem item)
+        GitReferenceModel Create(GitReferenceCacheItem item)
         {
             return new GitReferenceModel(item.Ref, item.Label, item.Sha, item.RepositoryCloneUrl);
         }

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -26,7 +26,7 @@ namespace GitHub.Services
     public class ModelService : IModelService
     {
         public const string PRPrefix = "pr";
-        const string TempFilesDirectory = "GitHubVisualStudio";
+        const string TempFilesDirectory = Info.ApplicationInfo.ApplicationName;
         const string CachedFilesDirectory = "CachedFiles";
         static readonly Logger log = LogManager.GetCurrentClassLogger();
 

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -288,7 +288,7 @@ namespace GitHub.Services
             });
         }
 
-        private async Task<string> ExtractFile(
+        async Task<string> ExtractFile(
             ILocalRepositoryModel repository,
             IRepository repo,
             IModelService modelService,

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -259,8 +259,7 @@ namespace GitHub.Services
             {
                 var repo = gitService.GetRepository(repository.LocalPath);
                 await gitClient.Fetch(repo, "origin");
-                var result = await gitClient.ExtractFile(repo, commitSha, fileName) ??
-                             await modelService.GetFileContents(repository, commitSha, fileName, fileSha);
+                var result = await GetFileFromRepositoryOrApi(repository, repo, modelService, commitSha, fileName, fileSha);
                 return Observable.Return(result);
             });
         }
@@ -282,13 +281,12 @@ namespace GitHub.Services
 
                 // The right file - if it comes from a fork - may not be fetched so fall back to
                 // getting the file contents from the model service.
-                var right = await gitClient.ExtractFile(repo, pullRequest.Head.Sha, fileName) ??
-                            await modelService.GetFileContents(repository, pullRequest.Head.Sha, fileName, fileSha);
+                var right = await GetFileFromRepositoryOrApi(repository, repo, modelService, pullRequest.Head.Sha, fileName, fileSha);
                 return Observable.Return(Tuple.Create(left, right));
             });
         }
 
-        async Task<string> ExtractFile(
+        async Task<string> GetFileFromRepositoryOrApi(
             ILocalRepositoryModel repository,
             IRepository repo,
             IModelService modelService,

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -260,6 +260,12 @@ namespace GitHub.Services
                 var repo = gitService.GetRepository(repository.LocalPath);
                 await gitClient.Fetch(repo, "origin");
                 var result = await GetFileFromRepositoryOrApi(repository, repo, modelService, commitSha, fileName, fileSha);
+
+                if (result == null)
+                {
+                    throw new FileNotFoundException($"Could not retrieve {fileName}@{commitSha}");
+                }
+
                 return Observable.Return(result);
             });
         }
@@ -282,6 +288,17 @@ namespace GitHub.Services
                 // The right file - if it comes from a fork - may not be fetched so fall back to
                 // getting the file contents from the model service.
                 var right = await GetFileFromRepositoryOrApi(repository, repo, modelService, pullRequest.Head.Sha, fileName, fileSha);
+
+                if (left == null)
+                {
+                    throw new FileNotFoundException($"Could not retrieve {fileName}@{pullRequest.Base.Sha}");
+                }
+
+                if (right == null)
+                {
+                    throw new FileNotFoundException($"Could not retrieve {fileName}@{pullRequest.Head.Sha}");
+                }
+
                 return Observable.Return(Tuple.Create(left, right));
             });
         }

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -352,7 +352,7 @@ namespace GitHub.ViewModels
         public Task<string> ExtractFile(IPullRequestFileNode file)
         {
             var path = Path.Combine(file.DirectoryPath, file.FileName);
-            return pullRequestsService.ExtractFile(repository, modelService, model.Head.Sha, path).ToTask();
+            return pullRequestsService.ExtractFile(repository, modelService, model.Head.Sha, path, file.Sha).ToTask();
         }
 
         /// <summary>
@@ -363,13 +363,13 @@ namespace GitHub.ViewModels
         public Task<Tuple<string, string>> ExtractDiffFiles(IPullRequestFileNode file)
         {
             var path = Path.Combine(file.DirectoryPath, file.FileName);
-            return pullRequestsService.ExtractDiffFiles(repository, modelService, model, path).ToTask();
+            return pullRequestsService.ExtractDiffFiles(repository, modelService, model, path, file.Sha).ToTask();
         }
 
         IEnumerable<IPullRequestFileNode> CreateChangedFilesList(IPullRequestModel pullRequest, TreeChanges changes)
         {
             return pullRequest.ChangedFiles
-                .Select(x => new PullRequestFileNode(repository.LocalPath, x.FileName, x.Status, GetStatusDisplay(x, changes)));
+                .Select(x => new PullRequestFileNode(repository.LocalPath, x.FileName, x.Sha, x.Status, GetStatusDisplay(x, changes)));
         }
 
         static IPullRequestDirectoryNode CreateChangedFilesTree(IEnumerable<IPullRequestFileNode> files)

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -352,7 +352,7 @@ namespace GitHub.ViewModels
         public Task<string> ExtractFile(IPullRequestFileNode file)
         {
             var path = Path.Combine(file.DirectoryPath, file.FileName);
-            return pullRequestsService.ExtractFile(repository, model.Head.Sha, path).ToTask();
+            return pullRequestsService.ExtractFile(repository, modelService, model.Head.Sha, path).ToTask();
         }
 
         /// <summary>
@@ -363,7 +363,7 @@ namespace GitHub.ViewModels
         public Task<Tuple<string, string>> ExtractDiffFiles(IPullRequestFileNode file)
         {
             var path = Path.Combine(file.DirectoryPath, file.FileName);
-            return pullRequestsService.ExtractDiffFiles(repository, model, path).ToTask();
+            return pullRequestsService.ExtractDiffFiles(repository, modelService, model, path).ToTask();
         }
 
         IEnumerable<IPullRequestFileNode> CreateChangedFilesList(IPullRequestModel pullRequest, TreeChanges changes)

--- a/src/GitHub.App/ViewModels/PullRequestFileNode.cs
+++ b/src/GitHub.App/ViewModels/PullRequestFileNode.cs
@@ -15,13 +15,15 @@ namespace GitHub.ViewModels
         /// </summary>
         /// <param name="repositoryPath">The absolute path to the repository.</param>
         /// <param name="path">The path to the file, relative to the repository.</param>
+        /// <param name="sha">The SHA of the file.</param>
         /// <param name="status">The way the file was changed.</param>
         /// <param name="statusDisplay">The string to display in the [message] box next to the filename.</param>
-        public PullRequestFileNode(string repositoryPath, string path, PullRequestFileStatus status, [AllowNull] string statusDisplay)
+        public PullRequestFileNode(string repositoryPath, string path, string sha, PullRequestFileStatus status, [AllowNull] string statusDisplay)
         {
             FileName = Path.GetFileName(path);
             DirectoryPath = Path.GetDirectoryName(path);
             DisplayPath = Path.Combine(Path.GetFileName(repositoryPath), DirectoryPath);
+            Sha = sha;
             Status = status;
             StatusDisplay = statusDisplay;
         }
@@ -40,6 +42,11 @@ namespace GitHub.ViewModels
         /// Gets the path to display in the "Path" column of the changed files list.
         /// </summary>
         public string DisplayPath { get; }
+
+        /// <summary>
+        /// Gets the SHA of the file.
+        /// </summary>
+        public string Sha { get; }
 
         /// <summary>
         /// Gets the type of change that was made to the file.

--- a/src/GitHub.Exports.Reactive/Api/IApiClient.cs
+++ b/src/GitHub.Exports.Reactive/Api/IApiClient.cs
@@ -39,5 +39,6 @@ namespace GitHub.Api
         IObservable<Branch> GetBranches(string owner, string repo);
         IObservable<Repository> GetRepositories();
         IObservable<Repository> GetRepository(string owner, string repo);
+        IObservable<RepositoryContent> GetFileContents(string owner, string name, string reference, string path);
     }
 }

--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -111,7 +111,9 @@ namespace GitHub.Services
         /// <param name="repository">The repository.</param>
         /// <param name="commitSha">The SHA of the commit.</param>
         /// <param name="fileName">The path to the file, relative to the repository.</param>
-        /// <returns>The filename of the extracted file.</returns>
+        /// <returns>
+        /// The filename of a temporary file containing the file contents.
+        /// </returns>
         Task<string> ExtractFile(IRepository repository, string commitSha, string fileName);
     }
 }

--- a/src/GitHub.Exports.Reactive/Services/IModelService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IModelService.cs
@@ -27,6 +27,6 @@ namespace GitHub.Services
             string title, string body);
         IObservable<IBranch> GetBranches(IRepositoryModel repo);
         IObservable<Unit> InvalidateAll();
-        IObservable<byte[]> GetFileContents(IRepositoryModel repo, string commitSha, string fileName);
+        IObservable<string> GetFileContents(IRepositoryModel repo, string commitSha, string path, string fileSha);
     }
 }

--- a/src/GitHub.Exports.Reactive/Services/IModelService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IModelService.cs
@@ -4,6 +4,7 @@ using System.Reactive;
 using GitHub.Models;
 using GitHub.Caches;
 using GitHub.Collections;
+using System.Threading.Tasks;
 
 namespace GitHub.Services
 {
@@ -26,5 +27,6 @@ namespace GitHub.Services
             string title, string body);
         IObservable<IBranch> GetBranches(IRepositoryModel repo);
         IObservable<Unit> InvalidateAll();
+        IObservable<byte[]> GetFileContents(IRepositoryModel repo, string commitSha, string fileName);
     }
 }

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
@@ -100,19 +100,29 @@ namespace GitHub.Services
         /// Extracts a file at a specified commit from the repository.
         /// </summary>
         /// <param name="repository">The repository.</param>
+        /// <param name="modelService">A model service to use as a cache if the file is not fetched.</param>
         /// <param name="commitSha">The SHA of the commit.</param>
         /// <param name="fileName">The path to the file, relative to the repository.</param>
         /// <returns>The filename of the extracted file.</returns>
-        IObservable<string> ExtractFile(ILocalRepositoryModel repository, string commitSha, string fileName);
+        IObservable<string> ExtractFile(
+            ILocalRepositoryModel repository,
+            IModelService modelService,
+            string commitSha,
+            string fileName);
 
         /// <summary>
         /// Gets the left and right files for a diff.
         /// </summary>
         /// <param name="repository">The repository.</param>
+        /// <param name="modelService">A model service to use as a cache if the file is not fetched.</param>
         /// <param name="pullRequest">The pull request details.</param>
         /// <param name="fileName">The filename relative to the repository root.</param>
         /// <returns>The filenames of the left and right files for the diff.</returns>
-        IObservable<Tuple<string, string>> ExtractDiffFiles(ILocalRepositoryModel repository, IPullRequestModel pullRequest, string fileName);
+        IObservable<Tuple<string, string>> ExtractDiffFiles(
+            ILocalRepositoryModel repository,
+            IModelService modelService,
+            IPullRequestModel pullRequest,
+            string fileName);
 
         IObservable<string> GetPullRequestTemplate(ILocalRepositoryModel repository);
     }

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
@@ -103,12 +103,14 @@ namespace GitHub.Services
         /// <param name="modelService">A model service to use as a cache if the file is not fetched.</param>
         /// <param name="commitSha">The SHA of the commit.</param>
         /// <param name="fileName">The path to the file, relative to the repository.</param>
+        /// <param name="fileSha">The SHA of the file in the pull request.</param>
         /// <returns>The filename of the extracted file.</returns>
         IObservable<string> ExtractFile(
             ILocalRepositoryModel repository,
             IModelService modelService,
             string commitSha,
-            string fileName);
+            string fileName,
+            string fileSha);
 
         /// <summary>
         /// Gets the left and right files for a diff.
@@ -117,12 +119,14 @@ namespace GitHub.Services
         /// <param name="modelService">A model service to use as a cache if the file is not fetched.</param>
         /// <param name="pullRequest">The pull request details.</param>
         /// <param name="fileName">The filename relative to the repository root.</param>
+        /// <param name="fileSha">The SHA of the file in the pull request.</param>
         /// <returns>The filenames of the left and right files for the diff.</returns>
         IObservable<Tuple<string, string>> ExtractDiffFiles(
             ILocalRepositoryModel repository,
             IModelService modelService,
             IPullRequestModel pullRequest,
-            string fileName);
+            string fileName,
+            string fileSha);
 
         IObservable<string> GetPullRequestTemplate(ILocalRepositoryModel repository);
     }

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestFileNode.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestFileNode.cs
@@ -15,6 +15,11 @@ namespace GitHub.ViewModels
         string DisplayPath { get; }
 
         /// <summary>
+        /// Gets the SHA of the file.
+        /// </summary>
+        string Sha { get; }
+
+        /// <summary>
         /// Gets the type of change that was made to the file.
         /// </summary>
         PullRequestFileStatus Status { get; }

--- a/src/GitHub.Exports/Models/IPullRequestFileModel.cs
+++ b/src/GitHub.Exports/Models/IPullRequestFileModel.cs
@@ -11,6 +11,7 @@
     public interface IPullRequestFileModel
     {
         string FileName { get; }
+        string Sha { get; }
         PullRequestFileStatus Status { get; }
     }
 }

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml.cs
@@ -129,16 +129,25 @@ namespace GitHub.VisualStudio.UI.Views
 
         async Task DoOpenFile(IPullRequestFileNode file)
         {
-            var fileName = await ViewModel.ExtractFile(file);
-            var window = Services.Dte.ItemOperations.OpenFile(fileName);
+            try
+            {
+                var fileName = await ViewModel.ExtractFile(file);
+                var window = Services.Dte.ItemOperations.OpenFile(fileName);
 
-            // If the file we extracted isn't the current file on disk, make the window read-only.
-            window.Document.ReadOnly = fileName != file.DirectoryPath;
+                // If the file we extracted isn't the current file on disk, make the window read-only.
+                window.Document.ReadOnly = fileName != file.DirectoryPath;
+            }
+            catch (Exception e)
+            {
+                ShowErrorInStatusBar("Error opening file", e);
+            }
         }
 
         async Task DoDiffFile(IPullRequestFileNode file)
         {
-            var fileNames = await ViewModel.ExtractDiffFiles(file);
+            try
+            {
+                var fileNames = await ViewModel.ExtractDiffFiles(file);
             var leftLabel = $"{file.FileName};{ViewModel.TargetBranchDisplayName}";
             var rightLabel = $"{file.FileName};PR {ViewModel.Model.Number}";
 
@@ -154,6 +163,17 @@ namespace GitHub.VisualStudio.UI.Views
                 (int)(__VSDIFFSERVICEOPTIONS.VSDIFFOPT_DetectBinaryFiles |
                     __VSDIFFSERVICEOPTIONS.VSDIFFOPT_LeftFileIsTemporary |
                     __VSDIFFSERVICEOPTIONS.VSDIFFOPT_RightFileIsTemporary));
+            }
+            catch (Exception e)
+            {
+                ShowErrorInStatusBar("Error opening file", e);
+            }
+        }
+
+        void ShowErrorInStatusBar(string message, Exception e)
+        {
+            var ns = Services.DefaultExportProvider.GetExportedValue<IStatusBarNotificationService>();
+            ns?.ShowMessage(message + ": " + e.Message);
         }
 
         void FileListMouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
@@ -58,11 +58,11 @@ namespace UnitTests.GitHub.App.ViewModels
 
                 pr.ChangedFiles = new[]
                 {
-                    new PullRequestFileModel("readme.md", PullRequestFileStatus.Modified),
-                    new PullRequestFileModel("dir1/f1.cs", PullRequestFileStatus.Added),
-                    new PullRequestFileModel("dir1/f2.cs", PullRequestFileStatus.Removed),
-                    new PullRequestFileModel("dir1/dir1a/f3.cs", PullRequestFileStatus.Modified),
-                    new PullRequestFileModel("dir2/f4.cs", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("readme.md", "abc", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/f1.cs", "abc", PullRequestFileStatus.Added),
+                    new PullRequestFileModel("dir1/f2.cs", "abc", PullRequestFileStatus.Removed),
+                    new PullRequestFileModel("dir1/dir1a/f3.cs", "abc", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir2/f4.cs", "abc", PullRequestFileStatus.Modified),
                 };
 
                 await target.Load(pr);
@@ -115,10 +115,10 @@ namespace UnitTests.GitHub.App.ViewModels
 
                 pr.ChangedFiles = new[]
                 {
-                    new PullRequestFileModel(@"readme.md", PullRequestFileStatus.Renamed),
-                    new PullRequestFileModel(@"dir1/f1.cs", PullRequestFileStatus.Renamed),
-                    new PullRequestFileModel(@"dir1/f2.cs", PullRequestFileStatus.Renamed),
-                    new PullRequestFileModel(@"f3.cs", PullRequestFileStatus.Renamed),
+                    new PullRequestFileModel(@"readme.md", "abc", PullRequestFileStatus.Renamed),
+                    new PullRequestFileModel(@"dir1/f1.cs", "abc", PullRequestFileStatus.Renamed),
+                    new PullRequestFileModel(@"dir1/f2.cs", "abc", PullRequestFileStatus.Renamed),
+                    new PullRequestFileModel(@"f3.cs", "abc", PullRequestFileStatus.Renamed),
                 };
 
                 var changes = Substitute.For<TreeChanges>();
@@ -158,11 +158,11 @@ namespace UnitTests.GitHub.App.ViewModels
 
                 pr.ChangedFiles = new[]
                 {
-                    new PullRequestFileModel("readme.md", PullRequestFileStatus.Modified),
-                    new PullRequestFileModel("dir1/f1.cs", PullRequestFileStatus.Modified),
-                    new PullRequestFileModel("dir1/f2.cs", PullRequestFileStatus.Modified),
-                    new PullRequestFileModel("dir1/dir1a/f3.cs", PullRequestFileStatus.Modified),
-                    new PullRequestFileModel("dir2/f4.cs", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("readme.md", "abc", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/f1.cs", "abc", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/f2.cs", "abc", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/dir1a/f3.cs", "abc", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir2/f4.cs", "abc", PullRequestFileStatus.Modified),
                 };
 
                 await target.Load(pr);


### PR DESCRIPTION
When viewing a PR from a fork in the PR details view, if the fork has not been fetched locally then "Compare File" and "Open File" were
failing silently. This is because to get the files to compare, we looked up the PR HEAD commit and get the file from the returned tree. We did a
fetch before looking up the PR HEAD but if the fork is a repository that does not yet have a remote then we won't have fetched the commit.

This adds a fallback to using the API and storing a cached version of the file contents.

#720 and #724 should be merged before this (which should resolve the conflicts)

Fixes #725 