### PR TITLE
Add VSIX to AppVeyor artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,3 +26,6 @@ test_script:
     scripts\Run-Nunit.ps1 TrackingCollectionTests 180 Release -AppVeyor
 
     scripts\Run-Xunit.ps1 UnitTests 180 Release -AppVeyor
+    
+artifacts:
+- path: build\Release\GitHub.VisualStudio.vsix


### PR DESCRIPTION
Now we have clearly marked 'Experimental' builds of the VSIX, I think it makes sense to make these visible on AppVeyor builds. They're unsigned and similar to builds any developer can create using the public repo.

This will make it easy to test the funcationality of an incomming PR, having reviewed it on the website. Having to build a version locally after minor code changes always seemed like a waste of time!