### PR TITLE
Ensure UsageTracker time runs on main thread.

### DIFF
--- a/src/GitHub.Exports/Helpers/ThreadingHelper.cs
+++ b/src/GitHub.Exports/Helpers/ThreadingHelper.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Windows;
 using static Microsoft.VisualStudio.Threading.JoinableTaskFactory;
 using static Microsoft.VisualStudio.Threading.AwaitExtensions;
+using System.Windows.Threading;
 
 namespace GitHub.Helpers
 {
@@ -24,6 +25,11 @@ namespace GitHub.Helpers
     public static class ThreadingHelper
     {
         public static bool InUIThread => (!Guard.InUnitTestRunner && Application.Current.Dispatcher.CheckAccess()) || !(Guard.InUnitTestRunner);
+
+        /// <summary>
+        /// Gets the Dispatcher for the main thread.
+        /// </summary>
+        public static Dispatcher MainThreadDispatcher => Application.Current.Dispatcher;
 
         /// <summary>
         /// Switch to the UI thread using ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync

--- a/src/GitHub.VisualStudio/Services/UsageTracker.cs
+++ b/src/GitHub.VisualStudio/Services/UsageTracker.cs
@@ -65,7 +65,7 @@ namespace GitHub.Services
                 TimeSpan.FromMinutes(3),
                 DispatcherPriority.Background,
                 TimerTick,
-                Dispatcher.CurrentDispatcher);
+                ThreadingHelper.MainThreadDispatcher);
 
             RunTimer();
         }


### PR DESCRIPTION
Previously metrics were not always being sent because `UsageTracker` could be created on a background thread. 