### PR TITLE
Increment diffLine when control line is encountered.

### DIFF
--- a/src/GitHub.Exports/Models/DiffUtilities.cs
+++ b/src/GitHub.Exports/Models/DiffUtilities.cs
@@ -41,34 +41,32 @@ namespace GitHub.Models
                     else if (chunk != null)
                     {
                         var type = GetLineChange(line[0]);
-                        if (type == DiffChangeType.Control)
-                        {
-                            // This might contain info about previous line (e.g. "\ No newline at end of file").
-                            ++diffLine;
-                            continue;
-                        }
 
-                        chunk.Lines.Add(new DiffLine
+                        // This might contain info about previous line (e.g. "\ No newline at end of file").
+                        if (type != DiffChangeType.Control)
                         {
-                            Type = type,
-                            OldLineNumber = type != DiffChangeType.Add ? oldLine : -1,
-                            NewLineNumber = type != DiffChangeType.Delete ? newLine : -1,
-                            DiffLineNumber = diffLine,
-                            Content = line,
-                        });
+                            chunk.Lines.Add(new DiffLine
+                            {
+                                Type = type,
+                                OldLineNumber = type != DiffChangeType.Add ? oldLine : -1,
+                                NewLineNumber = type != DiffChangeType.Delete ? newLine : -1,
+                                DiffLineNumber = diffLine,
+                                Content = line,
+                            });
 
-                        switch (type)
-                        {
-                            case DiffChangeType.None:
-                                ++oldLine;
-                                ++newLine;
-                                break;
-                            case DiffChangeType.Delete:
-                                ++oldLine;
-                                break;
-                            case DiffChangeType.Add:
-                                ++newLine;
-                                break;
+                            switch (type)
+                            {
+                                case DiffChangeType.None:
+                                    ++oldLine;
+                                    ++newLine;
+                                    break;
+                                case DiffChangeType.Delete:
+                                    ++oldLine;
+                                    break;
+                                case DiffChangeType.Add:
+                                    ++newLine;
+                                    break;
+                            }
                         }
                     }
 

--- a/src/GitHub.Exports/Models/DiffUtilities.cs
+++ b/src/GitHub.Exports/Models/DiffUtilities.cs
@@ -44,6 +44,7 @@ namespace GitHub.Models
                         if (type == DiffChangeType.Control)
                         {
                             // This might contain info about previous line (e.g. "\ No newline at end of file").
+                            ++diffLine;
                             continue;
                         }
 

--- a/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
@@ -47,7 +47,7 @@ namespace GitHub.InlineReviews.UnitTests.Models
             }
 
             [Fact]
-            public void NoNewLineAtEnd_NotAtEndOfChunk()
+            public void NoNewLineNotAtEndOfChunk_CheckLineCount()
             {
                 var header =
 @"@@ -1 +1 @@
@@ -55,10 +55,24 @@ namespace GitHub.InlineReviews.UnitTests.Models
 \ No newline at end of file
 +new";
 
-                var chunks = DiffUtilities.ParseFragment(header);
+                var chunk = DiffUtilities.ParseFragment(header).First();
 
-                var chunk = chunks.First();
                 Assert.Equal(2, chunk.Lines.Count());
+            }
+
+            [Fact]
+            public void NoNewLineNotAtEndOfChunk_CheckDiffLineNumber()
+            {
+                var header =
+@"@@ -1 +1 @@
+-old
+\ No newline at end of file
++new";
+
+                var chunk = DiffUtilities.ParseFragment(header).First();
+
+                var line = chunk.Lines.Last();
+                Assert.Equal(3, line.DiffLineNumber);
             }
 
             [Fact]


### PR DESCRIPTION
Previously control lines in diffs (e.g. "\ No newline at end of file") were being ignored but the `diffLine` wasn't being incremented. This caused certain comments to be left on the wrong line, as in #1141.

Fixes #1141.