### PR TITLE
Hide copy/open link when file not hosted on repo.

### DIFF
--- a/src/GitHub.VisualStudio/Menus/CopyLink.cs
+++ b/src/GitHub.VisualStudio/Menus/CopyLink.cs
@@ -42,9 +42,8 @@ namespace GitHub.VisualStudio.Menus
 
         public bool CanShow()
         {
-            var githubRepoCheckTask = IsGitHubRepo();
+            var githubRepoCheckTask = IsCurrentFileInGitHubRepository();
             return githubRepoCheckTask.Wait(250) ? githubRepoCheckTask.Result : false;
         }
-
     }
 }

--- a/src/GitHub.VisualStudio/Menus/LinkMenuBase.cs
+++ b/src/GitHub.VisualStudio/Menus/LinkMenuBase.cs
@@ -2,6 +2,8 @@
 using GitHub.Services;
 using System;
 using System.Threading.Tasks;
+using System.IO;
+using GitHub.Models;
 
 namespace GitHub.VisualStudio.Menus
 {
@@ -17,6 +19,17 @@ namespace GitHub.VisualStudio.Menus
             usageTracker = new Lazy<IUsageTracker>(() => ServiceProvider.TryGetService<IUsageTracker>());
         }
 
+        protected async Task<bool> IsCurrentFileInGitHubRepository()
+        {
+            if (!await IsGitHubRepo())
+                return false;
+
+            var activeDocument = ServiceProvider.TryGetService<IActiveDocumentSnapshot>();
+
+            return activeDocument != null &&
+                IsFileDescendantOfDirectory(activeDocument.Name, ActiveRepo.LocalPath);
+        }
+
         protected Task<UriString> GenerateLink()
         {
             var repo = ActiveRepo;
@@ -24,6 +37,24 @@ namespace GitHub.VisualStudio.Menus
             if (activeDocument == null)
                 return null;
             return repo.GenerateUrl(activeDocument.Name, activeDocument.StartLine, activeDocument.EndLine);
+        }
+
+        // Taken from http://stackoverflow.com/a/26012991/6448
+        public static bool IsFileDescendantOfDirectory(string file, string directory)
+        {
+            var fileInfo = new FileInfo(file);
+            var directoryInfo = new DirectoryInfo(directory);
+
+            // https://connect.microsoft.com/VisualStudio/feedback/details/777308/inconsistent-behavior-of-fullname-when-provided-path-ends-with-a-backslash
+            string path = directoryInfo.FullName.TrimEnd(Path.DirectorySeparatorChar);
+            DirectoryInfo dir = fileInfo.Directory;
+            while (dir != null)
+            {
+                if (dir.FullName.TrimEnd(Path.DirectorySeparatorChar).Equals(path, StringComparison.OrdinalIgnoreCase))
+                    return true;
+                dir = dir.Parent;
+            }
+            return false;
         }
     }
 }

--- a/src/GitHub.VisualStudio/Menus/OpenLink.cs
+++ b/src/GitHub.VisualStudio/Menus/OpenLink.cs
@@ -31,7 +31,7 @@ namespace GitHub.VisualStudio.Menus
 
         public bool CanShow()
         {
-            var githubRepoCheckTask = IsGitHubRepo();
+            var githubRepoCheckTask = IsCurrentFileInGitHubRepository();
             return githubRepoCheckTask.Wait(250) ? githubRepoCheckTask.Result : false;
         }
     }


### PR DESCRIPTION
Check to see if the current file is located in the active repository and only show "Open on GitHub" and "Copy link to clipboard" context menus if it is.

Fixes #530.