### PR TITLE
InfoPanel Fixes.

### DIFF
--- a/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml
@@ -58,6 +58,7 @@
                                 VerticalAlignment="Top"
                                 DockPanel.Dock="Top"
                                 Foreground="Black"
+                                Markdown="{Binding Message}"
                                 ScrollViewer.CanContentScroll="False"
                                 ScrollViewer.HorizontalScrollBarVisibility="Hidden"
                                 ScrollViewer.VerticalScrollBarVisibility="Hidden"/>

--- a/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml
@@ -9,7 +9,7 @@
              xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
              xmlns:automation="clr-namespace:GitHub.UI.TestAutomation;assembly=GitHub.UI"
              xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
-             Background="Beige"
+             Background="{DynamicResource VsBrush.InfoBackground}"
              d:DataContext="{d:DesignInstance Type=sampleData:InfoPanelDesigner, IsDesignTimeCreatable=True}"
              d:DesignHeight="300"
              d:DesignWidth="300"

--- a/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml
@@ -35,6 +35,10 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
+    <FrameworkElement.CommandBindings>
+        <CommandBinding Command="{x:Static markdig:Commands.Hyperlink}" Executed="OpenHyperlink" />
+    </FrameworkElement.CommandBindings>
+
     <DockPanel Margin="8" LastChildFill="True">
         <ui:OcticonImage Width="16"
                          Height="16"

--- a/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml.cs
@@ -51,13 +51,6 @@ namespace GitHub.VisualStudio.UI.Controls
             private set { iconColor = value; RaisePropertyChanged(nameof(IconColor)); }
         }
 
-        ICommand linkCommand;
-        public ICommand LinkCommand
-        {
-            get { return linkCommand; }
-            set { linkCommand = value; RaisePropertyChanged(nameof(LinkCommand)); }
-        }
-
         static InfoPanel()
         {
             WarningColorBrush.Freeze();
@@ -82,12 +75,14 @@ namespace GitHub.VisualStudio.UI.Controls
             DataContext = this;
             Icon = Octicon.info;
             IconColor = InfoColorBrush;
+        }
 
-            LinkCommand = new RelayCommand(x =>
-            {
-                if (!String.IsNullOrEmpty(x as string))
-                    Browser.OpenUrl(new Uri((string)x));
-            });
+        void OpenHyperlink(object sender, ExecutedRoutedEventArgs e)
+        {
+            var url = e.Parameter.ToString();
+
+            if (!string.IsNullOrEmpty(url))
+                Browser.OpenUrl(new Uri(url));
         }
 
         static void UpdateMessage(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
A few `InfoPanel` fixes:

- Bind `MarkdownViewer.Markdown` in `InfoPanel.xaml` - the panel won't display a message if we don't bind the property!
- Use `VsBrush.InfoBackground` as the background color, previously it was just `Beige`

Fixes #1131