### PR TITLE
Move all submodules to the editor-tools org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,16 +3,16 @@
 	url = https://github.com/editor-tools/Rothko.git
 [submodule "submodules/reactiveui"]
 	path = submodules/reactiveui
-	url = https://github.com/shana/ReactiveUI
+	url = https://github.com/editor-tools/ReactiveUI
 [submodule "submodules/octokit.net"]
 	path = submodules/octokit.net
-	url = https://github.com/shana/Octokit.Net
+	url = https://github.com/editor-tools/Octokit.Net
 [submodule "submodules/splat"]
 	path = submodules/splat
-	url = https://github.com/shana/splat.git
+	url = https://github.com/editor-tools/splat.git
 [submodule "submodules/akavache"]
 	path = submodules/akavache
-	url = https://github.com/shana/Akavache
+	url = https://github.com/editor-tools/Akavache
 [submodule "script"]
 	path = script
 	url = git@github.com:github/VisualStudioBuildScripts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GitHub Extension for Visual Studio
 
+**The location of the submodules has changed as of 31-01-2017.** If you have an existing clone, make sure to run `git submodule sync` to update your local clone with the new locations for the submodules.
+
 The GitHub Extension for Visual Studio provides GitHub integration in Visual Studio 2015.
 Most of the extension UI lives in the Team Explorer pane, which is available from the View menu.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ install:
     $full_build = Test-Path env:GHFVS_KEY
 
     git submodule init
+    
+    git submodule sync
 
     if ($full_build) {
       $fileContent = "-----BEGIN RSA PRIVATE KEY-----`n"
@@ -14,7 +16,7 @@ install:
       git submodule deinit script
     }
 
-    git submodule update
+    git submodule update --recursive --force
 
     nuget restore GitHubVS.sln
 build_script:


### PR DESCRIPTION
Moving all submodules to the editor-tools org, no sense having them under my profile now that we have that org. All the submodule forks have their default branch set to `GHfVS`, which is the branch we use for our own changes.

Make sure you run `git submodule sync` to update your local clone submodule urls.

~~Do not merge this until CI is updated to properly sync submodule urls.~~ CI is updated 👍 