### PR TITLE
Ensure that CacheIndex.IndexKey != null.

### DIFF
--- a/src/GitHub.App/Caches/CacheIndex.cs
+++ b/src/GitHub.App/Caches/CacheIndex.cs
@@ -18,11 +18,14 @@ namespace GitHub.Caches
 
         public static CacheIndex Create(string key)
         {
-            return new CacheIndex { IndexKey = key };
+            return new CacheIndex(key);
         }
 
-        public CacheIndex()
+        public CacheIndex(string key)
         {
+            Guard.ArgumentNotEmptyString(key, nameof(key));
+
+            IndexKey = key;
             Keys = new List<string>();
             OldKeys = new List<string>();
         }
@@ -90,9 +93,9 @@ namespace GitHub.Caches
                 .Select(x => this);
         }
 
-        public string IndexKey { get; set; }
-        public List<string> Keys { get; set; }
+        public string IndexKey { get; }
+        public List<string> Keys { get; }
         public DateTimeOffset UpdatedAt { get; set; }
-        public List<string> OldKeys { get; set; }
+        public List<string> OldKeys { get; private set; }
     }
 }


### PR DESCRIPTION
This is a strange one. In debugging #1139, I started by trying to make sure that ` CacheIndex.IndexKey` is not null by removing its setter, setting the property in the constructor and adding a `Guard`.

Somehow this fixed #1139. I have no idea how. Reverting this PR causes the crash to show up again.

(I also gave some properties in `CacheIndex` private setters or removed setters where they were only set by the class itself or in the constructor.)

