### PR TITLE
Fix GitHubServiceProvider.GetService<T, Ret>()

### DIFF
--- a/src/GitHub.VisualStudio/Services/GitHubServiceProvider.cs
+++ b/src/GitHub.VisualStudio/Services/GitHubServiceProvider.cs
@@ -224,7 +224,7 @@ namespace GitHub.VisualStudio
         public Ret GetService<T, Ret>() where T : class
                                         where Ret : class
         {
-            return TryGetService<T>() as Ret;
+            return TryGetService(typeof(T)) as Ret;
         }
 
         public void AddService<T>(object owner, T instance) where T : class


### PR DESCRIPTION
GitHubServiceProvider.GetService<T, Ret>() was previously calling `TryGetService<T>` which had the effect of tying to cast the service retreived
as `T` to  an instance of `T`, which due to the joys of COM services failed. This was breaking gists. Fixes #770.