### PR TITLE
AllUsers should by false when Experimental

### DIFF
--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -11,7 +11,7 @@
     <PreviewImage>Resources\preview_200x200.png</PreviewImage>
     <Tags>GitHub;git;open source;source control;branch;pull request;team explorer;commit;publish</Tags>
   </Metadata>
-  <Installation AllUsers="true" Experimental="true">
+  <Installation AllUsers="false" Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
   </Installation>
   <Dependencies>


### PR DESCRIPTION
It's important that `AllUsers=false` when `Experimental=true`. Otherwise it seems the Experimental install can overwrite the AllUsers (corrupting the install database 😕).

Fixes #963