### PR TITLE
Close other peek views before showing new one.

### DIFF
--- a/src/GitHub.InlineReviews/Commands/InlineCommentNavigationCommand.cs
+++ b/src/GitHub.InlineReviews/Commands/InlineCommentNavigationCommand.cs
@@ -215,6 +215,14 @@ namespace GitHub.InlineReviews.Commands
             ShowInlineCommentTag tag,
             IEnumerable<ITextView> allTextViews)
         {
+            foreach (var other in allTextViews)
+            {
+                if (other != textView)
+                {
+                    peekService.Hide(other);
+                }
+            }
+
             var point = peekService.Show(textView, tag);
 
             if (parameter?.MoveCursor != false)
@@ -229,14 +237,6 @@ namespace GitHub.InlineReviews.Commands
                 {
                     (textView as FrameworkElement)?.Focus();
                     textView.Caret.MoveTo(caretPoint.Value);
-                }
-            }
-
-            foreach (var other in allTextViews)
-            {
-                if (other != textView)
-                {
-                    peekService.Hide(other);
                 }
             }
         }


### PR DESCRIPTION
This PR is intended to fix #1043, where the peek comments window gets pushed out of the bounds of the window somehow when navigating between comments on different sides of the diff pane.

Fixes #1043