### PR TITLE
Use ProvideBindingRedirection instead of ProvideCodeBase

### DIFF
--- a/src/GitHub.VisualStudio/Properties/AssemblyInfo.cs
+++ b/src/GitHub.VisualStudio/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
 
@@ -6,10 +7,15 @@ using Microsoft.VisualStudio.Shell;
 [assembly: AssemblyDescription("GitHub for Visual Studio VSPackage")]
 [assembly: Guid("fad77eaa-3fe1-4c4b-88dc-3753b6263cd7")]
 
-[assembly: ProvideCodeBase(AssemblyName = "GitHub.UI", CodeBase = @"$PackageFolder$\GitHub.UI.dll")]
-[assembly: ProvideCodeBase(AssemblyName = "GitHub.VisualStudio.UI", CodeBase = @"$PackageFolder$\GitHub.VisualStudio.UI.dll")]
-[assembly: ProvideCodeBase(AssemblyName = "GitHub.Exports", CodeBase = @"$PackageFolder$\GitHub.Exports.dll")]
-[assembly: ProvideCodeBase(AssemblyName = "GitHub.Extensions", CodeBase = @"$PackageFolder$\GitHub.Extensions.dll")]
+[assembly: ProvideBindingRedirection(AssemblyName = "GitHub.UI", CodeBase = @"$PackageFolder$\GitHub.UI.dll",
+    OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = AssemblyVersionInformation.Version)]
+[assembly: ProvideBindingRedirection(AssemblyName = "GitHub.VisualStudio.UI", CodeBase = @"$PackageFolder$\GitHub.VisualStudio.UI.dll",
+    OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = AssemblyVersionInformation.Version)]
+[assembly: ProvideBindingRedirection(AssemblyName = "GitHub.Exports", CodeBase = @"$PackageFolder$\GitHub.Exports.dll",
+    OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = AssemblyVersionInformation.Version)]
+[assembly: ProvideBindingRedirection(AssemblyName = "GitHub.Extensions", CodeBase = @"$PackageFolder$\GitHub.Extensions.dll",
+    OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = AssemblyVersionInformation.Version)]
+
 [assembly: ProvideCodeBase(AssemblyName = "Octokit", CodeBase = @"$PackageFolder$\Octokit.dll")]
 [assembly: ProvideCodeBase(AssemblyName = "LibGit2Sharp", CodeBase = @"$PackageFolder$\LibGit2Sharp.dll")]
 [assembly: ProvideCodeBase(AssemblyName = "Splat", CodeBase = @"$PackageFolder$\Splat.dll")]


### PR DESCRIPTION
In PR #914 I used the VS SDK `ProvideCodeBase` attribute to ensure that a particular version of an assembly will load from a specific CodeBase (into the `Load` context). For example:
```c#
[assembly: ProvideCodeBase(AssemblyName = "GitHub.Exports",
    CodeBase = @"$PackageFolder$\GitHub.Exports.dll")]
```

This can help if another extension references the exact version of an assembly that has been installed (with a `ProvideCodeBase` attribute). If however a different version is referenced, another assembly will be loaded with a different codebase, static fields and types. Unless our assembly has been designed with side-by-side execution in mind, the results could be unpredictable.

A resolution for this would be to sweep up multiple versions of an using the `ProvideBindingRedirection` attribute. For example:
```c#
[assembly: ProvideBindingRedirection(AssemblyName = "GitHub.Exports",
    CodeBase = @"$PackageFolder$\GitHub.Exports.dll",
    OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "2.2.0.9")]
```

This would prevent old versions of an assembly being loaded at the same time as the current one (they would be redirected to the current one). This would also allowing 3rd party extensions that could work with multiple newer versions of GHfVS (rather than having to be built against a specific version).

This PR depends on #914.
See #926 and #923.