### PR TITLE
Route mouse enter/leave events to add line glyph

### DIFF
--- a/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
+++ b/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Tags\AddInlineCommentGlyph.xaml.cs">
       <DependentUpon>AddInlineCommentGlyph.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Tags\MouseEnterAndLeaveEventRouter.cs" />
     <Compile Include="Tags\ShowInlineCommentGlyph.xaml.cs">
       <DependentUpon>ShowInlineCommentGlyph.xaml</DependentUpon>
     </Compile>

--- a/src/GitHub.InlineReviews/Tags/AddInlineCommentGlyph.xaml.cs
+++ b/src/GitHub.InlineReviews/Tags/AddInlineCommentGlyph.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace GitHub.InlineReviews.Tags
 {
@@ -8,6 +9,19 @@ namespace GitHub.InlineReviews.Tags
         public AddInlineCommentGlyph()
         {
             InitializeComponent();
+            Visibility = System.Windows.Visibility.Hidden;
+        }
+
+        protected override void OnMouseEnter(MouseEventArgs e)
+        {
+            Visibility = System.Windows.Visibility.Visible;
+            base.OnMouseEnter(e);
+        }
+
+        protected override void OnMouseLeave(MouseEventArgs e)
+        {
+            Visibility = System.Windows.Visibility.Hidden;
+            base.OnMouseLeave(e);
         }
     }
 }

--- a/src/GitHub.InlineReviews/Tags/AddInlineCommentGlyph.xaml.cs
+++ b/src/GitHub.InlineReviews/Tags/AddInlineCommentGlyph.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows.Controls;
-using System.Windows.Input;
 
 namespace GitHub.InlineReviews.Tags
 {
@@ -9,19 +8,10 @@ namespace GitHub.InlineReviews.Tags
         public AddInlineCommentGlyph()
         {
             InitializeComponent();
-            Visibility = System.Windows.Visibility.Hidden;
-        }
 
-        protected override void OnMouseEnter(MouseEventArgs e)
-        {
-            Visibility = System.Windows.Visibility.Visible;
-            base.OnMouseEnter(e);
-        }
-
-        protected override void OnMouseLeave(MouseEventArgs e)
-        {
             Visibility = System.Windows.Visibility.Hidden;
-            base.OnMouseLeave(e);
+            MouseEnter += (s, e) => Visibility = System.Windows.Visibility.Visible;
+            MouseLeave += (s, e) => Visibility = System.Windows.Visibility.Hidden;
         }
     }
 }

--- a/src/GitHub.InlineReviews/Tags/InlineCommentGlyphMouseProcessor.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentGlyphMouseProcessor.cs
@@ -21,7 +21,7 @@ namespace GitHub.InlineReviews.Tags
         readonly ITextView textView;
         readonly IWpfTextViewMargin margin;
         readonly ITagAggregator<InlineCommentTag> tagAggregator;
-        readonly MouseEnterAndLeaveEventRouter mouseEventRouter;
+        readonly MouseEnterAndLeaveEventRouter<AddInlineCommentGlyph> mouseEventRouter;
 
         public InlineCommentGlyphMouseProcessor(
             IApiClientFactory apiClientFactory,
@@ -36,12 +36,17 @@ namespace GitHub.InlineReviews.Tags
             this.margin = margin;
             this.tagAggregator = aggregator;
 
-            mouseEventRouter = new MouseEnterAndLeaveEventRouter();
+            mouseEventRouter = new MouseEnterAndLeaveEventRouter<AddInlineCommentGlyph>();
         }
 
         public override void PostprocessMouseMove(MouseEventArgs e)
         {
-            mouseEventRouter.MouseMove<AddInlineCommentGlyph>(margin.VisualElement, e);
+            mouseEventRouter.MouseMove(margin.VisualElement, e);
+        }
+
+        public override void PostprocessMouseLeave(MouseEventArgs e)
+        {
+            mouseEventRouter.MouseLeave(margin.VisualElement, e);
         }
 
         public override void PreprocessMouseLeftButtonUp(MouseButtonEventArgs e)

--- a/src/GitHub.InlineReviews/Tags/InlineCommentGlyphMouseProcessor.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentGlyphMouseProcessor.cs
@@ -21,6 +21,7 @@ namespace GitHub.InlineReviews.Tags
         readonly ITextView textView;
         readonly IWpfTextViewMargin margin;
         readonly ITagAggregator<InlineCommentTag> tagAggregator;
+        readonly MouseEnterAndLeaveEventRouter mouseEventRouter;
 
         public InlineCommentGlyphMouseProcessor(
             IApiClientFactory apiClientFactory,
@@ -34,6 +35,13 @@ namespace GitHub.InlineReviews.Tags
             this.textView = textView;
             this.margin = margin;
             this.tagAggregator = aggregator;
+
+            mouseEventRouter = new MouseEnterAndLeaveEventRouter();
+        }
+
+        public override void PostprocessMouseMove(MouseEventArgs e)
+        {
+            mouseEventRouter.MouseMove<AddInlineCommentGlyph>(margin.VisualElement, e);
         }
 
         public override void PreprocessMouseLeftButtonUp(MouseButtonEventArgs e)

--- a/src/GitHub.InlineReviews/Tags/MouseEnterAndLeaveEventRouter.cs
+++ b/src/GitHub.InlineReviews/Tags/MouseEnterAndLeaveEventRouter.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace GitHub.InlineReviews.Tags
+{
+    class MouseEnterAndLeaveEventRouter
+    {
+        public void MouseMove<T>(object target, MouseEventArgs e) where T : FrameworkElement
+        {
+            var visitor = new Visitor<T>(this, e);
+            visitor.Visit(target);
+        }
+
+        FrameworkElement MouseOverElement { get; set; }
+
+        class Visitor<T> where T : FrameworkElement
+        {
+            MouseEnterAndLeaveEventRouter router;
+            MouseEventArgs mouseEventArgs;
+
+            internal Visitor(MouseEnterAndLeaveEventRouter router, MouseEventArgs mouseEventArgs)
+            {
+                this.router = router;
+                this.mouseEventArgs = mouseEventArgs;
+            }
+
+            internal void Visit(object obj)
+            {
+                if (obj is Panel)
+                {
+                    Visit((Panel)obj);
+                    return;
+                }
+
+                if (obj is T)
+                {
+                    Visit((T)obj);
+                    return;
+                }
+            }
+
+            internal void Visit(Panel panel)
+            {
+                foreach (var child in panel.Children)
+                {
+                    Visit(child);
+                }
+            }
+
+            internal void Visit(T element)
+            {
+                var point = mouseEventArgs.GetPosition(element);
+                if (point.Y >= 0 && point.Y < element.ActualHeight)
+                {
+                    if (element != router.MouseOverElement)
+                    {
+                        if (router.MouseOverElement != null)
+                        {
+                            router.MouseOverElement.RaiseEvent(new MouseEventArgs(mouseEventArgs.MouseDevice, mouseEventArgs.Timestamp)
+                            {
+                                RoutedEvent = Mouse.MouseLeaveEvent,
+                            });
+                        }
+
+                        router.MouseOverElement = element;
+                        router.MouseOverElement.RaiseEvent(new MouseEventArgs(mouseEventArgs.MouseDevice, mouseEventArgs.Timestamp)
+                        {
+                            RoutedEvent = Mouse.MouseEnterEvent,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Send MouseEnter/MouseLeave  events to the `AddInlineCommentGlyph`. As a test that it's working, `AddInlineCommentGlyph` simply sets its `Visible` property to `Visible` or `Hidden`. We'll likely want to do something a little more fancy. 😉 