### PR TITLE
Use correct encoding for temp diff files.

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -99,12 +99,10 @@ This requires that errors be propagated from the viewmodel to the view and from 
         public ReactiveCommand<object> OpenFileInWorkingDirectory { get; }
         public ReactiveCommand<object> ViewFile { get; }
 
-        public Task<string> ExtractFile(IPullRequestFileNode file, bool head, Encoding encoding)
+        public Task<string> ExtractFile(IPullRequestFileNode file, bool head)
         {
             return null;
         }
-
-        public Encoding GetEncoding(string path) => Encoding.UTF8;
 
         public string GetLocalFilePath(IPullRequestFileNode file)
         {

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -477,18 +477,12 @@ namespace GitHub.ViewModels
         /// </param>
         /// <param name="encoding">The encoding to use.</param>
         /// <returns>The path to a temporary file.</returns>
-        public Task<string> ExtractFile(IPullRequestFileNode file, bool head, Encoding encoding)
+        public Task<string> ExtractFile(IPullRequestFileNode file, bool head)
         {
             var path = Path.Combine(file.DirectoryPath, file.FileName);
+            var encoding = pullRequestsService.GetEncoding(path);
             return pullRequestsService.ExtractFile(LocalRepository, model, path, head, encoding).ToTask();
         }
-
-        /// <summary>
-        /// Gets the encoding for the specified file.
-        /// </summary>
-        /// <param name="path">The path to the file.</param>
-        /// <returns>The file's encoding</returns>
-        public Encoding GetEncoding(string path) => pullRequestsService.GetEncoding(path);
 
         /// <summary>
         /// Gets the full path to a file in the working directory.

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -475,7 +475,6 @@ namespace GitHub.ViewModels
         /// <param name="head">
         /// If true, gets the file at the PR head, otherwise gets the file at the PR merge base.
         /// </param>
-        /// <param name="encoding">The encoding to use.</param>
         /// <returns>The path to a temporary file.</returns>
         public Task<string> ExtractFile(IPullRequestFileNode file, bool head)
         {

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestDetailViewModel.cs
@@ -189,16 +189,8 @@ namespace GitHub.ViewModels
         /// <param name="head">
         /// If true, gets the file at the PR head, otherwise gets the file at the PR merge base.
         /// </param>
-        /// <param name="encoding">The encoding to use.</param>
         /// <returns>The path to a temporary file.</returns>
-        Task<string> ExtractFile(IPullRequestFileNode file, bool head, Encoding encoding);
-
-        /// <summary>
-        /// Gets the encoding for the specified file.
-        /// </summary>
-        /// <param name="path">The path to the file.</param>
-        /// <returns>The file's encoding</returns>
-        Encoding GetEncoding(string path);
+        Task<string> ExtractFile(IPullRequestFileNode file, bool head);
 
         /// <summary>
         /// Gets the full path to a file in the working directory.

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -61,9 +61,10 @@ namespace GitHub.InlineReviews.Services
         public async Task<bool> IsUnmodifiedAndPushed(ILocalRepositoryModel repository, string relativePath, byte[] contents)
         {
             var repo = await GetRepository(repository);
+            var modified = await gitClient.IsModified(repo, relativePath, contents);
+            var pushed = await gitClient.IsHeadPushed(repo);
 
-            return !await gitClient.IsModified(repo, relativePath, contents) &&
-                   await gitClient.IsHeadPushed(repo);
+            return !modified && pushed;
         }
 
         public async Task<byte[]> ExtractFileFromGit(

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml.cs
@@ -85,7 +85,7 @@ namespace GitHub.VisualStudio.UI.Views
             try
             {
                 var fullPath = ViewModel.GetLocalFilePath(file);
-                var fileName = workingDirectory ? fullPath : await ViewModel.ExtractFile(file, true, Encoding.UTF8);
+                var fileName = workingDirectory ? fullPath : await ViewModel.ExtractFile(file, true);
 
                 using (new NewDocumentStateScope(__VSNEWDOCUMENTSTATE.NDS_Provisional, VSConstants.NewDocumentStateReason.SolutionExplorer))
                 {
@@ -112,9 +112,8 @@ namespace GitHub.VisualStudio.UI.Views
             try
             {
                 var relativePath = System.IO.Path.Combine(file.DirectoryPath, file.FileName);
-                var rightFile = workingDirectory ? ViewModel.GetLocalFilePath(file) : await ViewModel.ExtractFile(file, true, Encoding.UTF8);
-                var encoding = ViewModel.GetEncoding(rightFile);
-                var leftFile = await ViewModel.ExtractFile(file, false, encoding);
+                var rightFile = workingDirectory ? ViewModel.GetLocalFilePath(file) : await ViewModel.ExtractFile(file, true);
+                var leftFile = await ViewModel.ExtractFile(file, false);
                 var fullPath = System.IO.Path.Combine(ViewModel.LocalRepository.LocalPath, relativePath);
                 var leftLabel = $"{relativePath};{ViewModel.TargetBranchDisplayName}";
                 var rightLabel = workingDirectory ? relativePath : $"{relativePath};PR {ViewModel.Model.Number}";


### PR DESCRIPTION
The encoding logic in `PullRequestDetailView` was completely wrong - it was extracting the right file with UTF8 encoding and then using that for the left file. Moved the encoding detection logic to `PullRequestDetailViewModel`.

Fixes #1137