### PR TITLE
Fix repository list refresh in Connect page

### DIFF
--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerSectionBase.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerSectionBase.cs
@@ -104,7 +104,8 @@ namespace GitHub.VisualStudio.Base
 
         protected ITeamExplorerSection GetSection(Guid section)
         {
-            return ServiceProvider.TryGetService<ITeamExplorerPage>()?.GetSection(section);
+            var tep = (ITeamExplorerPage)TEServiceProvider.GetServiceSafe(typeof(ITeamExplorerPage));
+            return tep?.GetSection(section);
         }
     }
 }

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -181,7 +181,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             // watch for new repos added to the local repo list
             var section = GetSection(TeamExplorerConnectionsSectionId);
             if (section != null)
-                sectionTracker = new SectionStateTracker(section, () => RefreshRepositories(true));
+                sectionTracker = new SectionStateTracker(section, () => RefreshRepositories(sectionIndex == 0));
         }
 
         void UpdateConnection()

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -163,7 +163,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                     IsExpanded = settings.IsExpanded;
                 }
                 if (TEServiceProvider != null)
-                    RefreshRepositories(sectionIndex == 0).Forget();
+                    RefreshRepositories().Forget();
             }
         }
 
@@ -181,7 +181,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             // watch for new repos added to the local repo list
             var section = GetSection(TeamExplorerConnectionsSectionId);
             if (section != null)
-                sectionTracker = new SectionStateTracker(section, () => RefreshRepositories(sectionIndex == 0));
+                sectionTracker = new SectionStateTracker(section, RefreshRepositories);
         }
 
         void UpdateConnection()
@@ -313,10 +313,11 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 #endif
         }
 
-        async Task RefreshRepositories(bool refreshConnectionManager)
+        async Task RefreshRepositories()
         {
-            if (refreshConnectionManager)
-                await connectionManager.RefreshRepositories();
+            // TODO: This is wasteful as we can be calling it multiple times for a single changed
+            // signal, once from each section. Needs refactoring.
+            await connectionManager.RefreshRepositories();
             RaisePropertyChanged("Repositories"); // trigger a re-check of the visibility of the listview based on item count
         }
 

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -162,8 +162,8 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                     settings = packageSettings.UIState.GetOrCreateConnectSection(Title);
                     IsExpanded = settings.IsExpanded;
                 }
-                if (sectionIndex == 0 && TEServiceProvider != null)
-                    RefreshRepositories().Forget();
+                if (TEServiceProvider != null)
+                    RefreshRepositories(sectionIndex == 0).Forget();
             }
         }
 
@@ -181,7 +181,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             // watch for new repos added to the local repo list
             var section = GetSection(TeamExplorerConnectionsSectionId);
             if (section != null)
-                sectionTracker = new SectionStateTracker(section, RefreshRepositories);
+                sectionTracker = new SectionStateTracker(section, () => RefreshRepositories(true));
         }
 
         void UpdateConnection()
@@ -313,9 +313,10 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 #endif
         }
 
-        async Task RefreshRepositories()
+        async Task RefreshRepositories(bool refreshConnectionManager)
         {
-            await connectionManager.RefreshRepositories();
+            if (refreshConnectionManager)
+                await connectionManager.RefreshRepositories();
             RaisePropertyChanged("Repositories"); // trigger a re-check of the visibility of the listview based on item count
         }
 

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -159,12 +159,11 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                     Title = connection.HostAddress.Title;
                     IsVisible = true;
                     LoggedIn = true;
-                    if (TEServiceProvider != null)
-                        RefreshRepositories().Forget();
-
                     settings = packageSettings.UIState.GetOrCreateConnectSection(Title);
                     IsExpanded = settings.IsExpanded;
                 }
+                if (sectionIndex == 0 && TEServiceProvider != null)
+                    RefreshRepositories().Forget();
             }
         }
 


### PR DESCRIPTION
Things broke on the connect page when https://github.com/github/VisualStudio/commit/1be202d9 got merged and the order in which `Refresh` gets called changed slightly.

Refresh gets called twice for each connect section when loading, once from the constructor and once from initialize. We can only call `RefreshRepositories` when `Initialize` get called (that's when the Team Explorer IServiceProvider is available and we can make sure the git services we rely upon are registered on that IServiceProvider), and we only want to refresh repositories once, since that command refreshes all repositories for all connections.

This needs to be tested with two accounts logged in (github.com and enterprise) so it creates two connect sections and we make sure it doesn't double-refresh or otherwise break.