### PR TITLE
Display indeterminate progress bar when updating PR details view.

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 using System.Threading.Tasks;
@@ -27,6 +28,8 @@ namespace GitHub.SampleData
     [ExcludeFromCodeCoverage]
     public class PullRequestDetailViewModelDesigner : PanePageViewModelBase, IPullRequestDetailViewModel
     {
+        private List<IPullRequestChangeNode> changedFilesTree;
+
         public PullRequestDetailViewModelDesigner()
         {
             var repoPath = @"C:\Repo";
@@ -63,8 +66,8 @@ This requires that errors be propagated from the viewmodel to the view and from 
             modelsDir.Files.Add(oldBranchModel);
             gitHubDir.Directories.Add(modelsDir);
 
-            ChangedFilesTree = new ReactiveList<IPullRequestChangeNode>();
-            ChangedFilesTree.Add(gitHubDir);
+            changedFilesTree = new List<IPullRequestChangeNode>();
+            changedFilesTree.Add(gitHubDir);
         }
 
         public IPullRequestModel Model { get; }
@@ -74,7 +77,7 @@ This requires that errors be propagated from the viewmodel to the view and from 
         public bool IsBusy { get; }
         public bool IsFromFork { get; }
         public string Body { get; }
-        public IReactiveList<IPullRequestChangeNode> ChangedFilesTree { get; }
+        public IReadOnlyList<IPullRequestChangeNode> ChangedFilesTree => changedFilesTree;
         public IPullRequestCheckoutState CheckoutState { get; set; }
         public IPullRequestUpdateState UpdateState { get; set; }
         public string OperationError { get; set; }

--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -70,6 +70,7 @@ This requires that errors be propagated from the viewmodel to the view and from 
         public IPullRequestModel Model { get; }
         public string SourceBranchDisplayName { get; set; }
         public string TargetBranchDisplayName { get; set; }
+        public bool IsLoading { get; }
         public bool IsBusy { get; }
         public bool IsFromFork { get; }
         public string Body { get; }

--- a/src/GitHub.App/SampleData/SampleViewModels.cs
+++ b/src/GitHub.App/SampleData/SampleViewModels.cs
@@ -374,11 +374,6 @@ namespace GitHub.SampleData
 
         public new string Title { get { return "Clone a GitHub Repository"; } }
 
-        public bool IsLoading
-        {
-            get { return false; }
-        }
-
         public IReactiveCommand<IReadOnlyList<IRemoteRepositoryModel>> LoadRepositoriesCommand
         {
             get;

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -35,6 +35,7 @@ namespace GitHub.ViewModels
         string sourceBranchDisplayName;
         string targetBranchDisplayName;
         string body;
+        IReadOnlyList<IPullRequestChangeNode> changedFilesTree;
         IPullRequestCheckoutState checkoutState;
         IPullRequestUpdateState updateState;
         string operationError;
@@ -213,7 +214,11 @@ namespace GitHub.ViewModels
         /// <summary>
         /// Gets the changed files as a tree.
         /// </summary>
-        public IReactiveList<IPullRequestChangeNode> ChangedFilesTree { get; } = new ReactiveList<IPullRequestChangeNode>();
+        public IReadOnlyList<IPullRequestChangeNode> ChangedFilesTree
+        {
+            get { return changedFilesTree; }
+            private set { this.RaiseAndSetIfChanged(ref changedFilesTree, value); }
+        }
 
         /// <summary>
         /// Gets a command that checks out the pull request locally.
@@ -280,15 +285,8 @@ namespace GitHub.ViewModels
             TargetBranchDisplayName = GetBranchDisplayName(IsFromFork, pullRequest.Base.Label);
             Body = !string.IsNullOrWhiteSpace(pullRequest.Body) ? pullRequest.Body : Resources.NoDescriptionProvidedMarkdown;
 
-            ChangedFilesTree.Clear();
-
-            var treeChanges = await pullRequestsService.GetTreeChanges(repository, pullRequest);
-
-            // WPF doesn't support AddRange here so iterate through the changes.
-            foreach (var change in CreateChangedFilesTree(pullRequest, treeChanges).Children)
-            {
-                ChangedFilesTree.Add(change);
-            }
+            var changes = await pullRequestsService.GetTreeChanges(repository, pullRequest);
+            ChangedFilesTree = CreateChangedFilesTree(pullRequest, changes).Children.ToList();
 
             var localBranches = await pullRequestsService.GetLocalBranches(repository, pullRequest).ToList();
             var isCheckedOut = localBranches.Contains(repository.CurrentBranch);

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -25,7 +25,7 @@ namespace GitHub.ViewModels
     [ExportViewModel(ViewType = UIViewType.PRDetail)]
     [PartCreationPolicy(CreationPolicy.NonShared)]
     [NullGuard(ValidationFlags.None)]
-    public class PullRequestDetailViewModel : PanePageViewModelBase, IPullRequestDetailViewModel, IHasBusy
+    public class PullRequestDetailViewModel : PanePageViewModelBase, IPullRequestDetailViewModel
     {
         readonly ILocalRepositoryModel repository;
         readonly IModelService modelService;
@@ -39,6 +39,7 @@ namespace GitHub.ViewModels
         IPullRequestUpdateState updateState;
         string operationError;
         bool isBusy;
+        bool isLoading;
         bool isFromFork;
         bool isInCheckout;
 
@@ -146,12 +147,21 @@ namespace GitHub.ViewModels
         }
 
         /// <summary>
-        /// Gets a value indicating whether the view model is loading.
+        /// Gets a value indicating whether the view model is updating.
         /// </summary>
         public bool IsBusy
         {
             get { return isBusy; }
             private set { this.RaiseAndSetIfChanged(ref isBusy, value); }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the view model is loading.
+        /// </summary>
+        public bool IsLoading
+        {
+            get { return isLoading; }
+            private set { this.RaiseAndSetIfChanged(ref isLoading, value); }
         }
 
         /// <summary>
@@ -243,7 +253,10 @@ namespace GitHub.ViewModels
         {
             var prNumber = data?.Data != null ? (int)data.Data : Model.Number;
 
-            IsBusy = true;
+            if (Model == null)
+                IsLoading = true;
+            else
+                IsBusy = true;
 
             OperationError = null;
             modelService.GetPullRequest(repository, prNumber)
@@ -340,7 +353,7 @@ namespace GitHub.ViewModels
                 UpdateState = null;
             }
 
-            IsBusy = false;
+            IsLoading = IsBusy = false;
 
             if (!isInCheckout)
             {

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
@@ -62,7 +62,7 @@ namespace GitHub.ViewModels
     /// <summary>
     /// Represents a view model for displaying details of a pull request.
     /// </summary>
-    public interface IPullRequestDetailViewModel : IViewModel, IHasBusy
+    public interface IPullRequestDetailViewModel : IViewModel, IHasLoading, IHasBusy
     {
         /// <summary>
         /// Gets the underlying pull request model.

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reactive;
 using System.Threading.Tasks;
 using GitHub.Models;
@@ -92,7 +93,7 @@ namespace GitHub.ViewModels
         /// <summary>
         /// Gets the changed files as a tree.
         /// </summary>
-        IReactiveList<IPullRequestChangeNode> ChangedFilesTree { get; }
+        IReadOnlyList<IPullRequestChangeNode> ChangedFilesTree { get; }
 
         /// <summary>
         /// Gets the state associated with the <see cref="Checkout"/> command.

--- a/src/GitHub.Exports.Reactive/ViewModels/IRepositoryCloneViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IRepositoryCloneViewModel.cs
@@ -20,11 +20,6 @@ namespace GitHub.ViewModels
         bool FilterTextIsEnabled { get; }
 
         /// <summary>
-        /// Whether or not we are currently loading repositories.
-        /// </summary>
-        bool IsLoading { get; }
-
-        /// <summary>
         /// If true, then we failed to load the repositories.
         /// </summary>
         bool LoadingFailed { get; }

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -129,6 +129,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ViewModels\IHasLoading.cs" />
     <Compile Include="ViewModels\IPanePageViewModel.cs" />
     <Compile Include="ViewModels\IViewModel.cs" />
     <None Include="..\..\script\Key.snk" Condition="$(Buildtype) == 'Internal'">

--- a/src/GitHub.Exports/ViewModels/IHasLoading.cs
+++ b/src/GitHub.Exports/ViewModels/IHasLoading.cs
@@ -12,8 +12,8 @@ namespace GitHub.ViewModels
     /// - When <see cref="IHasBusy.IsBusy"/> is true: There is data to display but that data is
     /// being updated or is in the process of being loaded.
     /// </remarks>
-    public interface IHasBusy
+    public interface IHasLoading
     {
-        bool IsBusy { get; }
+        bool IsLoading { get; }
     }
 }

--- a/src/GitHub.UI.Reactive/Assets/Controls/BusyStateView.xaml
+++ b/src/GitHub.UI.Reactive/Assets/Controls/BusyStateView.xaml
@@ -9,17 +9,29 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type local:BusyStateView}">
                     <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        
                         <Grid.Resources>
                             <BooleanToVisibilityConverter x:Key="b2v"/>
                         </Grid.Resources>
-                        
+
+                        <ui:GitHubProgressBar Foreground="{DynamicResource GitHubAccentBrush}"
+                                              IsIndeterminate="True"
+                                              Style="{DynamicResource GitHubProgressBar}"
+                                              Visibility="{TemplateBinding IsBusy, Converter={ui:BooleanToHiddenVisibilityConverter}}"/>
+
                         <c:Spinner Name="spinner" 
+                                   Grid.Row="1"
                                    Width="48"
                                    Height="48"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"
-                                   Visibility="{TemplateBinding IsBusy, Converter={ui:BooleanToHiddenVisibilityConverter}}"/>
-                        <ContentPresenter Visibility="{TemplateBinding IsBusy, Converter={ui:BooleanToInverseHiddenVisibilityConverter}}"/>
+                                   Visibility="{TemplateBinding IsLoading, Converter={ui:BooleanToHiddenVisibilityConverter}}"/>
+                        <ContentPresenter Grid.Row="1" 
+                                          Visibility="{TemplateBinding IsLoading, Converter={ui:BooleanToInverseHiddenVisibilityConverter}}"/>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/GitHub.UI.Reactive/Controls/BusyStateView.cs
+++ b/src/GitHub.UI.Reactive/Controls/BusyStateView.cs
@@ -98,7 +98,7 @@ namespace GitHub.UI
     }
 
     public class BusyStateView<TInterface, TImplementor> : BusyStateView, IViewFor<TInterface>, IView
-        where TInterface : class, IViewModel, IHasLoading
+        where TInterface : class, IViewModel
         where TImplementor : class
     {
         public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(

--- a/src/GitHub.UI.Reactive/Controls/BusyStateView.cs
+++ b/src/GitHub.UI.Reactive/Controls/BusyStateView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Windows;
@@ -14,6 +15,9 @@ namespace GitHub.UI
     {
         public static readonly DependencyProperty IsBusyProperty =
             DependencyProperty.Register(nameof(IsBusy), typeof(bool), typeof(BusyStateView));
+
+        public static readonly DependencyProperty IsLoadingProperty =
+            DependencyProperty.Register(nameof(IsLoading), typeof(bool), typeof(BusyStateView));
 
         readonly Subject<object> close = new Subject<object>();
         readonly Subject<object> cancel = new Subject<object>();
@@ -48,6 +52,12 @@ namespace GitHub.UI
         {
             get { return (bool)GetValue(IsBusyProperty); }
             set { SetValue(IsBusyProperty, value); }
+        }
+
+        public bool IsLoading
+        {
+            get { return (bool)GetValue(IsLoadingProperty); }
+            set { SetValue(IsLoadingProperty, value); }
         }
 
         protected void NotifyDone()
@@ -88,16 +98,37 @@ namespace GitHub.UI
     }
 
     public class BusyStateView<TInterface, TImplementor> : BusyStateView, IViewFor<TInterface>, IView
-        where TInterface : class, IViewModel, IHasBusy
+        where TInterface : class, IViewModel, IHasLoading
         where TImplementor : class
     {
         public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(
             "ViewModel", typeof(TInterface), typeof(TImplementor), new PropertyMetadata(null));
 
+        IDisposable subscriptions;
+
         public BusyStateView()
         {
-            DataContextChanged += (s, e) => ViewModel = (TInterface)e.NewValue;
-            this.OneWayBind(ViewModel, x => x.IsBusy, x => x.IsBusy);
+            DataContextChanged += (s, e) =>
+            {
+                subscriptions?.Dispose();
+                ViewModel = (TInterface)e.NewValue;
+
+                var hasLoading = ViewModel as IHasLoading;
+                var hasBusy = ViewModel as IHasBusy;
+                var subs = new CompositeDisposable();
+
+                if (hasLoading != null)
+                {
+                    subs.Add(this.OneWayBind(hasLoading, x => x.IsLoading, x => x.IsLoading));
+                }
+
+                if (hasBusy != null)
+                {
+                    subs.Add(this.OneWayBind(hasBusy, x => x.IsBusy, x => x.IsBusy));
+                }
+
+                subscriptions = subs;
+            };
         }
 
         [AllowNull]

--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
@@ -162,7 +162,7 @@
                           Foreground="{DynamicResource GitHubAccentBrush}"
                           IsIndeterminate="True"
                           Style="{DynamicResource GitHubProgressBar}"
-                          Visibility="{Binding IsLoading, Mode=OneWay, Converter={ui:BooleanToVisibilityConverter}}" />
+                          Visibility="{Binding IsBusy, Mode=OneWay, Converter={ui:BooleanToVisibilityConverter}}" />
 
     <StackPanel x:Name="loadingFailedPanel"
                 Margin="0,4,0,4"

--- a/src/UnitTests/GitHub.App/ViewModels/RepositoryCloneViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/RepositoryCloneViewModelTests.cs
@@ -71,7 +71,7 @@ public class RepositoryCloneViewModelTests
         }
     }
 
-    public class TheIsLoadingProperty : TestBaseClass
+    public class TheIsBusyProperty : TestBaseClass
     {
         [Fact]
         public async Task StartsTrueBecomesFalseWhenCompleted()
@@ -90,7 +90,7 @@ public class RepositoryCloneViewModelTests
                 Substitute.For<IUsageTracker>());
             var col = (ITrackingCollection<IRemoteRepositoryModel>)vm.Repositories;
 
-            Assert.True(vm.IsLoading);
+            Assert.True(vm.IsBusy);
 
             var done = new ReplaySubject<Unit>();
             done.OnNext(Unit.Default);
@@ -103,13 +103,13 @@ public class RepositoryCloneViewModelTests
             await done;
             done = null;
 
-            Assert.True(vm.IsLoading);
+            Assert.True(vm.IsBusy);
 
             repoSubject.OnCompleted();
 
             await col.OriginalCompleted;
 
-            Assert.False(vm.IsLoading);
+            Assert.False(vm.IsBusy);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ public class RepositoryCloneViewModelTests
                 Substitute.For<IUsageTracker>());
 
             Assert.True(vm.LoadingFailed);
-            Assert.False(vm.IsLoading);
+            Assert.False(vm.IsBusy);
         }
     }
 
@@ -313,7 +313,7 @@ public class RepositoryCloneViewModelTests
             repoSubject.OnError(new InvalidOperationException("Doh!"));
 
             Assert.True(vm.LoadingFailed);
-            Assert.False(vm.IsLoading);
+            Assert.False(vm.IsBusy);
             repoSubject.OnCompleted();
         }
     }


### PR DESCRIPTION
Added a new `IHasLoading` interface in addition to `IHasBusy` and use `IsLoading` when the PR details pane is initially loading and then    `IsBusy` afterwards. When `IsBusy` display an indeterminate progress bar at the top of the view instead of hiding the content and displaying a spinner.

Depends on #933 