### PR TITLE
Fix installing 2.2.0.9-Experimental on top of 2.2.0.8

### DIFF
--- a/src/GitHub.VisualStudio/AssemblyResolverPackage.cs
+++ b/src/GitHub.VisualStudio/AssemblyResolverPackage.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
-using System.Linq;
 
 namespace GitHub.VisualStudio
 {
@@ -14,6 +15,8 @@ namespace GitHub.VisualStudio
 
     // This fires before ShellInitialized and SolutionExists.
     [ProvideAutoLoad(VSConstants.UICONTEXT.NoSolution_string)]
+
+    [Guid(GuidList.guidAssemblyResolverPkgString)]
     public class AssemblyResolverPackage : Package
     {
         // list of assemblies that should be resolved by name only

--- a/src/GitHub.VisualStudio/Settings/Guids.cs
+++ b/src/GitHub.VisualStudio/Settings/Guids.cs
@@ -5,6 +5,7 @@ namespace GitHub.VisualStudio
     static class GuidList
     {
         public const string guidGitHubPkgString = "c3d3dc68-c977-411f-b3e8-03b0dccf7dfc";
+        public const string guidAssemblyResolverPkgString = "a6424dba-34cb-360d-a4de-1b0b0411e57d";
         public const string guidGitHubCmdSetString = "c4c91892-8881-4588-a5d9-b41e8f540f5a";
         public const string guidGitHubToolbarCmdSetString = "C5F1193E-F300-41B3-B4C4-5A703DD3C1C6";
         public const string guidContextMenuSetString = "31057D08-8C3C-4C5B-9F91-8682EA08EC27";


### PR DESCRIPTION
Due to quirks of how Experimental versions are installed, the GUIDs of packages mustn't change between versions.

Because `AssemblyResolverPackage` wasn't being referenced from anywhere else, it didn't need an explicit GUID. The default GUID is a hash of the type name and full assembly name. This meant that when the assembly version was bumped, the package GUID also changed.

This wouldn't have been a problem, except for the fact that `Experimental` versions are overlayed on top of `AllUsers` versions (rather than replacing them entirely). The package GUID from the `AllUsers` version leaked through, causing both versions to get loaded!

Fixes #910