### PR TITLE
Add `GitHubVS.proj` script to build `Debug`, `Release` and `ProductComponent` flavors

### DIFF
--- a/GitHubVS.proj
+++ b/GitHubVS.proj
@@ -1,20 +1,23 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
     <PropertyGroup>
       <SolutionFile>GitHubVS.sln</SolutionFile>
-      <OutputDirectory>$(MSBuildProjectDirectory)</OutputDirectory>
+      <BuildDirectory>$(MSBuildProjectDirectory)\build</BuildDirectory>
+      <ProductComponentDirectory>$(MSBuildProjectDirectory)\build\ProductComponent</ProductComponentDirectory>
+      <VsixFileName>GitHub.VisualStudio.vsix</VsixFileName>
     </PropertyGroup>
     <ItemGroup>  
         <ProjectToBuild Include="$(SolutionFile)">
-            <Properties>Configuration=Debug;IsExperimental=true;IsProductComponent=false;TargetVsixContainer=$(OutputDirectory)\GitHubVS_Debug.vsix</Properties>
+            <Properties>Configuration=Debug;IsExperimental=true;IsProductComponent=false</Properties>
         </ProjectToBuild>  
         <ProjectToBuild Include="$(SolutionFile)">
-            <Properties>Configuration=Release;IsExperimental=false;IsProductComponent=false;TargetVsixContainer=$(OutputDirectory)\GitHubVS_Release.vsix</Properties>
+            <Properties>Configuration=Release;IsExperimental=false;IsProductComponent=false</Properties>
         </ProjectToBuild>  
         <ProjectToBuild Include="$(SolutionFile)">
-            <Properties>Configuration=Release;IsExperimental=false;IsProductComponent=true;TargetVsixContainer=$(OutputDirectory)\GitHubVS_ProductComponent.vsix</Properties>
+            <Properties>Configuration=Release;IsExperimental=false;IsProductComponent=true;TargetVsixContainer=$(ProductComponentDirectory)\$(VsixFileName)</Properties>
         </ProjectToBuild>  
     </ItemGroup>  
-    <Target Name="Build">  
+    <Target Name="Build">
+        <MakeDir Directories="$(ProductComponentDirectory)"/>  
         <MSBuild Targets="GitHub_VisualStudio" Projects="@(ProjectToBuild)"/>  
     </Target>  
 </Project>  

--- a/GitHubVS.proj
+++ b/GitHubVS.proj
@@ -1,10 +1,14 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <Import Project="tools\MSBuild-Tasks\Zip.tasks" />
+    
     <PropertyGroup>
       <SolutionFile>GitHubVS.sln</SolutionFile>
       <BuildDirectory>$(MSBuildProjectDirectory)\build</BuildDirectory>
       <ProductComponentDirectory>$(MSBuildProjectDirectory)\build\ProductComponent</ProductComponentDirectory>
-      <VsixFileName>GitHub.VisualStudio.vsix</VsixFileName>
+      <ExtensionName>GitHub.VisualStudio</ExtensionName>
     </PropertyGroup>
+    
     <ItemGroup>  
         <ProjectToBuild Include="$(SolutionFile)">
             <Properties>Configuration=Debug;IsExperimental=true;IsProductComponent=false</Properties>
@@ -13,11 +17,17 @@
             <Properties>Configuration=Release;IsExperimental=false;IsProductComponent=false</Properties>
         </ProjectToBuild>  
         <ProjectToBuild Include="$(SolutionFile)">
-            <Properties>Configuration=Release;IsExperimental=false;IsProductComponent=true;TargetVsixContainer=$(ProductComponentDirectory)\$(VsixFileName)</Properties>
+            <Properties>Configuration=Release;IsExperimental=false;IsProductComponent=true;TargetVsixContainer=$(ProductComponentDirectory)\$(ExtensionName).vsix</Properties>
         </ProjectToBuild>  
     </ItemGroup>  
+    
     <Target Name="Build">
-        <MakeDir Directories="$(ProductComponentDirectory)"/>  
-        <MSBuild Targets="GitHub_VisualStudio" Projects="@(ProjectToBuild)"/>  
+        <MakeDir Directories="$(ProductComponentDirectory)"/>
+        <MSBuild Targets="GitHub_VisualStudio" Projects="@(ProjectToBuild)"/>
+        <Zip
+          InputFileNames="$(ProductComponentDirectory)\$(ExtensionName).vsix;$(ProductComponentDirectory)\$(ExtensionName).json"
+          OutputFileName="$(ProductComponentDirectory)\$(ExtensionName).zip"
+          OverwriteExistingFile="true" />
     </Target>  
+    
 </Project>  

--- a/GitHubVS.proj
+++ b/GitHubVS.proj
@@ -1,0 +1,20 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+    <PropertyGroup>
+      <SolutionFile>GitHubVS.sln</SolutionFile>
+      <OutputDirectory>$(MSBuildProjectDirectory)</OutputDirectory>
+    </PropertyGroup>
+    <ItemGroup>  
+        <ProjectToBuild Include="$(SolutionFile)">
+            <Properties>Configuration=Debug;IsExperimental=true;IsProductComponent=false;TargetVsixContainer=$(OutputDirectory)\GitHubVS_Debug.vsix</Properties>
+        </ProjectToBuild>  
+        <ProjectToBuild Include="$(SolutionFile)">
+            <Properties>Configuration=Release;IsExperimental=false;IsProductComponent=false;TargetVsixContainer=$(OutputDirectory)\GitHubVS_Release.vsix</Properties>
+        </ProjectToBuild>  
+        <ProjectToBuild Include="$(SolutionFile)">
+            <Properties>Configuration=Release;IsExperimental=false;IsProductComponent=true;TargetVsixContainer=$(OutputDirectory)\GitHubVS_ProductComponent.vsix</Properties>
+        </ProjectToBuild>  
+    </ItemGroup>  
+    <Target Name="Build">  
+        <MSBuild Targets="GitHub_VisualStudio" Projects="@(ProjectToBuild)"/>  
+    </Target>  
+</Project>  

--- a/build_all.cmd
+++ b/build_all.cmd
@@ -1,0 +1,3 @@
+call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
+
+msbuild GitHubVS.proj

--- a/tools/MSBuild-Tasks/Zip.tasks
+++ b/tools/MSBuild-Tasks/Zip.tasks
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Thanks to https://github.com/moozzyk/MSBuild-Tasks (MIT License) -->
+
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="Zip" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <InputFileNames ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <OutputFileName ParameterType="System.String" Required="true" />
+      <OverwriteExistingFile ParameterType="System.Boolean" Required="false" />
+	</ParameterGroup>
+    <Task>
+      <Reference Include="System.IO.Compression" />
+      <Using Namespace="System.IO.Compression" />
+      <Code Type="Fragment" Language="cs">
+      <![CDATA[        
+        var fileMode = OverwriteExistingFile ? FileMode.Create : FileMode.CreateNew;
+        using (var archive = new ZipArchive(new FileStream(OutputFileName, fileMode), ZipArchiveMode.Create))
+        {
+            foreach (var inputFileName in InputFileNames.Select(f => f.ItemSpec))
+            {
+                var archiveEntry = archive.CreateEntry(Path.GetFileName(inputFileName));
+                using (var fs = new FileStream(inputFileName, FileMode.Open))
+                {
+                    using (var zipStream = archiveEntry.Open())
+                    {
+                        fs.CopyTo(zipStream);
+                    }
+                }
+            }
+        }
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <UsingTask TaskName="ZipDir" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <InputBaseDirectory ParameterType="System.String" Required="true" />
+      <OutputFileName ParameterType="System.String" Required="true" />
+      <OverwriteExistingFile ParameterType="System.Boolean" Required="false" />
+      <IncludeBaseDirectory ParameterType="System.Boolean" Required="false" />
+	</ParameterGroup>
+    <Task>
+      <Reference Include="System.IO.Compression" />
+      <Reference Include="System.IO.Compression.FileSystem" />
+      <Using Namespace="System.IO.Compression" />
+      <Code Type="Fragment" Language="cs">
+      <![CDATA[        
+        if (File.Exists(OutputFileName))
+        {
+            if (!OverwriteExistingFile)
+            {
+                return false;
+            }
+            File.Delete(OutputFileName);
+        }
+        ZipFile.CreateFromDirectory
+        (
+            InputBaseDirectory, OutputFileName, 
+            CompressionLevel.Optimal, IncludeBaseDirectory
+        );
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+</Project>


### PR DESCRIPTION
The `GitHubVS.proj` MSBuild file is intended to be an alternative target for our CI build scripts. It will build build `Debug`, `Release` and `ProductComponent` flavors.

The artifacts will be placed in the following locations:

This is an 'Experimental' build that will install for the current user.
`build\Debug\GitHub.VisualStudio.vsix`

This is a 'Release' build that will install for all users.
`build\Release\GitHub.VisualStudio.vsix`

This is a 'Release build with 'IsProductComponent=true'.
`build\ProductComponent\GitHub.VisualStudio.zip`
(which contains 'GitHub.VisualStudio.vsix' and 'GitHub.VisualStudio.vsix')

When the CA scripts are updated to target `GitHubVS.proj` instead of `GitHubVS.sln`, they shouldn't set `Configuration`, `IsExperimental` or `IsProductComponent` properties.