### PR TITLE
Fix enterprise login.

### DIFF
--- a/src/GitHub.App/Models/RepositoryHosts.cs
+++ b/src/GitHub.App/Models/RepositoryHosts.cs
@@ -53,7 +53,6 @@ namespace GitHub.Models
                 .Select(HostAddress.Create)
                 .Where(x => connectionManager.Connections.Any(c => c.HostAddress.Equals(x)))
                 .Select(repositoryHostFactory.Create)
-                .Do(x => EnterpriseHost = x)
                 .Do(disposables.Add)
                 .SelectUnit();
 

--- a/src/GitHub.App/Models/RepositoryHosts.cs
+++ b/src/GitHub.App/Models/RepositoryHosts.cs
@@ -42,20 +42,6 @@ namespace GitHub.Models
             GitHubHost = DisconnectedRepositoryHost;
             EnterpriseHost = DisconnectedRepositoryHost;
 
-            var initialCacheLoadObs = sharedCache.UserAccount.GetObject<Uri>(EnterpriseHostApiBaseUriCacheKey)
-                .Catch<Uri, KeyNotFoundException>(_ => Observable.Return<Uri>(null))
-                .Catch<Uri, Exception>(ex =>
-                {
-                    log.Warn("Failed to get Enterprise host URI from cache.", ex);
-                    return Observable.Return<Uri>(null);
-                })
-                .WhereNotNull()
-                .Select(HostAddress.Create)
-                .Where(x => connectionManager.Connections.Any(c => c.HostAddress.Equals(x)))
-                .Select(repositoryHostFactory.Create)
-                .Do(disposables.Add)
-                .SelectUnit();
-
             var persistEntepriseHostObs = this.WhenAny(x => x.EnterpriseHost, x => x.Value)
                 .Skip(1)  // The first value will be null or something already in the db
                 .SelectMany(enterpriseHost =>
@@ -108,7 +94,7 @@ namespace GitHub.Models
 
             // Wait until we've loaded (or failed to load) an enterprise uri from the db and then
             // start tracking changes to the EnterpriseHost property and persist every change to the db
-            disposables.Add(Observable.Concat(initialCacheLoadObs, persistEntepriseHostObs).Subscribe());
+            disposables.Add(persistEntepriseHostObs.Subscribe());
         }
 
         IObservable<IConnection> RunLoginHandler(IConnection connection)


### PR DESCRIPTION
#612 added an `operator==` for `HostAddress`, however this fixed a bug where [this line](https://github.com/github/VisualStudio/blob/master/src/GitHub.App/Models/RepositoryHosts.cs#L135) was previously always resulting in `false` even when the hosts had matching URLs. Because of this bug, `DisconnectedRepositoryHost` (the correct initial state of `EnterpriseHost`) was always being set in the line affected by this PR, so things carried on working anyway.

Before the fix in this PR, the UI controller would see the real `RepositoryHost` and see that it's not logged in  and so show the login dialog. After the fix in this PR the login from cache happens like it should.