### PR TITLE
Hide additional progress bar in 2FA dialog.

### DIFF
--- a/src/GitHub.UI.Reactive/Controls/ViewBase.cs
+++ b/src/GitHub.UI.Reactive/Controls/ViewBase.cs
@@ -42,6 +42,13 @@ namespace GitHub.UI
                 typeof(ViewBase),
                 new FrameworkPropertyMetadata());
 
+        static readonly DependencyProperty ShowBusyStateProperty =
+            DependencyProperty.Register(
+                nameof(ShowBusyState),
+                typeof(bool),
+                typeof(ViewBase),
+                new FrameworkPropertyMetadata(true));
+
         public static readonly DependencyProperty HasBusyStateProperty = HasBusyStatePropertyKey.DependencyProperty;
         public static readonly DependencyProperty IsBusyProperty = IsBusyPropertyKey.DependencyProperty;
         public static readonly DependencyProperty IsLoadingProperty = IsLoadingPropertyKey.DependencyProperty;
@@ -81,6 +88,15 @@ namespace GitHub.UI
         {
             get { return (bool)GetValue(IsLoadingProperty); }
             protected set { SetValue(IsLoadingPropertyKey, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to display the view model's busy state.
+        /// </summary>
+        public bool ShowBusyState
+        {
+            get { return (bool)GetValue(ShowBusyStateProperty); }
+            set { SetValue(ShowBusyStateProperty, value); }
         }
 
         internal ViewBase()

--- a/src/GitHub.UI.Reactive/Themes/Generic.xaml
+++ b/src/GitHub.UI.Reactive/Themes/Generic.xaml
@@ -32,16 +32,28 @@
 
                 <ui:GitHubProgressBar Foreground="{DynamicResource GitHubAccentBrush}"
                                       IsIndeterminate="True"
-                                      Style="{DynamicResource GitHubProgressBar}"
-                                      Visibility="{TemplateBinding IsBusy, Converter={ui:BooleanToHiddenVisibilityConverter}}"/>
+                                      Style="{DynamicResource GitHubProgressBar}">
+                    <ui:GitHubProgressBar.Visibility>
+                        <MultiBinding Converter="{ui:MultiBooleanToVisibilityConverter}">
+                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsBusy"/>
+                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ShowBusyState"/>
+                        </MultiBinding>
+                    </ui:GitHubProgressBar.Visibility>
+                </ui:GitHubProgressBar>
 
                 <c:Spinner Name="spinner" 
                            Grid.Row="1"
                            Width="48"
                            Height="48"
                            HorizontalAlignment="Center"
-                           VerticalAlignment="Center"
-                           Visibility="{TemplateBinding IsLoading, Converter={ui:BooleanToVisibilityConverter}}"/>
+                           VerticalAlignment="Center">
+                    <c:Spinner.Visibility>
+                        <MultiBinding Converter="{ui:MultiBooleanToVisibilityConverter}">
+                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="IsLoading"/>
+                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ShowBusyState"/>
+                        </MultiBinding>
+                    </c:Spinner.Visibility>
+                </c:Spinner>
                 
                 <ContentPresenter Grid.Row="1"
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/GitHub.UI/Converters/MultiBooleanToVisibilityConverter.cs
+++ b/src/GitHub.UI/Converters/MultiBooleanToVisibilityConverter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows;
+using NullGuard;
+
+namespace GitHub.UI
+{
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    public sealed class MultiBooleanToVisibilityConverter : MultiValueConverterMarkupExtension<MultiBooleanToVisibilityConverter>
+    {
+        readonly System.Windows.Controls.BooleanToVisibilityConverter converter = new System.Windows.Controls.BooleanToVisibilityConverter();
+
+        public override object Convert(
+            [AllowNull]object[] value,
+            [AllowNull]Type targetType,
+            [AllowNull]object parameter,
+            [AllowNull]CultureInfo culture)
+        {
+            return value.OfType<bool>().All(x => x) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public override object[] ConvertBack(
+            [AllowNull]object value,
+            [AllowNull]Type[] targetType,
+            [AllowNull]object parameter,
+            [AllowNull]CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/src/GitHub.UI/GitHub.UI.csproj
+++ b/src/GitHub.UI/GitHub.UI.csproj
@@ -91,6 +91,7 @@
       <DependentUpon>Spinner.xaml</DependentUpon>
     </Compile>
     <Compile Include="Converters\AllCapsConverter.cs" />
+    <Compile Include="Converters\MultiBooleanToVisibilityConverter.cs" />
     <Compile Include="Converters\NullToVisibilityConverter.cs" />
     <Compile Include="Converters\BranchNameConverter.cs" />
     <Compile Include="Converters\CountToVisibilityConverter.cs" />

--- a/src/GitHub.VisualStudio/UI/Views/Controls/TwoFactorControl.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/TwoFactorControl.xaml
@@ -15,6 +15,7 @@
     d:DesignWidth="414"
     d:DesignHeight="440"
     Style="{DynamicResource DialogUserControl}"
+    ShowBusyState="False"
     AutomationProperties.AutomationId="{x:Static automation:AutomationIDs.TwoFactorAuthenticationCustom}" >
 
     <Control.Resources>


### PR DESCRIPTION
To do this, introduced `ViewBase.ShowBusyState` property to allow hiding of progress bar when not required.

Before:

![image](https://user-images.githubusercontent.com/1775141/27324076-3bfec3c4-55a4-11e7-8e9e-24c7922d15c4.png)

After:

![image](https://user-images.githubusercontent.com/1775141/27324216-c3bfa224-55a4-11e7-98bc-99b7d7e7febb.png)

Fixes #1014