### PR TITLE
Fix update in PR details view.

### DIFF
--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -113,7 +113,18 @@ namespace GitHub.ViewModels
         public IPullRequestModel Model
         {
             get { return model; }
-            private set { this.RaiseAndSetIfChanged(ref model, value); }
+            private set
+            {
+                // PullRequestModel overrides Equals such that two PRs with the same number are
+                // considered equal. This was causing the Model not to be updated on refresh:
+                // we need to use ReferenceEquals.
+                if (!ReferenceEquals(model, value))
+                {
+                    this.RaisePropertyChanging(nameof(Model));
+                    model = value;
+                    this.RaisePropertyChanged(nameof(Model));
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
`PullRequestModel` overrides Equals such that two PRs with the same number are
considered equal. This was causing the `PullRequestDetailViewModel.Model` property not to be updated on refresh

Changed the setter to not use use `RaiseAndSetIfChanged` but instead compare the two models with `ReferenceEquals` and call the change events manually. Longer term we probably should remove the Equals override on `PullRequestModel` and instead use a comparer in the PR list, as this is where the current equality behavior is needed.

Fixes #901