### PR TITLE
Fix crash when on deleted PR branch

### DIFF
--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -390,10 +390,10 @@ namespace GitHub.Services
         {
             return Task.Factory.StartNew(() =>
             {
-                if(repo.Head.IsTracking)
+                if (repo.Head.IsTracking)
                 {
                     var trackedBranchTip = repo.Head.TrackedBranch.Tip;
-                    if(trackedBranchTip != null)
+                    if (trackedBranchTip != null)
                     {
                         return repo.Head.Tip.Sha == trackedBranchTip.Sha;
                     }

--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -390,7 +390,16 @@ namespace GitHub.Services
         {
             return Task.Factory.StartNew(() =>
             {
-                return repo.Head.IsTracking && repo.Head.Tip.Sha == repo.Head.TrackedBranch.Tip.Sha;
+                if(repo.Head.IsTracking)
+                {
+                    var trackedBranchTip = repo.Head.TrackedBranch.Tip;
+                    if(trackedBranchTip != null)
+                    {
+                        return repo.Head.Tip.Sha == trackedBranchTip.Sha;
+                    }
+                }
+
+                return false;
             });
         }
 

--- a/src/UnitTests/GitHub.App/Services/GitClientTests.cs
+++ b/src/UnitTests/GitHub.App/Services/GitClientTests.cs
@@ -9,6 +9,51 @@ using Xunit;
 
 public class GitClientTests
 {
+    public class TheIsHeadPushedMethod : TestBaseClass
+    {
+        [Theory]
+        [InlineData(true, "sha", "sha", true)]
+        [InlineData(true, "xxx", "yyy", false)]
+        [InlineData(true, "headSha", null, false)]
+        [InlineData(false, "sha", "sha", false)]
+        public async Task IsHeadPushed(bool istracking, string headSha, string trackedBranchSha, bool expectHeadPushed)
+        {
+            var gitClient = new GitClient(Substitute.For<IGitHubCredentialProvider>());
+            var repository = MockTrackedBranchRepository(istracking, headSha, trackedBranchSha);
+
+            var isHeadPushed = await gitClient.IsHeadPushed(repository);
+
+            Assert.Equal(expectHeadPushed, isHeadPushed);
+        }
+
+        static IRepository MockTrackedBranchRepository(bool isTracking, string headSha, string trackedBranchSha)
+        {
+            var trackedBranch = Substitute.For<Branch>();
+            var trackedBranchTip = MockCommitOrNull(trackedBranchSha);
+            trackedBranch.Tip.Returns(trackedBranchTip);
+            var headBranch = Substitute.For<Branch>();
+            var headTip = MockCommitOrNull(headSha);
+            headBranch.Tip.Returns(headTip);
+            headBranch.IsTracking.Returns(isTracking);
+            headBranch.TrackedBranch.Returns(trackedBranch);
+            var repository = Substitute.For<IRepository>();
+            repository.Head.Returns(headBranch);
+            return repository;
+        }
+
+        static Commit MockCommitOrNull(string sha)
+        {
+            if(sha != null)
+            {
+                var commit = Substitute.For<Commit>();
+                commit.Sha.Returns(sha);
+                return commit;
+            }
+
+            return null;
+        }
+    }
+
     public class ThePushMethod : TestBaseClass
     {
         [Fact]

--- a/src/UnitTests/GitHub.App/Services/GitClientTests.cs
+++ b/src/UnitTests/GitHub.App/Services/GitClientTests.cs
@@ -43,7 +43,7 @@ public class GitClientTests
 
         static Commit MockCommitOrNull(string sha)
         {
-            if(sha != null)
+            if (sha != null)
             {
                 var commit = Substitute.For<Commit>();
                 commit.Sha.Returns(sha);
@@ -188,7 +188,7 @@ public class GitClientTests
             var mergeBaseCommit = Substitute.For<Commit>();
             mergeBaseCommit.Sha.Returns(mergeBaseSha);
 
-            if(baseSha != null)
+            if (baseSha != null)
             {
                 repo.Lookup<Commit>(baseSha).Returns(baseCommit);
             }


### PR DESCRIPTION
Visual Studio was crashing when the branch for a PR was deleted.

This PR makes `IsHeadPushed` return `false` when `IsTracking` is `true` but the branch has since been deleted.

To repro this issue:

1. Open GitHub tool window and show Closed PRs.
2. Checkout any PR that is on a deleted branch (most closed PRs)

- If solution isn't open you will see:
![image](https://user-images.githubusercontent.com/11719160/28370414-28f1d8b6-6c92-11e7-9aa8-ec3dd9bd3d0a.png)
- If solution is open, Visual Studio will crash.
![image](https://user-images.githubusercontent.com/11719160/28370564-7c4dca24-6c92-11e7-8901-5dabac48966e.png)

Fixes #1081