### PR TITLE
Make OcticonImage inherit Foreground.

### DIFF
--- a/src/GitHub.UI/Controls/Octicons/OcticonImage.xaml
+++ b/src/GitHub.UI/Controls/Octicons/OcticonImage.xaml
@@ -5,7 +5,6 @@
 
     <Style x:Key="OcticonImage" TargetType="{x:Type ui:OcticonImage}">
         <Setter Property="Focusable" Value="False" />
-        <Setter Property="Foreground" Value="Black" />
         <Setter Property="Height" Value="16" />
         <Setter Property="Width" Value="16" />
         <Setter Property="HorizontalAlignment" Value="Center" />

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -67,10 +67,6 @@
                 </Style.Resources>
             </Style>
 
-            <Style TargetType="ui:OcticonImage" BasedOn="{StaticResource OcticonImage}">
-                <Setter Property="Foreground" Value="{DynamicResource GitHubVsWindowText}"/>
-            </Style>
-            
             <!-- TODO Fix this: here we change the color of TextBlock depending on the label.
                  It's a hack, it will break with localization -->
             <Style x:Key="StateIndicator" TargetType="TextBlock">
@@ -347,7 +343,6 @@
                                             <ui:OcticonImage Icon="file_code" Margin="0,0,0,2">
                                                 <ui:OcticonImage.Style>
                                                     <Style TargetType="ui:OcticonImage" BasedOn="{StaticResource OcticonImage}">
-                                                        <Setter Property="Foreground" Value="{DynamicResource GitHubVsWindowText}"/>
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding Status}" Value="Removed">
                                                                 <Setter Property="Foreground" Value="{DynamicResource GitHubDeletedFileIconBrush}"/>


### PR DESCRIPTION
Don't set the `OcticonImage.Foreground` property in the `OcticonImage` default theme: this way it inherits the foreground color which is usually what is wanted.

I went through the usages of `OcticonImage` and made sure that they still look OK after this change - hopefully I didn't miss anything.

Note: #866 should be merged first.

Fixes #793.