### PR TITLE
Prevent threading error when cloning.

### DIFF
--- a/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/RepositoryCloneViewModel.cs
@@ -125,15 +125,17 @@ namespace GitHub.ViewModels
 
             IsBusy = true;
             repositoryHost.ModelService.GetRepositories(repositories);
-            repositories.OriginalCompleted.Subscribe(
-                _ => { }
-                , ex =>
-                {
-                    LoadingFailed = true;
-                    IsBusy = false;
-                    log.Error("Error while loading repositories", ex);
-                },
-                () => IsBusy = false
+            repositories.OriginalCompleted
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(
+                    _ => { }
+                    , ex =>
+                    {
+                        LoadingFailed = true;
+                        IsBusy = false;
+                        log.Error("Error while loading repositories", ex);
+                    },
+                    () => IsBusy = false
             );
             repositories.Subscribe();
         }


### PR DESCRIPTION
@tierninho was experiencing crashes when cloning. Though I couldn't reproduce this locally, I paired with him and saw that for some reason `repositories.OriginalCompleted` on his machine was completing on a non-UI thread.

Fixes #1064 
