### PR TITLE
Allow comment navigation with 1 comment.

### DIFF
--- a/src/GitHub.InlineReviews/Commands/InlineCommentNavigationCommand.cs
+++ b/src/GitHub.InlineReviews/Commands/InlineCommentNavigationCommand.cs
@@ -49,7 +49,7 @@ namespace GitHub.InlineReviews.Commands
             get
             {
                 var tags = GetTags(GetCurrentTextViews());
-                return tags.Count > 1;
+                return tags.Count > 0;
             }
         }
 


### PR DESCRIPTION
This was an oversight where I was thinking "if you only have 1 comment you don't need to go backwards and forwards". But I was thinking of an already open inline peek window. If you're not currently viewing the single comment, of course previous/next comment make sense.

Fixes #1053.