### PR TITLE
Fix race condition on initialization

### DIFF
--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -53,7 +53,7 @@ namespace GitHub.VisualStudio
             await EnsurePackageLoaded(new Guid(ServiceProviderPackage.ServiceProviderPackageId));
 
             // Activate the usage tracker by forcing an instance to be created.
-            GetServiceAsync(typeof(IUsageTracker)).Forget();
+            await GetServiceAsync(typeof(IUsageTracker));
 
             InitializeMenus().Forget();
         }


### PR DESCRIPTION
If the package loader happens very early at VS init time, the call to get the ComponentModel inside GitHubServiceProvider will take some time (while VS is pondering life), causing the Initialize codepath to continue attemping to initialize the menus, which will cause a reentrancy deadlock between MEF getting services and our service provider initializing. sigh.