### PR TITLE
Fix compile error introduced in merge.

### DIFF
--- a/src/GitHub.VisualStudio/Resources/icons/question.xaml
+++ b/src/GitHub.VisualStudio/Resources/icons/question.xaml
@@ -1,10 +1,10 @@
 ﻿<Viewbox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
          Width="1024" Height="1024">
     <Border BorderBrush="Transparent" BorderThickness="1">
-        <ui:OcticonImage xmlns:cache="clr-namespace:GitHub.VisualStudio.Helpers"
-                     xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
-                     Foreground="#00458D"
-                     Icon="question">
+        <ui:OcticonImage xmlns:cache="clr-namespace:GitHub.UI.Helpers;assembly=GitHub.UI"
+                         xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
+                         Foreground="#00458D"
+                         Icon="question">
             <ui:OcticonImage.Resources>
                 <ResourceDictionary>
                     <ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
I introduced a compile error with the recent merge of 2.2.0.10 to master, because `SharedDictionaryManager` has moved. This fixes it.