### PR TITLE
Surface errors when loading PR details.

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -86,6 +86,7 @@ This requires that errors be propagated from the viewmodel to the view and from 
         public IPullRequestCheckoutState CheckoutState { get; set; }
         public IPullRequestUpdateState UpdateState { get; set; }
         public string OperationError { get; set; }
+        public string ErrorMessage { get; set; }
 
         public ReactiveCommand<Unit> Checkout { get; }
         public ReactiveCommand<Unit> Pull { get; }

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -39,6 +39,7 @@ namespace GitHub.ViewModels
         IReadOnlyList<IPullRequestChangeNode> changedFilesTree;
         IPullRequestCheckoutState checkoutState;
         IPullRequestUpdateState updateState;
+        string errorMessage;
         string operationError;
         bool isBusy;
         bool isLoading;
@@ -237,6 +238,15 @@ namespace GitHub.ViewModels
         }
 
         /// <summary>
+        /// Gets an error message to display if loading fails.
+        /// </summary>
+        public string ErrorMessage
+        {
+            get { return errorMessage; }
+            private set { this.RaiseAndSetIfChanged(ref errorMessage, value); }
+        }
+
+        /// <summary>
         /// Gets the error message to be displayed in the action area as a result of an error in a
         /// git operation.
         /// </summary>
@@ -298,10 +308,16 @@ namespace GitHub.ViewModels
             else
                 IsBusy = true;
 
-            OperationError = null;
+            ErrorMessage = OperationError = null;
             modelService.GetPullRequest(Repository, prNumber)
                 .TakeLast(1)
                 .ObserveOn(RxApp.MainThreadScheduler)
+                .Catch<IPullRequestModel, Exception>(ex =>
+                {
+                    ErrorMessage = ex.Message.Trim();
+                    IsLoading = IsBusy = false;
+                    return Observable.Empty<IPullRequestModel>();
+                })
                 .Subscribe(x => Load(x).Forget());
         }
 
@@ -312,94 +328,103 @@ namespace GitHub.ViewModels
         /// <param name="files">The pull request's changed files.</param>
         public async Task Load(IPullRequestModel pullRequest)
         {
-            var firstLoad = (Model == null);
-            Model = pullRequest;
-            Session = await sessionManager.GetSession(pullRequest);
-            Title = Resources.PullRequestNavigationItemText + " #" + pullRequest.Number;
-
-            IsFromFork = pullRequestsService.IsPullRequestFromFork(Repository, Model);
-            SourceBranchDisplayName = GetBranchDisplayName(IsFromFork, pullRequest.Head?.Label);
-            TargetBranchDisplayName = GetBranchDisplayName(IsFromFork, pullRequest.Base.Label);
-            CommentCount = pullRequest.Comments.Count +  pullRequest.ReviewComments.Count;
-            Body = !string.IsNullOrWhiteSpace(pullRequest.Body) ? pullRequest.Body : Resources.NoDescriptionProvidedMarkdown;
-
-            var changes = await pullRequestsService.GetTreeChanges(Repository, pullRequest);
-            ChangedFilesTree = (await CreateChangedFilesTree(pullRequest, changes)).Children.ToList();
-
-            var localBranches = await pullRequestsService.GetLocalBranches(Repository, pullRequest).ToList();
-
-            IsCheckedOut = localBranches.Contains(Repository.CurrentBranch);
-
-            if (IsCheckedOut)
+            try
             {
-                var divergence = await pullRequestsService.CalculateHistoryDivergence(Repository, Model.Number);
-                var pullEnabled = divergence.BehindBy > 0;
-                var pushEnabled = divergence.AheadBy > 0 && !pullEnabled;
-                string pullToolTip;
-                string pushToolTip;
+                var firstLoad = (Model == null);
+                Model = pullRequest;
+                Session = await sessionManager.GetSession(pullRequest);
+                Title = Resources.PullRequestNavigationItemText + " #" + pullRequest.Number;
 
-                if (pullEnabled)
+                IsFromFork = pullRequestsService.IsPullRequestFromFork(Repository, Model);
+                SourceBranchDisplayName = GetBranchDisplayName(IsFromFork, pullRequest.Head?.Label);
+                TargetBranchDisplayName = GetBranchDisplayName(IsFromFork, pullRequest.Base.Label);
+                CommentCount = pullRequest.Comments.Count + pullRequest.ReviewComments.Count;
+                Body = !string.IsNullOrWhiteSpace(pullRequest.Body) ? pullRequest.Body : Resources.NoDescriptionProvidedMarkdown;
+
+                var changes = await pullRequestsService.GetTreeChanges(Repository, pullRequest);
+                ChangedFilesTree = (await CreateChangedFilesTree(pullRequest, changes)).Children.ToList();
+
+                var localBranches = await pullRequestsService.GetLocalBranches(Repository, pullRequest).ToList();
+
+                IsCheckedOut = localBranches.Contains(Repository.CurrentBranch);
+
+                if (IsCheckedOut)
                 {
-                    pullToolTip = string.Format(
-                        Resources.PullRequestDetailsPullToolTip,
-                        IsFromFork ? Resources.Fork : Resources.Remote,
-                        SourceBranchDisplayName);
+                    var divergence = await pullRequestsService.CalculateHistoryDivergence(Repository, Model.Number);
+                    var pullEnabled = divergence.BehindBy > 0;
+                    var pushEnabled = divergence.AheadBy > 0 && !pullEnabled;
+                    string pullToolTip;
+                    string pushToolTip;
+
+                    if (pullEnabled)
+                    {
+                        pullToolTip = string.Format(
+                            Resources.PullRequestDetailsPullToolTip,
+                            IsFromFork ? Resources.Fork : Resources.Remote,
+                            SourceBranchDisplayName);
+                    }
+                    else
+                    {
+                        pullToolTip = Resources.NoCommitsToPull;
+                    }
+
+                    if (pushEnabled)
+                    {
+                        pushToolTip = string.Format(
+                            Resources.PullRequestDetailsPushToolTip,
+                            IsFromFork ? Resources.Fork : Resources.Remote,
+                            SourceBranchDisplayName);
+                    }
+                    else if (divergence.AheadBy == 0)
+                    {
+                        pushToolTip = Resources.NoCommitsToPush;
+                    }
+                    else
+                    {
+                        pushToolTip = Resources.MustPullBeforePush;
+                    }
+
+                    UpdateState = new UpdateCommandState(divergence, pullEnabled, pushEnabled, pullToolTip, pushToolTip);
+                    CheckoutState = null;
                 }
                 else
                 {
-                    pullToolTip = Resources.NoCommitsToPull;
+                    var caption = localBranches.Count > 0 ?
+                        string.Format(Resources.PullRequestDetailsCheckout, localBranches.First().DisplayName) :
+                        string.Format(Resources.PullRequestDetailsCheckoutTo, await pullRequestsService.GetDefaultLocalBranchName(Repository, Model.Number, Model.Title));
+                    var clean = await pullRequestsService.IsWorkingDirectoryClean(Repository);
+                    string disabled = null;
+
+                    if (pullRequest.Head == null || !pullRequest.Head.RepositoryCloneUrl.IsValidUri)
+                    {
+                        disabled = Resources.SourceRepositoryNoLongerAvailable;
+                    }
+                    else if (!clean)
+                    {
+                        disabled = Resources.WorkingDirectoryHasUncommittedCHanges;
+                    }
+
+                    CheckoutState = new CheckoutCommandState(caption, disabled);
+                    UpdateState = null;
                 }
 
-                if (pushEnabled)
+                if (firstLoad)
                 {
-                    pushToolTip = string.Format(
-                        Resources.PullRequestDetailsPushToolTip,
-                        IsFromFork ? Resources.Fork : Resources.Remote,
-                        SourceBranchDisplayName);
-                }
-                else if (divergence.AheadBy == 0)
-                {
-                    pushToolTip = Resources.NoCommitsToPush;
-                }
-                else
-                {
-                    pushToolTip = Resources.MustPullBeforePush;
+                    usageTracker.IncrementPullRequestOpened().Forget();
                 }
 
-                UpdateState = new UpdateCommandState(divergence, pullEnabled, pushEnabled, pullToolTip, pushToolTip);
-                CheckoutState = null;
+                if (!isInCheckout)
+                {
+                    pullRequestsService.RemoveUnusedRemotes(Repository).Subscribe(_ => { });
+                }
             }
-            else
+            catch (Exception ex)
             {
-                var caption = localBranches.Count > 0 ?
-                    string.Format(Resources.PullRequestDetailsCheckout, localBranches.First().DisplayName) :
-                    string.Format(Resources.PullRequestDetailsCheckoutTo, await pullRequestsService.GetDefaultLocalBranchName(Repository, Model.Number, Model.Title));
-                var clean = await pullRequestsService.IsWorkingDirectoryClean(Repository);
-                string disabled = null;
-
-                if (pullRequest.Head == null || !pullRequest.Head.RepositoryCloneUrl.IsValidUri)
-                {
-                    disabled = Resources.SourceRepositoryNoLongerAvailable;
-                }
-                else if (!clean)
-                {
-                    disabled = Resources.WorkingDirectoryHasUncommittedCHanges;
-                }
-
-                CheckoutState = new CheckoutCommandState(caption, disabled);
-                UpdateState = null;
+                ErrorMessage = ex.Message.Trim();
             }
-
-            IsLoading = IsBusy = false;
-
-            if (firstLoad)
+            finally
             {
-                usageTracker.IncrementPullRequestOpened().Forget();
-            }
-
-            if (!isInCheckout)
-            {
-                pullRequestsService.RemoveUnusedRemotes(Repository).Subscribe(_ => { });
+                IsLoading = IsBusy = false;
             }
         }
 

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
@@ -64,7 +64,7 @@ namespace GitHub.ViewModels
     /// <summary>
     /// Represents a view model for displaying details of a pull request.
     /// </summary>
-    public interface IPullRequestDetailViewModel : IViewModel, IHasLoading, IHasBusy
+    public interface IPullRequestDetailViewModel : IViewModel, IHasLoading, IHasBusy, IHasErrorState
     {
         /// <summary>
         /// Gets the underlying pull request model.

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Models\ICommentModel.cs" />
     <Compile Include="Models\IInlineCommentModel.cs" />
     <Compile Include="Models\IPullRequestReviewCommentModel.cs" />
+    <Compile Include="ViewModels\IHasErrorState.cs" />
     <Compile Include="ViewModels\IHasLoading.cs" />
     <Compile Include="ViewModels\IPanePageViewModel.cs" />
     <Compile Include="ViewModels\IViewModel.cs" />

--- a/src/GitHub.Exports/ViewModels/IHasErrorState.cs
+++ b/src/GitHub.Exports/ViewModels/IHasErrorState.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace GitHub.ViewModels
+{
+    /// <summary>
+    /// Interface for view models that have an error state.
+    /// </summary>
+    public interface IHasErrorState
+    {
+        /// <summary>
+        /// Gets the view model's error message or null if the view model is not in an error state.
+        /// </summary>
+        string ErrorMessage { get; }
+    }
+}

--- a/src/GitHub.UI.Reactive/Controls/ViewBase.cs
+++ b/src/GitHub.UI.Reactive/Controls/ViewBase.cs
@@ -21,9 +21,16 @@ namespace GitHub.UI
     /// </remarks>
     public class ViewBase : ContentControl
     {
-        static readonly DependencyPropertyKey HasBusyStatePropertyKey =
+        static readonly DependencyPropertyKey ErrorMessagePropertyKey =
             DependencyProperty.RegisterReadOnly(
-                nameof(HasBusyState),
+                nameof(ErrorMessage),
+                typeof(string),
+                typeof(ViewBase),
+                new FrameworkPropertyMetadata());
+
+        static readonly DependencyPropertyKey HasStatePropertyKey =
+            DependencyProperty.RegisterReadOnly(
+                nameof(HasState),
                 typeof(bool),
                 typeof(ViewBase),
                 new FrameworkPropertyMetadata());
@@ -42,6 +49,13 @@ namespace GitHub.UI
                 typeof(ViewBase),
                 new FrameworkPropertyMetadata());
 
+        static readonly DependencyPropertyKey ShowContentPropertyKey =
+            DependencyProperty.RegisterReadOnly(
+                nameof(ShowContent),
+                typeof(bool),
+                typeof(ViewBase),
+                new FrameworkPropertyMetadata());
+
         static readonly DependencyProperty ShowBusyStateProperty =
             DependencyProperty.Register(
                 nameof(ShowBusyState),
@@ -49,9 +63,11 @@ namespace GitHub.UI
                 typeof(ViewBase),
                 new FrameworkPropertyMetadata(true));
 
-        public static readonly DependencyProperty HasBusyStateProperty = HasBusyStatePropertyKey.DependencyProperty;
+        public static readonly DependencyProperty ErrorMessageProperty = ErrorMessagePropertyKey.DependencyProperty;
+        public static readonly DependencyProperty HasStateProperty = HasStatePropertyKey.DependencyProperty;
         public static readonly DependencyProperty IsBusyProperty = IsBusyPropertyKey.DependencyProperty;
         public static readonly DependencyProperty IsLoadingProperty = IsLoadingPropertyKey.DependencyProperty;
+        public static readonly DependencyProperty ShowContentProperty = ShowContentPropertyKey.DependencyProperty;
 
         static ViewBase()
         {
@@ -63,13 +79,23 @@ namespace GitHub.UI
         }
 
         /// <summary>
-        /// Gets a value indicating whether the associated view model implements <see cref="IHasLoading"/>
-        /// or <see cref="IHasBusy"/>.
+        /// Gets a value reflecting the associated view model's <see cref="IHasErrorState.ErrorMessage"/> property.
         /// </summary>
-        public bool HasBusyState
+        [AllowNull]
+        public string ErrorMessage
         {
-            get { return (bool)GetValue(HasBusyStateProperty); }
-            protected set { SetValue(HasBusyStatePropertyKey, value); }
+            get { return (string)GetValue(ErrorMessageProperty); }
+            protected set { SetValue(ErrorMessagePropertyKey, value); }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the associated view model implements <see cref="IHasLoading"/>
+        /// <see cref="IHasBusy"/> or <see cref="IHasErrorState"/>.
+        /// </summary>
+        public bool HasState
+        {
+            get { return (bool)GetValue(HasStateProperty); }
+            protected set { SetValue(HasStatePropertyKey, value); }
         }
 
         /// <summary>
@@ -99,6 +125,15 @@ namespace GitHub.UI
             set { SetValue(ShowBusyStateProperty, value); }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to the view model content.
+        /// </summary>
+        public bool ShowContent
+        {
+            get { return (bool)GetValue(ShowContentProperty); }
+            protected set { SetValue(ShowContentPropertyKey, value); }
+        }
+
         internal ViewBase()
         {
         }
@@ -109,9 +144,9 @@ namespace GitHub.UI
     /// </summary>
     /// <remarks>
     /// Exposes a typed <see cref="ViewModel"/> property and optionally displays <see cref="IHasLoading.IsLoading"/> 
-    /// and <see cref="IHasBusy.IsBusy"/> state if the view model implements those interfaces. In addition, if the view
-    /// model is an <see cref="IDialogViewModel"/>, invokes <see cref="IDialogViewModel.Cancel"/> when the escape key
-    /// is pressed.
+    /// <see cref="IHasBusy.IsBusy"/> and <see cref="IHasErrorState.ErrorMessage"/> state if the view model implements
+    /// those interfaces. In addition, if the view model is an <see cref="IDialogViewModel"/>, invokes 
+    /// <see cref="IDialogViewModel.Cancel"/> when the escape key is pressed.
     /// </remarks>
     public class ViewBase<TInterface, TImplementor> : ViewBase, IView, IViewFor<TInterface>, IDisposable
         where TInterface : class, IViewModel
@@ -134,6 +169,7 @@ namespace GitHub.UI
 
                 var hasLoading = ViewModel as IHasLoading;
                 var hasBusy = ViewModel as IHasBusy;
+                var hasErrorState = ViewModel as IHasErrorState;
                 var subs = new CompositeDisposable();
 
                 if (hasLoading != null)
@@ -146,7 +182,12 @@ namespace GitHub.UI
                     subs.Add(this.OneWayBind(hasBusy, x => x.IsBusy, x => x.IsBusy));
                 }
 
-                HasBusyState = hasLoading != null || hasBusy != null;
+                if (hasErrorState != null)
+                {
+                    subs.Add(this.OneWayBind(hasErrorState, x => x.ErrorMessage, x => x.ErrorMessage));
+                }
+
+                HasState = hasLoading != null || hasBusy != null;
                 subscriptions = subs;
             };
 
@@ -161,6 +202,12 @@ namespace GitHub.UI
                         (this.ViewModel as IDialogViewModel)?.Cancel.Execute(null);
                     }));
             });
+
+            this.WhenAnyValue(
+                x => x.IsLoading,
+                x => x.ErrorMessage,
+                (l, m) => !l && m == null)
+                .Subscribe(x => ShowContent = x);
         }
 
         /// <summary>

--- a/src/GitHub.UI.Reactive/Themes/Generic.xaml
+++ b/src/GitHub.UI.Reactive/Themes/Generic.xaml
@@ -59,7 +59,26 @@
                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                  Visibility="{TemplateBinding IsLoading, Converter={ui:BooleanToInverseVisibilityConverter}}"/>
+                                  Visibility="{TemplateBinding ShowContent, Converter={ui:BooleanToVisibilityConverter}}"/>
+
+                <Border Grid.RowSpan="2"
+                        Background="{TemplateBinding Background}"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch">
+                    <Border.Style>
+                        <Style TargetType="Border">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding ErrorMessage}" Value="{x:Null}">
+                                    <Setter Property="Visibility" Value="Collapsed"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Border.Style>
+                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <ui:OcticonImage Icon="alert" Width="32" Height="32" Margin="8"/>
+                        <TextBlock Text="{Binding ErrorMessage}" TextAlignment="Center" TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
             </Grid>
         </Border>
     </ControlTemplate>
@@ -67,10 +86,10 @@
     <!-- Applies the control template for ViewBase depending on HasBusyState -->
     <Style TargetType="local:ViewBase">
         <Style.Triggers>
-            <Trigger Property="HasBusyState" Value="False">
+            <Trigger Property="HasState" Value="False">
                 <Setter Property="Template" Value="{StaticResource ViewBaseDefaultTemplate}"/>
             </Trigger>
-            <Trigger Property="HasBusyState" Value="True">
+            <Trigger Property="HasState" Value="True">
                 <Setter Property="Template" Value="{StaticResource ViewBaseBusyStateTemplate}"/>
             </Trigger>
         </Style.Triggers>


### PR DESCRIPTION
When an error occurs loading PR details, currently the spinner just spins forever with no indication of an error. This PR adds a simple error display to the view which can easily be reused by other views.

- Added a new `IHasErrorState` interface for view models
- Updated ViewBase to track the `IHasErrorState.ErrorMessage` property and display the error message when non-null
- Catch exceptions when loading `PullRequestDetailsViewModel`

## To test:

- Run the extension and load the PR list
- Run fiddler and set up an autoresponder to respond with an error for requests to api.github.com
- Click to open a PR

## Currently looks like this:

![image](https://user-images.githubusercontent.com/1775141/28115096-d3dec926-6703-11e7-8c50-f488e5c9bda7.png)

Could probably do with some beautification!

## Not addressed in this PR

- Showing a "Retry" button on network error
- Showing a "Login" button on auth error

These are rather more involved and so will be addressed in another PR.

Fixes #1049 