### PR TITLE
Add data context and resources for glyphs

### DIFF
--- a/src/GitHub.InlineReviews/Tags/AddInlineCommentGlyph.xaml
+++ b/src/GitHub.InlineReviews/Tags/AddInlineCommentGlyph.xaml
@@ -6,18 +6,32 @@
              mc:Ignorable="d">
     <UserControl.Resources>
         <SolidColorBrush x:Key="DiffChangeBackground" Color="DarkSlateGray" />
+        <SolidColorBrush x:Key="AddDiffChangeBackground" Color="Green" />
+        <SolidColorBrush x:Key="RemovedDiffChangeBackground" Color="Red" />
     </UserControl.Resources>
-
-    <!-- This is just an exmaple showing where DiffChangeType is exposed -->
-    <UserControl.ToolTip>
-        <TextBlock Text="{Binding DiffChangeType}" />
-    </UserControl.ToolTip>
-    <!-- ^ delete me ^ -->
 
     <Grid Background="{DynamicResource DiffChangeBackground}">
         <Viewbox x:Name="AddViewbox">
-            <Path Stroke="Black"
-          Data="M13 2H1c-0.55 0-1 0.45-1 1v8c0 0.55 0.45 1 1 1h2v3.5l3.5-3.5h6.5c0.55 0 1-0.45 1-1V3c0-0.55-0.45-1-1-1z m0 9H6L4 13V11H1V3h12v8z M7,5 L7,9 M5,7 L9,7"/>
+            <Path
+          Data="M13 2H1c-0.55 0-1 0.45-1 1v8c0 0.55 0.45 1 1 1h2v3.5l3.5-3.5h6.5c0.55 0 1-0.45 1-1V3c0-0.55-0.45-1-1-1z m0 9H6L4 13V11H1V3h12v8z M7,5 L7,9 M5,7 L9,7">
+                <Path.Style>
+                    <Style TargetType="Path">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding DiffChangeType}" Value="Add">
+                                <Setter Property="Stroke" Value="{DynamicResource AddDiffChangeBackground}" />
+                            </DataTrigger>
+
+                            <DataTrigger Binding="{Binding DiffChangeType}" Value="None">
+                                <Setter Property="Stroke" Value="{DynamicResource DiffChangeBackground}" />
+                            </DataTrigger>
+
+                            <DataTrigger Binding="{Binding DiffChangeType}" Value="Delete">
+                                <Setter Property="Stroke" Value="{DynamicResource RemovedDiffChangeBackground}" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Path.Style>
+            </Path>
         </Viewbox>
     </Grid>
 </UserControl>

--- a/src/GitHub.InlineReviews/Tags/AddInlineCommentGlyph.xaml
+++ b/src/GitHub.InlineReviews/Tags/AddInlineCommentGlyph.xaml
@@ -8,6 +8,12 @@
         <SolidColorBrush x:Key="DiffChangeBackground" Color="DarkSlateGray" />
     </UserControl.Resources>
 
+    <!-- This is just an exmaple showing where DiffChangeType is exposed -->
+    <UserControl.ToolTip>
+        <TextBlock Text="{Binding DiffChangeType}" />
+    </UserControl.ToolTip>
+    <!-- ^ delete me ^ -->
+
     <Grid Background="{DynamicResource DiffChangeBackground}">
         <Viewbox x:Name="AddViewbox">
             <Path Stroke="Black"

--- a/src/GitHub.InlineReviews/Tags/AddInlineCommentGlyph.xaml
+++ b/src/GitHub.InlineReviews/Tags/AddInlineCommentGlyph.xaml
@@ -4,8 +4,14 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d">
-    <Viewbox x:Name="AddViewbox">
-        <Path Stroke="Black"
+    <UserControl.Resources>
+        <SolidColorBrush x:Key="DiffChangeBackground" Color="DarkSlateGray" />
+    </UserControl.Resources>
+
+    <Grid Background="{DynamicResource DiffChangeBackground}">
+        <Viewbox x:Name="AddViewbox">
+            <Path Stroke="Black"
           Data="M13 2H1c-0.55 0-1 0.45-1 1v8c0 0.55 0.45 1 1 1h2v3.5l3.5-3.5h6.5c0.55 0 1-0.45 1-1V3c0-0.55-0.45-1-1-1z m0 9H6L4 13V11H1V3h12v8z M7,5 L7,9 M5,7 L9,7"/>
-    </Viewbox>
+        </Viewbox>
+    </Grid>
 </UserControl>

--- a/src/GitHub.InlineReviews/Tags/InlineCommentGlyphFactory.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentGlyphFactory.cs
@@ -76,7 +76,7 @@ namespace GitHub.InlineReviews.Tags
                 if (OpenThreadView(tag)) e.Handled = true;
             };
 
-            glyph.Background = brushesManager.GetBackground(tag.DiffChangeType);
+            glyph.Resources["DiffChangeBackground"] = brushesManager.GetBackground(tag.DiffChangeType);
             return glyph;
         }
 

--- a/src/GitHub.InlineReviews/Tags/InlineCommentGlyphFactory.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentGlyphFactory.cs
@@ -69,7 +69,7 @@ namespace GitHub.InlineReviews.Tags
         public UIElement GenerateGlyph(IWpfTextViewLine line, InlineCommentTag tag)
         {
             var glyph = CreateGlyph(tag);
-            glyph.Tag = tag;
+            glyph.DataContext = tag;
 
             glyph.MouseLeftButtonUp += (s, e) =>
             {

--- a/src/GitHub.InlineReviews/Tags/ShowInlineCommentGlyph.xaml
+++ b/src/GitHub.InlineReviews/Tags/ShowInlineCommentGlyph.xaml
@@ -5,11 +5,20 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d"
              ToolTipService.ShowDuration="600000" ToolTipService.HasDropShadow="True">
+
+    <UserControl.Resources>
+        <!-- This will be the color of an added/deleted word in the diff view or the indicator margin color -->
+        <SolidColorBrush x:Key="DiffChangeBackground" Color="DarkSlateGray" />
+    </UserControl.Resources>
+
     <UserControl.ToolTip>
         <ToolTip x:Name="CommentToolTip" />
     </UserControl.ToolTip>
-    <Viewbox>
-        <Path Stroke="Black"
+
+    <Grid Background="{DynamicResource DiffChangeBackground}">
+        <Viewbox>
+            <Path Stroke="Black"
           Data="M13 2H1c-0.55 0-1 0.45-1 1v8c0 0.55 0.45 1 1 1h2v3.5l3.5-3.5h6.5c0.55 0 1-0.45 1-1V3c0-0.55-0.45-1-1-1z m0 9H6L4 13V11H1V3h12v8z"/>
-    </Viewbox>
+        </Viewbox>
+    </Grid>
 </UserControl>

--- a/src/GitHub.InlineReviews/Tags/ShowInlineCommentGlyph.xaml.cs
+++ b/src/GitHub.InlineReviews/Tags/ShowInlineCommentGlyph.xaml.cs
@@ -16,19 +16,22 @@ namespace GitHub.InlineReviews.Tags
 
         protected override void OnToolTipOpening(ToolTipEventArgs e)
         {
-            var tag = Tag as ShowInlineCommentTag;
-            var comments = tag.Thread.Comments.Select(comment => new PullRequestReviewCommentModel
+            var tag = DataContext as ShowInlineCommentTag;
+            if (tag != null)
             {
-                User = comment.User,
-                Body = comment.Body,
-                CreatedAt = comment.CreatedAt
-            });
+                var comments = tag.Thread.Comments.Select(comment => new PullRequestReviewCommentModel
+                {
+                    User = comment.User,
+                    Body = comment.Body,
+                    CreatedAt = comment.CreatedAt
+                });
 
-            var viewModel = new TooltipCommentThreadViewModel(comments);
-            var view = new TooltipCommentThreadView();
-            view.DataContext = viewModel;
+                var viewModel = new TooltipCommentThreadViewModel(comments);
+                var view = new TooltipCommentThreadView();
+                view.DataContext = viewModel;
 
-            CommentToolTip.Content = view;
+                CommentToolTip.Content = view;
+            }
         }
 
         protected override void OnToolTipClosing(ToolTipEventArgs e)


### PR DESCRIPTION
This PR is intended to provide the context needed to change the look of the glyphs in XAML.

1. Add a dynamic resource with ID `DiffChangeBackground`
   - This will be the color of an added/deleted word in the diff view or the indicator margin color
2. Set the glyph's `DataContext` as the `InlineCommentTag` subtype
  - The will expose the type of change (add/delete/none) via `{Binding DiffChangeType}`

I've added an example where the `AddInlineCommentGlyph` will show its `DiffChangeType` as a tooltip. This should be backed out before we merge.

Fixes #1078