### PR TITLE
Use correct cache key in ModelService.GetRepository.

### DIFF
--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -219,7 +219,7 @@ namespace GitHub.Services
         public IObservable<IRemoteRepositoryModel> GetRepository(string owner, string repo)
         {
             var keyobs = GetUserFromCache()
-                .Select(user => string.Format(CultureInfo.InvariantCulture, "{0}|{1}", CacheIndex.RepoPrefix, user.Login));
+                .Select(user => string.Format(CultureInfo.InvariantCulture, "{0}|{1}|{2}/{3}", CacheIndex.RepoPrefix, user.Login, owner, repo));
 
             return Observable.Defer(() => keyobs
                 .SelectMany(key =>


### PR DESCRIPTION
The cache key being used in `ModelService.GetRepository` was wrong - it was using the cache key for the index and overwriting it with a `RepositoryCacheItem` model. This was causing the crashes/brokenness seen in #1139 and #1143.

Fixes #1139
Fixes #1143