### PR TITLE
Handle inline comments in moved files.

### DIFF
--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -99,13 +99,14 @@ namespace GitHub.Services
         /// Compares a file in a commit to a string.
         /// </summary>
         /// <param name="repository">The repository</param>
-        /// <param name="sha">The SHA of the first commit.</param>
+        /// <param name="sha1">The SHA of the first commit.</param>
+        /// <param name="sha2">The SHA of the second commit.</param>
         /// <param name="path">The relative path to the file.</param>
         /// <param name="contents">The contents to compare with the file.</param>
         /// <returns>
         /// A <see cref="Patch"/> object or null if the commit could not be found in the repository.
         /// </returns>
-        Task<ContentChanges> CompareWith(IRepository repository, string sha, string path, byte[] contents);
+        Task<ContentChanges> CompareWith(IRepository repository, string sha1, string sha2, string path, byte[] contents);
 
         /// Gets the value of a configuration key.
         /// </summary>

--- a/src/GitHub.InlineReviews/Services/DiffService.cs
+++ b/src/GitHub.InlineReviews/Services/DiffService.cs
@@ -23,11 +23,12 @@ namespace GitHub.InlineReviews.Services
 
         public async Task<IList<DiffChunk>> Diff(
             IRepository repo,
-            string sha,
+            string baseSha,
+            string headSha,
             string path,
             byte[] contents)
         {
-            var changes = await gitClient.CompareWith(repo, sha, path, contents);
+            var changes = await gitClient.CompareWith(repo, baseSha, headSha, path, contents);
             return DiffUtilities.ParseFragment(changes.Patch).ToList();
         }
     }

--- a/src/GitHub.InlineReviews/Services/IDiffService.cs
+++ b/src/GitHub.InlineReviews/Services/IDiffService.cs
@@ -7,6 +7,6 @@ namespace GitHub.InlineReviews.Services
 {
     public interface IDiffService
     {
-        Task<IList<DiffChunk>> Diff(IRepository repo, string baseSha, string relativePath, byte[] contents);
+        Task<IList<DiffChunk>> Diff(IRepository repo, string baseSha, string headSha, string relativePath, byte[] contents);
     }
 }

--- a/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
@@ -15,12 +15,14 @@ namespace GitHub.InlineReviews.Services
         /// </summary>
         /// <param name="repository">The repository.</param>
         /// <param name="baseSha">The commit to use as the base.</param>
+        /// <param name="headSha">The commit to use as the head.</param>
         /// <param name="relativePath">The relative path to the file.</param>
         /// <param name="contents">The contents of the file.</param>
         /// <returns></returns>
         Task<IList<DiffChunk>> Diff(
             ILocalRepositoryModel repository,
             string baseSha,
+            string headSha,
             string relativePath,
             byte[] contents);
 

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -35,10 +35,10 @@ namespace GitHub.InlineReviews.Services
         }
 
         /// <inheritdoc/>
-        public async Task<IList<DiffChunk>> Diff(ILocalRepositoryModel repository, string baseSha, string relativePath, byte[] contents)
+        public async Task<IList<DiffChunk>> Diff(ILocalRepositoryModel repository, string baseSha, string headSha, string relativePath, byte[] contents)
         {
             var repo = await GetRepository(repository);
-            return await diffService.Diff(repo, baseSha, relativePath, contents);
+            return await diffService.Diff(repo, baseSha, headSha, relativePath, contents);
         }
 
         /// <inheritdoc/>

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
@@ -594,7 +594,7 @@ Line 4";
 
                     // Simulate calling GetFile with a file that's not yet been initialized
                     // while doing the Update.
-                    service.WhenForAnyArgs(x => x.Diff(null, null, null, null))
+                    service.WhenForAnyArgs(x => x.Diff(null, null, null, null, null))
                         .Do(_ => target.GetFile("other.cs").Forget());
 
                     await target.Update(pullRequest);
@@ -648,12 +648,14 @@ Line 4";
                 Arg.Any<ILocalRepositoryModel>(),
                 Arg.Any<string>(),
                 Arg.Any<string>(),
+                Arg.Any<string>(),
                 Arg.Any<byte[]>())
                 .Returns(i => diffService.Diff(
                     null,
                     i.ArgAt<string>(1),
                     i.ArgAt<string>(2),
-                    i.ArgAt<byte[]>(3)));
+                    i.ArgAt<string>(3),
+                    i.ArgAt<byte[]>(4)));
             result.GetTipSha(Arg.Any<ILocalRepositoryModel>()).Returns("BRANCH_TIP");
             return result;
         }

--- a/test/GitHub.InlineReviews.UnitTests/TestDoubles/FakeDiffService.cs
+++ b/test/GitHub.InlineReviews.UnitTests/TestDoubles/FakeDiffService.cs
@@ -43,7 +43,7 @@ namespace GitHub.InlineReviews.UnitTests.TestDoubles
             DeleteDirectory(path);
         }
 
-        public Task<IList<DiffChunk>> Diff(IRepository repo, string baseSha, string path, byte[] contents)
+        public Task<IList<DiffChunk>> Diff(IRepository repo, string baseSha, string headSha, string path, byte[] contents)
         {
             var tip = repository.Head.Tip.Sha;
             var stream = contents != null ? new MemoryStream(contents) : new MemoryStream();


### PR DESCRIPTION
When comparing a file with a `byte[]`, check whether the file has been moved.

Fixes #1110