### PR TITLE
Display "Updated" instead of "Opened" in PR list tooltip.

### DIFF
--- a/src/GitHub.VisualStudio.UI/Resources.Designer.cs
+++ b/src/GitHub.VisualStudio.UI/Resources.Designer.cs
@@ -639,18 +639,18 @@ namespace GitHub.VisualStudio.UI {
         /// <summary>
         ///   Looks up a localized string similar to by.
         /// </summary>
-        public static string prOpenedByText {
+        public static string prUpdatedByText {
             get {
-                return ResourceManager.GetString("prOpenedByText", resourceCulture);
+                return ResourceManager.GetString("prUpdatedByText", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to opened.
+        ///   Looks up a localized string similar to Updated.
         /// </summary>
-        public static string prOpenedText {
+        public static string prUpdatedText {
             get {
-                return ResourceManager.GetString("prOpenedText", resourceCulture);
+                return ResourceManager.GetString("prUpdatedText", resourceCulture);
             }
         }
         
@@ -790,7 +790,7 @@ namespace GitHub.VisualStudio.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Thanks for installing GitHub for Visual Studio. Why not take a look at our [training](show-training) or [documentation](show-docs)?
+        ///   Looks up a localized string similar to Welcome to GitHub for Visual Studio! Why not take a look at our [training](show-training) or [documentation](show-docs)?
         ///
         ///[Don&apos;t show this again](dont-show-again).
         /// </summary>

--- a/src/GitHub.VisualStudio.UI/Resources.resx
+++ b/src/GitHub.VisualStudio.UI/Resources.resx
@@ -156,11 +156,8 @@
   <data name="gistCreationFailedMessage" xml:space="preserve">
     <value>Failed to create gist</value>
   </data>
-  <data name="prOpenedByText" xml:space="preserve">
+  <data name="prUpdatedByText" xml:space="preserve">
     <value>by</value>
-  </data>
-  <data name="prOpenedText" xml:space="preserve">
-    <value>opened</value>
   </data>
   <data name="Options_PrivacyTitle" xml:space="preserve">
     <value>Privacy</value>
@@ -382,5 +379,8 @@
     <value>Welcome to GitHub for Visual Studio! Why not take a look at our [training](show-training) or [documentation](show-docs)?
 
 [Don't show this again](dont-show-again)</value>
+  </data>
+  <data name="prUpdatedText" xml:space="preserve">
+    <value>Updated</value>
   </data>
 </root>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
@@ -123,7 +123,7 @@
           <TextBlock.Text>
             <MultiBinding StringFormat="{} {0} {1} {2}">
               <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
-              <Binding Source="{x:Static i18n:Resources.prOpenedByText}" />
+              <Binding Source="{x:Static i18n:Resources.prUpdatedByText}" />
               <Binding Path="Author.Login" />
             </MultiBinding>
           </TextBlock.Text>
@@ -133,9 +133,9 @@
                 <TextBlock>
                     <TextBlock.Text>
                        <MultiBinding StringFormat="{} {0} {1} {2} {3}">
-                          <Binding Source="{x:Static i18n:Resources.prOpenedText}" />
+                          <Binding Source="{x:Static i18n:Resources.prUpdatedText}" />
                           <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
-                          <Binding Source="{x:Static i18n:Resources.prOpenedByText}" />
+                          <Binding Source="{x:Static i18n:Resources.prUpdatedByText}" />
                           <Binding Path="Author.Login" />
                         </MultiBinding>
                     </TextBlock.Text>


### PR DESCRIPTION
The time being displayed us the `UpdatedAt` time but the tooltip was saying "Opened at". Change the text to match the data being shown.

Before:

![image](https://user-images.githubusercontent.com/1775141/28169579-1bee12dc-67e3-11e7-99fb-db34e330d8e8.png)

After:

![image](https://user-images.githubusercontent.com/1775141/28169637-43c0f8c4-67e3-11e7-9ed8-1ed86ecf0c33.png)

Fixes #1035