### PR TITLE
Don't add a byte order mark to editor contents.

### DIFF
--- a/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
@@ -157,7 +157,9 @@ namespace GitHub.InlineReviews.Tags
 
         Task<byte[]> IEditorContentSource.GetContent()
         {
-            return Task.FromResult(GetContents(buffer.CurrentSnapshot));
+            var text = buffer.CurrentSnapshot.GetText();
+            var bytes = document.Encoding.GetBytes(text);
+            return Task.FromResult(bytes);
         }
 
         void Initialize()
@@ -277,22 +279,6 @@ namespace GitHub.InlineReviews.Tags
 
                 signalRebuild.OnNext(buffer.CurrentSnapshot);
             }
-        }
-
-        byte[] GetContents(ITextSnapshot snapshot)
-        {
-            var currentText = snapshot.GetText();
-
-            var content = document.Encoding.GetBytes(currentText);
-
-            var preamble = document.Encoding.GetPreamble();
-            if (preamble.Length == 0) return content;
-
-            var completeContent = new byte[preamble.Length + content.Length];
-            Buffer.BlockCopy(preamble, 0, completeContent, 0, preamble.Length);
-            Buffer.BlockCopy(content, 0, completeContent, preamble.Length, content.Length);
-
-            return completeContent;
         }
 
         async Task Rebuild(ITextSnapshot snapshot)


### PR DESCRIPTION
This was causing #1137; this code was obviously added for a reason in 6b81f3ff but I can no longer reproduce VS erroneously signalling a file as changed if we don't add the BOM. Maybe we handle this elsewhere now?

I could do with some 👀 on this @jcansdale as I'm worried I'm missing something.

Fixes #1137.