### PR TITLE
Handle non-latin PR titles.

### DIFF
--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -159,7 +159,7 @@ namespace GitHub.Services
                     current = initial + '-' + index++;
                 }
 
-                return Observable.Return(current);
+                return Observable.Return(current.TrimEnd('-'));
             });
         }
 

--- a/src/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
+++ b/src/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
@@ -178,6 +178,20 @@ public class PullRequestServiceTests : TestBaseClass
         }
 
         [Fact]
+        public async Task ShouldReturnCorrectDefaultLocalBranchNameForPullRequestsWithNonLatinChars()
+        {
+            var service = new PullRequestService(
+                Substitute.For<IGitClient>(),
+                MockGitService(),
+                Substitute.For<IOperatingSystem>(),
+                Substitute.For<IUsageTracker>());
+
+            var localRepo = Substitute.For<ILocalRepositoryModel>();
+            var result = await service.GetDefaultLocalBranchName(localRepo, 123, "コードをレビューする準備ができたこと");
+            Assert.Equal("pr/123", result);
+        }
+
+        [Fact]
         public async Task DefaultLocalBranchNameShouldNotClashWithExistingBranchNames()
         {
             var service = new PullRequestService(


### PR DESCRIPTION
Previously a non-latin PR title resulted in a PR branch called `pr/[Number]-`. Use just `pr/[Number]` in this case.

Fixes #618.