### PR TITLE
Normalize Dispose implementations across the codebase

### DIFF
--- a/src/CredentialManagement/Credential.cs
+++ b/src/CredentialManagement/Credential.cs
@@ -63,12 +63,12 @@ namespace GitHub.Authentication.CredentialManagement
         bool disposed;
         void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
+                disposed = true;
                 SecurePassword.Clear();
                 SecurePassword.Dispose();
-                disposed = true;
             }
         }
 

--- a/src/CredentialManagement/CredentialSet.cs
+++ b/src/CredentialManagement/CredentialSet.cs
@@ -28,14 +28,14 @@ namespace GitHub.Authentication.CredentialManagement
         bool disposed;
         private void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
+                disposed = true;
                 if (Count > 0)
                 {
                     ForEach(cred => cred.Dispose());
                 }
-                disposed = true;
             }
         }
 

--- a/src/GitHub.App/Caches/CredentialCache.cs
+++ b/src/GitHub.App/Caches/CredentialCache.cs
@@ -256,14 +256,13 @@ namespace GitHub.Caches
         bool disposed;
         void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
-
+                disposed = true;
                 Scheduler = null;
                 shutdown.OnNext(Unit.Default);
                 shutdown.OnCompleted();
-                disposed = true;
             }
         }
         public void Dispose()

--- a/src/GitHub.App/Caches/SharedCache.cs
+++ b/src/GitHub.App/Caches/SharedCache.cs
@@ -76,17 +76,16 @@ namespace GitHub.Caches
         bool disposed;
         protected virtual void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
-
+                disposed = true;
                 UserAccount.Dispose();
                 UserAccount.Shutdown.Wait();
                 LocalMachine.Dispose();
                 LocalMachine.Shutdown.Wait();
                 Secure.Dispose();
                 Secure.Shutdown.Wait();
-                disposed = true;
             }
         }
 

--- a/src/GitHub.App/Controllers/NavigationController.cs
+++ b/src/GitHub.App/Controllers/NavigationController.cs
@@ -229,16 +229,14 @@ namespace GitHub.Controllers
         bool disposed = false;
         protected void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (!disposed)
-                {
-                    disposed = true;
-                    disposablesForCurrentView.Dispose();
-                    reusableControllers.Values.ForEach(c => uiProvider.StopUI(c));
-                    reusableControllers.Clear();
-                    history.Clear();
-                }
+                disposed = true;
+                disposablesForCurrentView.Dispose();
+                reusableControllers.Values.ForEach(c => uiProvider.StopUI(c));
+                reusableControllers.Clear();
+                history.Clear();
             }
         }
 

--- a/src/GitHub.App/Controllers/UIController.cs
+++ b/src/GitHub.App/Controllers/UIController.cs
@@ -681,9 +681,9 @@ namespace GitHub.Controllers
         bool disposed; // To detect redundant calls
         protected virtual void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
                 disposed = true;
 
                 Debug.WriteLine("Disposing ({0})", GetHashCode());

--- a/src/GitHub.App/Factories/RepositoryHostFactory.cs
+++ b/src/GitHub.App/Factories/RepositoryHostFactory.cs
@@ -56,9 +56,9 @@ namespace GitHub.Factories
         bool disposed;
         protected virtual void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
                 disposed = true;
                 hosts.Dispose();
             }

--- a/src/GitHub.App/Factories/SqlitePersistentBlobCacheFactory.cs
+++ b/src/GitHub.App/Factories/SqlitePersistentBlobCacheFactory.cs
@@ -39,9 +39,9 @@ namespace GitHub.Factories
         bool disposed;
         protected virtual void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
                 disposed = true;
                 Task.Run(() =>
                 {

--- a/src/GitHub.App/Factories/UIFactory.cs
+++ b/src/GitHub.App/Factories/UIFactory.cs
@@ -92,14 +92,14 @@ namespace GitHub.App.Factories
         bool disposed = false;
         void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
+                disposed = true;
                 if (!handlers.IsDisposed)
                     handlers.Dispose();
                 view?.Dispose();
                 viewModel?.Dispose();
-                disposed = true;
             }
         }
         public void Dispose()

--- a/src/GitHub.App/Models/RepositoryHosts.cs
+++ b/src/GitHub.App/Models/RepositoryHosts.cs
@@ -206,10 +206,10 @@ namespace GitHub.Models
         bool disposed;
         protected void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
-
+                disposed = true;
                 try
                 {
                     connectionManager.DoLogin -= RunLoginHandler;
@@ -219,7 +219,6 @@ namespace GitHub.Models
                 {
                     log.Warn("Exception occured while disposing RepositoryHosts", e);
                 }
-                disposed = true;
             }
         }
 

--- a/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestCreationViewModel.cs
@@ -172,11 +172,10 @@ namespace GitHub.ViewModels
         bool disposed; // To detect redundant calls
         void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
                 disposed = true;
-
                 disposables.Dispose();
             }
         }

--- a/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
@@ -239,13 +239,13 @@ namespace GitHub.ViewModels
         bool disposed;
         protected void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
+                disposed = true;
                 pullRequests.Dispose();
                 trackingAuthors.Dispose();
                 trackingAssignees.Dispose();
-                disposed = true;
             }
         }
 

--- a/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
+++ b/src/GitHub.Exports.Reactive/Collections/TrackingCollection.cs
@@ -1191,15 +1191,13 @@ namespace GitHub.Collections
 
         void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (!disposed)
-                {
-                    disposed = true;
-                    pumpDisposables.Dispose();
-                    disposables.Dispose();
-                    cache = null;
-                }
+                disposed = true;
+                pumpDisposables.Dispose();
+                disposables.Dispose();
+                cache = null;
             }
         }
 

--- a/src/GitHub.Exports.Reactive/Services/NotificationDispatcher.cs
+++ b/src/GitHub.Exports.Reactive/Services/NotificationDispatcher.cs
@@ -78,9 +78,9 @@ namespace GitHub.Services
         bool disposed; // To detect redundant calls
         void Dispose(bool disposing)
         {
+            if (disposed) return;
             if (disposing)
             {
-                if (disposed) return;
                 disposed = true;
                 notifications.Dispose();
             }

--- a/src/GitHub.UI.Reactive/Controls/ViewBase.cs
+++ b/src/GitHub.UI.Reactive/Controls/ViewBase.cs
@@ -197,15 +197,12 @@ namespace GitHub.UI
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (disposed) return;
+            if (disposing)
             {
-                if (disposing)
-                {
-                    subscriptions?.Dispose();
-                    subscriptions = null;
-                }
-
                 disposed = true;
+                subscriptions?.Dispose();
+                subscriptions = null;
             }
         }
 

--- a/test/GitHub.UI.UnitTests/Helpers/AppDomainContext.cs
+++ b/test/GitHub.UI.UnitTests/Helpers/AppDomainContext.cs
@@ -28,11 +28,6 @@ namespace GitHub.UI.Helpers.UnitTests
             domain = AppDomain.CreateDomain(friendlyName, null, setup);
         }
 
-        public void Dispose()
-        {
-            AppDomain.Unload(domain);
-        }
-
         public void Invoke(Action remoteAction)
         {
             var targetType = remoteAction.Target.GetType();
@@ -54,6 +49,24 @@ namespace GitHub.UI.Helpers.UnitTests
         {
             return (T)domain.CreateInstanceFromAndUnwrap(typeof(T).Assembly.CodeBase, typeof(T).FullName);
         }
+
+        bool disposed;
+        private void Dispose(bool disposing)
+        {
+            if (disposed) return;
+            if (disposing)
+            {
+                disposed = true;
+                AppDomain.Unload(domain);
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
 
         class Remote : MarshalByRefObject
         {


### PR DESCRIPTION
Went through our various `Dispose()` implementations and normalized them to the same pattern of:

```
bool disposed;
private [virtual/override] void Dispose(bool disposing)
{
  if (disposed) return;
  if (disposing)
  {
    disposed = true;
    // dispose managed stuff
  }
  // dispose native stuff
}

public void Dispose()
{
  Dispose(true);
  GC.SuppressFinalize(this);
}
```