### PR TITLE
Fix PR branch display layout

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -39,8 +39,8 @@ namespace GitHub.SampleData
                 CommitCount = 9,
             };
 
-            SourceBranchDisplayName = "shana/error-handling-a-ridiculously-long-branch-name-because-why-not";
-            TargetBranchDisplayName = "master-is-always-stable";
+            SourceBranchDisplayName = "shana/error-handling";
+            TargetBranchDisplayName = "master";
             Body = @"Adds a way to surface errors from the view model to the view so that view hosts can get to them.
 
 ViewModels are responsible for handling the UI on the view they control, but they shouldn't be handling UI for things outside of the view. In this case, we're showing errors in VS outside the view, and that should be handled by the section that is hosting the view.
@@ -72,8 +72,8 @@ This requires that errors be propagated from the viewmodel to the view and from 
         }
 
         public IPullRequestModel Model { get; }
-        public string SourceBranchDisplayName { get; }
-        public string TargetBranchDisplayName { get; }
+        public string SourceBranchDisplayName { get; set; }
+        public string TargetBranchDisplayName { get; set; }
         public string Body { get; }
         public ChangedFilesViewType ChangedFilesViewType { get; set; }
         public OpenChangedFileAction OpenChangedFileAction { get; set; }

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -135,10 +135,10 @@
 
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
                 <!-- source and target branches -->
-                <Grid Margin="0 -3">
+                <Grid Margin="0 -3" HorizontalAlignment="Left">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -172,7 +172,7 @@
                                          Content="{Binding CheckoutState.Caption}"
                                          Grid.Column="2"
                                          VerticalAlignment="Center"
-                                         TextWrapping="Wrap"
+                                         TextTrimming="CharacterEllipsis"
                                          Visibility="{Binding CheckoutState, Converter={ui:NullToVisibilityConverter}}"
                                          ToolTip="{Binding CheckoutState.DisabledMessage}"
                                          ToolTipService.ShowOnDisabled="True"/>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -22,7 +22,8 @@
     <d:DesignProperties.DataContext>
         <Binding>
             <Binding.Source>
-                <sampleData:PullRequestDetailViewModelDesigner>
+                <sampleData:PullRequestDetailViewModelDesigner SourceBranchDisplayName="shana/error-handling-a-ridiculously-long-branch-name-because-why-not"
+                                                               TargetBranchDisplayName="master-is-always-stable">
                     <!--
                     <sampleData:PullRequestDetailViewModelDesigner.CheckoutState>
                         <sampleData:PullRequestCheckoutStateDesigner Caption="Checkout error-handling/>


### PR DESCRIPTION
Finishing off the work in #730, this PR attempts to fix the handling of long branch names in the PR details view. The current results are:

Short branch names:

![image](https://cloud.githubusercontent.com/assets/1775141/21349415/bb7ecc5a-c6a9-11e6-89db-69ab65e8cb72.png)

Long branch names (screenshot taken in designer for this one):

![image](https://cloud.githubusercontent.com/assets/1775141/21349438/de3b34ae-c6a9-11e6-87d8-ea3a96986629.png)

Mixture of long and short branch names:

![image](https://cloud.githubusercontent.com/assets/1775141/21349382/8a88e842-c6a9-11e6-9b99-a64e789120b8.png)

As you can see this is almost right, except with a mixture of short and long branch names both the short and long branch name take up max 50% of the free space, where the long branch name could take up more. To fix this, I think we'd need to move to a custom `Panel`. Thoughts @donokuda @shana ?