### PR TITLE
Add tooltips to View Pull Request buttons

### DIFF
--- a/src/GitHub.VisualStudio.UI/Resources.Designer.cs
+++ b/src/GitHub.VisualStudio.UI/Resources.Designer.cs
@@ -574,6 +574,15 @@ namespace GitHub.VisualStudio.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to View Pull Request on GitHub.
+        /// </summary>
+        public static string OpenPROnGitHubToolTip {
+            get {
+                return ResourceManager.GetString("OpenPROnGitHubToolTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open the two-factor authentication app on your device to view your authentication code..
         /// </summary>
         public static string openTwoFactorAuthAppText {

--- a/src/GitHub.VisualStudio.UI/Resources.resx
+++ b/src/GitHub.VisualStudio.UI/Resources.resx
@@ -375,4 +375,7 @@
   <data name="UpdatedFormat" xml:space="preserve">
     <value>updated {0}</value>
   </data>
+  <data name="OpenPROnGitHubToolTip" xml:space="preserve">
+    <value>View Pull Request on GitHub</value>
+  </data>
 </root>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
@@ -6,7 +6,8 @@
                     xmlns:models="clr-namespace:GitHub.Models;assembly=GitHub.Exports"
                     xmlns:viewmodels="clr-namespace:GitHub.ViewModels;assembly=GitHub.Exports.Reactive"
                     xmlns:vsui="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
-                    xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI">
+                    xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
+                    xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI">
 
   <ResourceDictionary.MergedDictionaries>
     <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml"/>
@@ -110,6 +111,7 @@
                 Command="{Binding OpenPROnGitHub, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"
                 CommandParameter="{Binding Number}"
                 Content="{Binding Number}"
+                ToolTip="{x:Static prop:Resources.OpenPROnGitHubToolTip}"
                 FontFamily="Segoe UI"
                 Style="{StaticResource HashtagActionLink}" />
         <TextBlock x:Name="description"


### PR DESCRIPTION
This is a fix for #824.
The heading link now says: "View Pull Request details".
The # link now says: "View Pull Request details".