### PR TITLE
Fix "view conversation on GitHub" link.

### DIFF
--- a/src/GitHub.Exports/Services/Services.cs
+++ b/src/GitHub.Exports/Services/Services.cs
@@ -16,11 +16,14 @@ namespace GitHub.VisualStudio
 {
     public static class Services
     {
-        public static IServiceProvider PackageServiceProvider { get; set; }
+        /// <summary>
+        /// Gets a service provider which can be used by unit tests to inject services.
+        /// </summary>
+        public static IServiceProvider UnitTestServiceProvider { get; set; }
 
         /// <summary>
         /// Three ways of getting a service. First, trying the passed-in <paramref name="provider"/>,
-        /// then <see cref="PackageServiceProvider"/>, then <see cref="T:Microsoft.VisualStudio.Shell.Package"/>
+        /// then <see cref="UnitTestServiceProvider"/>, then <see cref="T:Microsoft.VisualStudio.Shell.Package"/>
         /// If the passed-in provider returns null, try PackageServiceProvider or Package, returning the fetched value
         /// regardless of whether it's null or not. Package.GetGlobalService is never called if PackageServiceProvider is set.
         /// This is on purpose, to support easy unit testing outside VS.
@@ -36,8 +39,8 @@ namespace GitHub.VisualStudio
                 ret = provider.GetService(typeof(T)) as Ret;
             if (ret != null)
                 return ret;
-            if (PackageServiceProvider != null)
-                return PackageServiceProvider.GetService(typeof(T)) as Ret;
+            if (UnitTestServiceProvider != null)
+                return UnitTestServiceProvider.GetService(typeof(T)) as Ret;
             return Package.GetGlobalService(typeof(T)) as Ret;
         }
 

--- a/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml.cs
@@ -71,7 +71,7 @@ namespace GitHub.VisualStudio.UI.Controls
             get
             {
                 if (browser == null)
-                    browser = Services.PackageServiceProvider.GetServiceSafe<IVisualStudioBrowser>();
+                    browser = Services.GitHubServiceProvider.TryGetService<IVisualStudioBrowser>();
                 return browser;
             }
         }

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml.cs
@@ -46,6 +46,12 @@ namespace GitHub.VisualStudio.UI.Views
             });
         }
 
+        [Import]
+        ITeamExplorerServiceHolder TeamExplorerServiceHolder { get; set; }
+
+        [Import]
+        IVisualStudioBrowser VisualStudioBrowser { get; set; }
+
         protected override void OnVisualParentChanged(DependencyObject oldParent)
         {
             base.OnVisualParentChanged(oldParent);
@@ -53,8 +59,8 @@ namespace GitHub.VisualStudio.UI.Views
 
         void DoOpenOnGitHub()
         {
-            var repo = Services.PackageServiceProvider.GetServiceSafe<ITeamExplorerServiceHolder>().ActiveRepo;
-            var browser = Services.PackageServiceProvider.GetServiceSafe<IVisualStudioBrowser>();
+            var repo = TeamExplorerServiceHolder.ActiveRepo;
+            var browser = VisualStudioBrowser;
             var url = repo.CloneUrl.ToRepositoryUrl().Append("pull/" + ViewModel.Model.Number);
             browser.OpenUrl(url);
         }

--- a/src/UnitTests/Substitutes.cs
+++ b/src/UnitTests/Substitutes.cs
@@ -109,7 +109,7 @@ namespace UnitTests
             cc.ComposeExportedValue(gitservice);
             ((IComponentModel)cm).DefaultExportProvider.Returns(cc);
             ret.GetService(typeof(SComponentModel)).Returns(cm);
-            Services.PackageServiceProvider = ret;
+            Services.UnitTestServiceProvider = ret;
 
             var os = OperatingSystem;
             var vsgit = IVSGitServices;


### PR DESCRIPTION
`PackageServiceProvider` should not be used to get services from views, instead they should be injected (as they now are in `PullRequestDetailView`) or got from `GitHubServiceProvider` (as they now are in `InfoPanel`).

Also renamed `Services.PackageServiceProvider` to `Services.UnitTestServiceProvider` as unit tests were the only place in which this property was set and it was intended for use by unit tests to inject services given that full MEF is not available.