### PR TITLE
Show docs in GitHub repo only

### DIFF
--- a/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
+++ b/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
@@ -53,25 +53,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             var openOnGitHub = ReactiveCommand.Create();
             openOnGitHub.Subscribe(_ => DoOpenOnGitHub());
             OpenOnGitHub = openOnGitHub;
-
-            // We want to display a welcome message but only if Team Explorer isn't
-            // already displaying the "Install 3rd Party Tools" message and the current repo is hosted on GitHub. 
-            // To do this we need to set a timer and check in the tick as at this point the message
-            // won't be initialized.
-            if (!settings.HideTeamExplorerWelcomeMessage)
-            {
-                var timer = new DispatcherTimer();
-                timer.Interval = new TimeSpan(10);
-                timer.Tick += (s, e) =>
-                {
-                    timer.Stop();
-                    if (!IsGitToolsMessageVisible() && IsVisible)
-                    {
-                        ShowWelcomeMessage();
-                    }
-                };
-                timer.Start();
-            }
         }
 
         bool IsGitToolsMessageVisible()
@@ -106,6 +87,17 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             IsVisible = await IsAGitHubRepo();
             if (IsVisible)
             {
+                // We want to display a welcome message but only if Team Explorer isn't
+                // already displaying the "Install 3rd Party Tools" message and the current repo is hosted on GitHub. 
+                // To do this we need to set a timer and check in the tick as at this point the message
+                // won't be initialized.
+                if (!settings.HideTeamExplorerWelcomeMessage)
+                {
+                    if (!IsGitToolsMessageVisible())
+                    {
+                        ShowWelcomeMessage();
+                    }
+                }
                 IsLoggedIn = IsUserAuthenticated();
             }
             base.Refresh();

--- a/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
+++ b/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
@@ -75,11 +75,23 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
                 RepoName = ActiveRepoName;
                 RepoUrl = ActiveRepoUri.ToString();
                 Icon = GetIcon(false, true, false);
+
+                // We want to display a welcome message but only if Team Explorer isn't
+                // already displaying the "Install 3rd Party Tools" message and the current repo is hosted on GitHub. 
+                if (!settings.HideTeamExplorerWelcomeMessage && !IsGitToolsMessageVisible())
+                {
+                    ShowWelcomeMessage();
+                }
+
                 Debug.Assert(SimpleApiClient != null,
                     "If we're in this block, simpleApiClient cannot be null. It was created by UpdateStatus");
                 var repo = await SimpleApiClient.GetRepository();
                 Icon = GetIcon(repo.Private, true, repo.Fork);
                 IsLoggedIn = IsUserAuthenticated();
+            }
+            else
+            {
+                teamExplorerServices.HideNotification(welcomeMessageGuid);
             }
         }
 
@@ -88,17 +100,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             IsVisible = await IsAGitHubRepo();
             if (IsVisible)
             {
-                // We want to display a welcome message but only if Team Explorer isn't
-                // already displaying the "Install 3rd Party Tools" message and the current repo is hosted on GitHub. 
-                if (!settings.HideTeamExplorerWelcomeMessage && !IsGitToolsMessageVisible())
-                {
-                    ShowWelcomeMessage();
-                }
                 IsLoggedIn = IsUserAuthenticated();
-            }
-            else
-            {
-                teamExplorerServices.HideNotification(welcomeMessageGuid);
             }
 
             base.Refresh();

--- a/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
+++ b/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
@@ -55,8 +55,8 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             OpenOnGitHub = openOnGitHub;
 
             // We want to display a welcome message but only if Team Explorer isn't
-            // already displaying the "Install 3rd Party Tools" message. To do this
-            // we need to set a timer and check in the tick as at this point the message
+            // already displaying the "Install 3rd Party Tools" message and the current repo is hosted on GitHub. 
+            // To do this we need to set a timer and check in the tick as at this point the message
             // won't be initialized.
             if (!settings.HideTeamExplorerWelcomeMessage)
             {
@@ -65,7 +65,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
                 timer.Tick += (s, e) =>
                 {
                     timer.Stop();
-                    if (!IsGitToolsMessageVisible())
+                    if (!IsGitToolsMessageVisible() && IsVisible)
                     {
                         ShowWelcomeMessage();
                     }

--- a/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
+++ b/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
@@ -26,6 +26,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
     {
         public const string GitHubHomeSectionId = "72008232-2104-4FA0-A189-61B0C6F91198";
         const string TrainingUrl = "https://services.github.com/on-demand/windows/visual-studio";
+        readonly static Guid welcomeMessageGuid = new Guid(Guids.TeamExplorerWelcomeMessage);
 
         readonly IVisualStudioBrowser visualStudioBrowser;
         readonly ITeamExplorerServices teamExplorerServices;
@@ -89,15 +90,17 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             {
                 // We want to display a welcome message but only if Team Explorer isn't
                 // already displaying the "Install 3rd Party Tools" message and the current repo is hosted on GitHub. 
-                if (!settings.HideTeamExplorerWelcomeMessage)
+                if (!settings.HideTeamExplorerWelcomeMessage && !IsGitToolsMessageVisible())
                 {
-                    if (!IsGitToolsMessageVisible())
-                    {
-                        ShowWelcomeMessage();
-                    }
+                    ShowWelcomeMessage();
                 }
                 IsLoggedIn = IsUserAuthenticated();
             }
+            else
+            {
+                teamExplorerServices.HideNotification(welcomeMessageGuid);
+            }
+
             base.Refresh();
         }
 
@@ -139,7 +142,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
 
         void ShowWelcomeMessage()
         {
-            var welcomeMessageGuid = new Guid(Guids.TeamExplorerWelcomeMessage);
             teamExplorerServices.ShowMessage(
                 Resources.TeamExplorerWelcomeMessage,
                 new RelayCommand(o =>

--- a/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
+++ b/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
@@ -89,8 +89,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             {
                 // We want to display a welcome message but only if Team Explorer isn't
                 // already displaying the "Install 3rd Party Tools" message and the current repo is hosted on GitHub. 
-                // To do this we need to set a timer and check in the tick as at this point the message
-                // won't be initialized.
                 if (!settings.HideTeamExplorerWelcomeMessage)
                 {
                     if (!IsGitToolsMessageVisible())


### PR DESCRIPTION
Hot fix for #971. Hide the welcome message if user is not in a github repo.  (#980 will only show this message once a week if user does not click "don't show this again")