### PR TITLE
Make diff line matching more robust

### DIFF
--- a/src/GitHub.Exports/Models/DiffUtilities.cs
+++ b/src/GitHub.Exports/Models/DiffUtilities.cs
@@ -96,7 +96,10 @@ namespace GitHub.Models
                 {
                     if (source.Lines[i].Content == target[j].Content)
                     {
-                        if (++j == target.Count) return source.Lines[i + j - 1];
+                        if (++j == target.Count || i == 0)
+                        {
+                            return source.Lines[i + j - 1];
+                        }
                     }
                     else
                     {

--- a/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
@@ -173,14 +173,20 @@ namespace GitHub.InlineReviews.UnitTests.Models
         {
             [Theory]
             [InlineData(" 1", " 1", 0)]
-            [InlineData(" 1\n 2", " 2", 1)]
-            [InlineData(" 1\n 1", " 1", 1)] // match the later line
+            [InlineData(" 1. 2", " 2", 1)]
+            [InlineData(" 1. 1", " 1", 1)] // match the later line
             [InlineData("+x", "-x", -1)]
             [InlineData("", " x", -1)]
             [InlineData(" x", "", -1)]
+
+            [InlineData(" 1. 2.", " 2. 1.", 1)] // matched full context
+            [InlineData(" 1. 2.", " 2. 3.", -1)] // didn't match full context
+            [InlineData(" 2.", " 2. 1.", 0)] // match if we run out of context lines
             public void MatchLine(string lines1, string lines2, int skip /* -1 for no match */)
             {
                 var header = "@@ -1 +1 @@";
+                lines1 = lines1.Replace(".", "\r\n");
+                lines2 = lines2.Replace(".", "\r\n");
                 var chunks1 = DiffUtilities.ParseFragment(header + "\n" + lines1).ToList();
                 var chunks2 = DiffUtilities.ParseFragment(header + "\n" + lines2).ToList();
                 var expectLine = (skip != -1) ? chunks1.First().Lines.Skip(skip).First() : null;


### PR DESCRIPTION
This PR matches diff lines based on their original line number and content.

- Diff lines can be matched based on a single line (multiple lines of context aren't required)
- Lines can be inserted between and near to comments without them vanishing

Fixes #1052