### PR TITLE
Removed progress bar from RepositoryCloneControl.

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml
@@ -155,15 +155,6 @@
                       IsEnabled="{Binding FilterTextIsEnabled, Mode=OneWay}"
                       AutomationProperties.AutomationId="{x:Static automation:AutomationIDs.SearchRepositoryTextBox}" />
 
-    <ui:GitHubProgressBar x:Name="loadingProgressBar"
-                          Margin="0"
-                          HorizontalContentAlignment="Stretch"
-                          DockPanel.Dock="Top"
-                          Foreground="{DynamicResource GitHubAccentBrush}"
-                          IsIndeterminate="True"
-                          Style="{DynamicResource GitHubProgressBar}"
-                          Visibility="{Binding IsBusy, Mode=OneWay, Converter={ui:BooleanToVisibilityConverter}}" />
-
     <StackPanel x:Name="loadingFailedPanel"
                 Margin="0,4,0,4"
                 HorizontalAlignment="Center"


### PR DESCRIPTION
`ViewBase` now displays its own progress bar if the view model has `IHasLoading` - this was causing the Clone dialog to display two progress bars. Remove the one in the `RepositoryCloneControl` xaml.

Fixes #999