### PR TITLE
Display checkout button tooltip even when enabled.

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -11,7 +11,8 @@ namespace GitHub.SampleData
     public class PullRequestCheckoutStateDesigner : IPullRequestCheckoutState
     {
         public string Caption { get; set; }
-        public string DisabledMessage { get; set; }
+        public bool IsEnabled { get; set; }
+        public string ToolTip { get; set; }
     }
 
     public class PullRequestUpdateStateDesigner : IPullRequestUpdateState

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -88,7 +88,7 @@ namespace GitHub.ViewModels
             Checkout = ReactiveCommand.CreateAsyncObservable(
                 this.WhenAnyValue(x => x.CheckoutState)
                     .Cast<CheckoutCommandState>()
-                    .Select(x => x != null && x.DisabledMessage == null), 
+                    .Select(x => x != null && x.IsEnabled), 
                 DoCheckout);
             Checkout.ThrownExceptions.Subscribe(x => OperationError = x.Message);
             Checkout.IsExecuting.Subscribe(x => isInCheckout = x);
@@ -533,11 +533,13 @@ namespace GitHub.ViewModels
             public CheckoutCommandState(string caption, string disabledMessage)
             {
                 Caption = caption;
-                DisabledMessage = disabledMessage;
+                IsEnabled = disabledMessage == null;
+                ToolTip = disabledMessage ?? caption;
             }
 
             public string Caption { get; }
-            public string DisabledMessage { get; }
+            public bool IsEnabled { get; }
+            public string ToolTip { get; }
         }
 
         class UpdateCommandState : IPullRequestUpdateState

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
@@ -49,9 +49,14 @@ namespace GitHub.ViewModels
         string Caption { get; }
 
         /// <summary>
-        /// Gets the message to display when a checkout cannot be carried out.
+        /// Gets a value indicating whether checkout is available.
         /// </summary>
-        string DisabledMessage { get; }
+        bool IsEnabled { get; }
+
+        /// <summary>
+        /// Gets the message to display as the checkout button's tooltip.
+        /// </summary>
+        string ToolTip { get; }
     }
 
     /// <summary>

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -174,7 +174,7 @@
                                          VerticalAlignment="Center"
                                          TextTrimming="CharacterEllipsis"
                                          Visibility="{Binding CheckoutState, Converter={ui:NullToVisibilityConverter}}"
-                                         ToolTip="{Binding CheckoutState.DisabledMessage}"
+                                         ToolTip="{Binding CheckoutState.ToolTip}"
                                          ToolTipService.ShowOnDisabled="True"/>
 
                     <!-- Pull/push buttons -->

--- a/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/PullRequestDetailViewModelTests.cs
@@ -216,7 +216,8 @@ namespace UnitTests.GitHub.App.ViewModels
                 await target.Load(CreatePullRequest());
 
                 Assert.True(target.Checkout.CanExecute(null));
-                Assert.Null(target.CheckoutState.DisabledMessage);
+                Assert.True(target.CheckoutState.IsEnabled);
+                Assert.Equal("Checkout pr/123", target.CheckoutState.ToolTip);
             }
 
             [Fact]
@@ -229,7 +230,7 @@ namespace UnitTests.GitHub.App.ViewModels
                 await target.Load(CreatePullRequest());
 
                 Assert.False(target.Checkout.CanExecute(null));
-                Assert.Equal("Cannot checkout as your working directory has uncommitted changes.", target.CheckoutState.DisabledMessage);
+                Assert.Equal("Cannot checkout as your working directory has uncommitted changes.", target.CheckoutState.ToolTip);
             }
 
             [Fact]
@@ -268,7 +269,7 @@ namespace UnitTests.GitHub.App.ViewModels
                 await target.Load(pr);
 
                 Assert.False(target.Checkout.CanExecute(null));
-                Assert.Equal("The source repository is no longer available.", target.CheckoutState.DisabledMessage);
+                Assert.Equal("The source repository is no longer available.", target.CheckoutState.ToolTip);
             }
 
             [Fact]


### PR DESCRIPTION
In the PR details view, use the checkout button caption as the checkout button tooltip when the button is enabled, as the button is often truncated and so a tooltip is useful to see what the full name of the branch to check out is.