### PR TITLE
Prevent PR details auto-scolling to top.

### DIFF
--- a/src/GitHub.UI/GitHub.UI.csproj
+++ b/src/GitHub.UI/GitHub.UI.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Helpers\LoadingResourceDictionary.cs" />
     <Compile Include="Helpers\ScrollViewerUtilities.cs" />
     <Compile Include="Helpers\SharedDictionaryManager.cs" />
+    <Compile Include="Helpers\TreeViewExtensions.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/GitHub.UI/Helpers/TreeViewExtensions.cs
+++ b/src/GitHub.UI/Helpers/TreeViewExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Windows.Controls;
+
+namespace GitHub.UI.Helpers
+{
+    /// <summary>
+    /// Extensions for TreeView control.
+    /// </summary>
+    public static class TreeViewExtensions
+    {
+        /// <summary>
+        /// Gets the TreeViewItem for an item in the TreeView.
+        /// </summary>
+        /// <param name="tree">The tree view.</param>
+        /// <param name="item">The item to search for.</param>
+        /// <returns>The TreeViewItem or null if the item was null or not found.</returns>
+        public static TreeViewItem GetTreeViewItem(this TreeView tree, object item)
+        {
+            if (item == null)
+            {
+                return null;
+            }
+
+            return GetTreeViewItem(tree.ItemContainerGenerator, item);
+        }
+
+        static TreeViewItem GetTreeViewItem(ItemContainerGenerator itemContainerGenerator, object item)
+        {
+            var container = (TreeViewItem)itemContainerGenerator.ContainerFromItem(item);
+
+            if (container == null)
+            {
+                foreach (var childItem in itemContainerGenerator.Items)
+                {
+                    var node = (TreeViewItem)itemContainerGenerator.ContainerFromItem(childItem);
+                    container = GetTreeViewItem(node.ItemContainerGenerator, item);
+
+                    if (container != null)
+                    {
+                        return container;
+                    }
+                }
+            }
+
+            return container;
+        }
+    }
+}

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml
@@ -236,7 +236,7 @@
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,5,-8,0"/>
 
         <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,0,-8,0">
-            <Grid Margin="0 5 0 0">
+            <Grid Name="bodyGrid" Margin="0 5 0 0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
@@ -297,7 +297,8 @@
                             </Grid.Resources>
 
                             <!-- Tree View -->
-                            <TreeView ItemsSource="{Binding ChangedFilesTree}"
+                            <TreeView Name="changesTree"
+                                      ItemsSource="{Binding ChangedFilesTree}"
                                       ContextMenuOpening="TreeView_ContextMenuOpening"
                                       ContextMenu="{StaticResource FileContextMenu}"
                                       Background="Transparent"


### PR DESCRIPTION
Prevent PR details view scrolling to the top when VS gives it focus. Instead focus selected tree view item, if any.

Fixes #1042.