### PR TITLE
Update push/pull tooltips.

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -19,8 +19,8 @@ namespace GitHub.SampleData
         public int CommitsAhead { get; set; }
         public int CommitsBehind { get; set; }
         public bool UpToDate { get; set; }
-        public string PullDisabledMessage { get; set; }
-        public string PushDisabledMessage { get; set; }
+        public string PullToolTip { get; set; }
+        public string PushToolTip { get; set; }
     }
 
     [ExcludeFromCodeCoverage]

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -196,7 +196,14 @@ namespace GitHub.Services
 
         public bool IsPullRequestFromFork(ILocalRepositoryModel repository, IPullRequestModel pullRequest)
         {
-            return pullRequest.Head.RepositoryCloneUrl?.ToRepositoryUrl() != repository.CloneUrl.ToRepositoryUrl();
+            if (pullRequest.Head?.Label != null && pullRequest.Base?.Label != null)
+            {
+                var headOwner = pullRequest.Head.Label.Split(':')[0];
+                var baseOwner = pullRequest.Base.Label.Split(':')[0];
+                return headOwner != baseOwner;
+            }
+
+            return false;
         }
 
         public IObservable<Unit> SwitchToBranch(ILocalRepositoryModel repository, IPullRequestModel pullRequest)

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
@@ -78,12 +78,12 @@ namespace GitHub.ViewModels
         /// <summary>
         /// Gets the message to display when a pull cannot be carried out.
         /// </summary>
-        string PullDisabledMessage { get; }
+        string PullToolTip { get; }
 
         /// <summary>
         /// Gets the message to display when a push cannot be carried out.
         /// </summary>
-        string PushDisabledMessage { get; }
+        string PushToolTip { get; }
     }
 
     /// <summary>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -176,7 +176,7 @@
                         <ui:GitHubActionLink Content="Pull"
                                              Command="{Binding Pull}"
                                              Margin="4,0"
-                                             ToolTip="{Binding UpdateState.PullDisabledMessage}"
+                                             ToolTip="{Binding UpdateState.PullToolTip}"
                                              ToolTipService.ShowOnDisabled="True"
                                              VerticalAlignment="Center"/>
                         <ui:OcticonImage Icon="arrow_up"/>
@@ -184,7 +184,7 @@
                         <ui:GitHubActionLink Content="Push"
                                              Command="{Binding Push}"
                                              Margin="4,0"
-                                             ToolTip="{Binding UpdateState.PushDisabledMessage}"
+                                             ToolTip="{Binding UpdateState.PushToolTip}"
                                              ToolTipService.ShowOnDisabled="True"
                                              VerticalAlignment="Center"/>
                     </StackPanel>

--- a/src/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
+++ b/src/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
@@ -220,7 +220,7 @@ public class PullRequestServiceTests : TestBaseClass
             var localRepo = Substitute.For<ILocalRepositoryModel>();
             localRepo.CloneUrl.Returns(new UriString("https://github.com/foo/bar"));
 
-            var result = await service.GetLocalBranches(localRepo, CreatePullRequest());
+            var result = await service.GetLocalBranches(localRepo, CreatePullRequest(fromFork: false));
 
             Assert.Equal("source", result.Name);
         }
@@ -253,14 +253,13 @@ public class PullRequestServiceTests : TestBaseClass
                 Substitute.For<IUsageTracker>());
 
             var localRepo = Substitute.For<ILocalRepositoryModel>();
-            localRepo.CloneUrl.Returns(new UriString("https://github.com/baz/bar"));
 
-            var result = await service.GetLocalBranches(localRepo, CreatePullRequest());
+            var result = await service.GetLocalBranches(localRepo, CreatePullRequest(true));
 
             Assert.Equal("pr/1-foo", result.Name);
         }
 
-        static IPullRequestModel CreatePullRequest()
+        static IPullRequestModel CreatePullRequest(bool fromFork)
         {
             var author = Substitute.For<IAccount>();
 
@@ -268,7 +267,7 @@ public class PullRequestServiceTests : TestBaseClass
             {
                 State = PullRequestStateEnum.Open,
                 Body = string.Empty,
-                Head = new GitReferenceModel("source", "foo:baz", "sha", "https://github.com/foo/bar.git"),
+                Head = new GitReferenceModel("source", fromFork ? "fork:baz" : "foo:baz", "sha", "https://github.com/foo/bar.git"),
                 Base = new GitReferenceModel("dest", "foo:bar", "sha", "https://github.com/foo/bar.git"),
             };
         }

--- a/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
@@ -44,7 +44,7 @@ namespace UnitTests.GitHub.App.ViewModels
 
                 await target.Load(model);
 
-                Assert.Equal("[Invalid]", target.SourceBranchDisplayName);
+                Assert.Equal("[invalid]", target.SourceBranchDisplayName);
             }
         }
 
@@ -309,7 +309,7 @@ namespace UnitTests.GitHub.App.ViewModels
                 Assert.False(target.Pull.CanExecute(null));
                 Assert.Equal(0, target.UpdateState.CommitsAhead);
                 Assert.Equal(0, target.UpdateState.CommitsBehind);
-                Assert.Equal("No commits to pull", target.UpdateState.PullDisabledMessage);
+                Assert.Equal("No commits to pull", target.UpdateState.PullToolTip);
             }
 
             [Fact]
@@ -324,7 +324,7 @@ namespace UnitTests.GitHub.App.ViewModels
                 Assert.True(target.Pull.CanExecute(null));
                 Assert.Equal(0, target.UpdateState.CommitsAhead);
                 Assert.Equal(2, target.UpdateState.CommitsBehind);
-                Assert.Null(target.UpdateState.PullDisabledMessage);
+                Assert.Equal("Pull from remote branch baz", target.UpdateState.PullToolTip);
             }
 
             [Fact]
@@ -340,7 +340,23 @@ namespace UnitTests.GitHub.App.ViewModels
                 Assert.True(target.Pull.CanExecute(null));
                 Assert.Equal(3, target.UpdateState.CommitsAhead);
                 Assert.Equal(2, target.UpdateState.CommitsBehind);
-                Assert.Null(target.UpdateState.PullDisabledMessage);
+                Assert.Equal("Pull from remote branch baz", target.UpdateState.PullToolTip);
+            }
+
+            [Fact]
+            public async Task CheckedOutAndBehindFork()
+            {
+                var target = CreateTarget(
+                    currentBranch: "pr/123",
+                    existingPrBranch: "pr/123",
+                    prFromFork: true,
+                    behindBy: 2);
+                await target.Load(CreatePullRequest());
+
+                Assert.True(target.Pull.CanExecute(null));
+                Assert.Equal(0, target.UpdateState.CommitsAhead);
+                Assert.Equal(2, target.UpdateState.CommitsBehind);
+                Assert.Equal("Pull from fork branch foo:baz", target.UpdateState.PullToolTip);
             }
 
             [Fact]
@@ -381,7 +397,7 @@ namespace UnitTests.GitHub.App.ViewModels
                 Assert.False(target.Push.CanExecute(null));
                 Assert.Equal(0, target.UpdateState.CommitsAhead);
                 Assert.Equal(0, target.UpdateState.CommitsBehind);
-                Assert.Equal("No commits to push", target.UpdateState.PushDisabledMessage);
+                Assert.Equal("No commits to push", target.UpdateState.PushToolTip);
             }
 
             [Fact]
@@ -396,7 +412,7 @@ namespace UnitTests.GitHub.App.ViewModels
                 Assert.True(target.Push.CanExecute(null));
                 Assert.Equal(2, target.UpdateState.CommitsAhead);
                 Assert.Equal(0, target.UpdateState.CommitsBehind);
-                Assert.Null(target.UpdateState.PushDisabledMessage);
+                Assert.Equal("Push to remote branch baz", target.UpdateState.PushToolTip);
             }
 
             [Fact]
@@ -411,7 +427,7 @@ namespace UnitTests.GitHub.App.ViewModels
                 Assert.False(target.Push.CanExecute(null));
                 Assert.Equal(0, target.UpdateState.CommitsAhead);
                 Assert.Equal(2, target.UpdateState.CommitsBehind);
-                Assert.Equal("No commits to push", target.UpdateState.PushDisabledMessage);
+                Assert.Equal("No commits to push", target.UpdateState.PushToolTip);
             }
 
             [Fact]
@@ -427,7 +443,23 @@ namespace UnitTests.GitHub.App.ViewModels
                 Assert.False(target.Push.CanExecute(null));
                 Assert.Equal(3, target.UpdateState.CommitsAhead);
                 Assert.Equal(2, target.UpdateState.CommitsBehind);
-                Assert.Equal("You must pull before you can push", target.UpdateState.PushDisabledMessage);
+                Assert.Equal("You must pull before you can push", target.UpdateState.PushToolTip);
+            }
+
+            [Fact]
+            public async Task CheckedOutAndAheadOfFork()
+            {
+                var target = CreateTarget(
+                    currentBranch: "pr/123",
+                    existingPrBranch: "pr/123",
+                    prFromFork: true,
+                    aheadBy: 2);
+                await target.Load(CreatePullRequest());
+
+                Assert.True(target.Push.CanExecute(null));
+                Assert.Equal(2, target.UpdateState.CommitsAhead);
+                Assert.Equal(0, target.UpdateState.CommitsBehind);
+                Assert.Equal("Push to remote branch foo:baz", target.UpdateState.PushToolTip);
             }
 
             [Fact]

--- a/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
@@ -459,7 +459,7 @@ namespace UnitTests.GitHub.App.ViewModels
                 Assert.True(target.Push.CanExecute(null));
                 Assert.Equal(2, target.UpdateState.CommitsAhead);
                 Assert.Equal(0, target.UpdateState.CommitsBehind);
-                Assert.Equal("Push to remote branch foo:baz", target.UpdateState.PushToolTip);
+                Assert.Equal("Push to fork branch foo:baz", target.UpdateState.PushToolTip);
             }
 
             [Fact]


### PR DESCRIPTION
Display the name of the branch that changes will be pushed to/pulled from.

Also fix the logic in `PullRequestService.IsPullRequestFromFork` - it
was incorrect before.

@donokuda this was the change you requested in your PR, targeted at your PR.