### PR TITLE
ModelService prevents ObjectDisposedException

### DIFF
--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -164,8 +164,7 @@ namespace GitHub.Services
                                  .Select(PullRequestCacheItem.Create),
                         item =>
                         {
-                            if(collection.Disposed)
-                            { return; }
+                            if (collection.Disposed) return;
 
                             // this could blow up due to the collection being disposed somewhere else
                             try { collection.RemoveItem(Create(item)); }
@@ -209,9 +208,8 @@ namespace GitHub.Services
                                  .Select(RepositoryCacheItem.Create),
                         item =>
                         {
-                            if (collection.Disposed)
-                            { return; }
-                            
+                            if (collection.Disposed) return;
+
                             // this could blow up due to the collection being disposed somewhere else
                             try { collection.RemoveItem(Create(item)); }
                             catch (ObjectDisposedException) { }

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -157,22 +157,33 @@ namespace GitHub.Services
             var keyobs = GetUserFromCache()
                 .Select(user => string.Format(CultureInfo.InvariantCulture, "{0}|{1}:{2}", CacheIndex.PRPrefix, user.Login, repo.Name));
 
-            var source = Observable.Defer(() => keyobs
-                .SelectMany(key =>
-                    hostCache.GetAndFetchLatestFromIndex(key, () =>
+            var source = Observable.Defer(() =>
+            {
+                var collectionIsDisposed = false;
+
+                return keyobs
+                    .SelectMany(key => hostCache.GetAndFetchLatestFromIndex(key, () =>
                         apiClient.GetPullRequestsForRepository(repo.CloneUrl.Owner, repo.CloneUrl.RepositoryName)
-                                 .Select(PullRequestCacheItem.Create),
-                        item =>
-                        {
-                            // this could blow up due to the collection being disposed somewhere else
-                            try { collection.RemoveItem(Create(item)); }
-                            catch (ObjectDisposedException) { }
-                        },
-                        TimeSpan.Zero,
-                        TimeSpan.FromDays(7))
-                )
-                .Select(Create)
-            );
+                            .Select(PullRequestCacheItem.Create), item =>
+                            {
+                                try
+                                {
+                                    if (!collectionIsDisposed)
+                                    {
+                                        // this could blow up due to the collection being disposed somewhere else
+                                        collection.RemoveItem(Create(item));
+                                    }
+                                }
+                                catch (ObjectDisposedException)
+                                {
+                                    // take the hint and stop trying
+                                    collectionIsDisposed = true;
+                                }
+                            }, 
+                            TimeSpan.Zero, 
+                            TimeSpan.FromDays(7)))
+                    .Select(Create);
+            });
 
             collection.Listen(source);
             return collection;
@@ -199,22 +210,33 @@ namespace GitHub.Services
             var keyobs = GetUserFromCache()
                 .Select(user => string.Format(CultureInfo.InvariantCulture, "{0}|{1}", CacheIndex.RepoPrefix, user.Login));
 
-            var source = Observable.Defer(() => keyobs
-                .SelectMany(key =>
-                    hostCache.GetAndFetchLatestFromIndex(key, () =>
+            var source = Observable.Defer(() =>
+            {
+                var collectionIsDisposed = false;
+
+                return keyobs
+                    .SelectMany(key => hostCache.GetAndFetchLatestFromIndex(key, () =>
                         apiClient.GetRepositories()
-                                 .Select(RepositoryCacheItem.Create),
-                        item =>
-                        {
-                            // this could blow up due to the collection being disposed somewhere else
-                            try { collection.RemoveItem(Create(item)); }
-                            catch (ObjectDisposedException) { }
-                        },
-                        TimeSpan.FromMinutes(5),
-                        TimeSpan.FromDays(1))
-                )
-                .Select(Create)
-            );
+                            .Select(RepositoryCacheItem.Create), item =>
+                            {
+                                try
+                                {
+                                    if (!collectionIsDisposed)
+                                    {
+                                        // this could blow up due to the collection being disposed somewhere else
+                                        collection.RemoveItem(Create(item));
+                                    }
+                                }
+                                catch (ObjectDisposedException)
+                                {
+                                    // take the hint and stop trying
+                                    collectionIsDisposed = true;
+                                }
+                            },
+                            TimeSpan.FromMinutes(5),
+                            TimeSpan.FromDays(1)))
+                    .Select(Create);
+            });
 
             collection.Listen(source);
             return collection;

--- a/src/GitHub.Exports.Reactive/Collections/ITrackingCollection.cs
+++ b/src/GitHub.Exports.Reactive/Collections/ITrackingCollection.cs
@@ -67,5 +67,7 @@ namespace GitHub.Collections
         /// regardless of filtering
         /// </summary>
         int UnfilteredCount { get; }
+
+        bool Disposed { get; }
     }
 }

--- a/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
+++ b/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
@@ -1179,6 +1179,8 @@ namespace GitHub.Collections
         }
 
         bool disposed = false;
+        public bool Disposed => disposed;
+
         void Dispose(bool disposing)
         {
             if (disposing)


### PR DESCRIPTION
A fix for #738 and #597
I realized I wouldn't be able to make a unit test for an exception that was being discarded.
And that's when I realized the fix might just be to "take the hint".
If the collection throws an `ObjectDisposedException`, simply stop trying to access it.