### PR TITLE
Use correct path to get file encoding.

### DIFF
--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -328,12 +328,14 @@ namespace GitHub.Services
             });
         }
 
-        public Encoding GetEncoding(string path)
+        public Encoding GetEncoding(ILocalRepositoryModel repository, string relativePath)
         {
-            if (File.Exists(path))
+            var fullPath = Path.Combine(repository.LocalPath, relativePath);
+
+            if (File.Exists(fullPath))
             {
                 var encoding = Encoding.UTF8;
-                if (HasPreamble(path, encoding))
+                if (HasPreamble(fullPath, encoding))
                 {
                     return encoding;
                 }

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -478,9 +478,9 @@ namespace GitHub.ViewModels
         /// <returns>The path to a temporary file.</returns>
         public Task<string> ExtractFile(IPullRequestFileNode file, bool head)
         {
-            var path = Path.Combine(file.DirectoryPath, file.FileName);
-            var encoding = pullRequestsService.GetEncoding(path);
-            return pullRequestsService.ExtractFile(LocalRepository, model, path, head, encoding).ToTask();
+            var relativePath = Path.Combine(file.DirectoryPath, file.FileName);
+            var encoding = pullRequestsService.GetEncoding(LocalRepository, relativePath);
+            return pullRequestsService.ExtractFile(LocalRepository, model, relativePath, head, encoding).ToTask();
         }
 
         /// <summary>

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
@@ -126,7 +126,9 @@ namespace GitHub.Services
         /// </summary>
         /// <param name="repository">The repository.</param>
         /// <param name="relativePath">The relative path to the file in the repository.</param>
-        /// <returns>The file's encoding</returns>
+        /// <returns>
+        /// The file's encoding or <see cref="Encoding.Default"/> if the file doesn't exist.
+        /// </returns>
         Encoding GetEncoding(ILocalRepositoryModel repository, string relativePath);
 
         /// <summary>

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
@@ -124,9 +124,10 @@ namespace GitHub.Services
         /// <summary>
         /// Gets the encoding for the specified file.
         /// </summary>
-        /// <param name="path">The path to the file.</param>
+        /// <param name="repository">The repository.</param>
+        /// <param name="relativePath">The relative path to the file in the repository.</param>
         /// <returns>The file's encoding</returns>
-        Encoding GetEncoding(string path);
+        Encoding GetEncoding(ILocalRepositoryModel repository, string relativePath);
 
         /// <summary>
         /// Gets a file as it appears in a pull request.


### PR DESCRIPTION
`PullRequestService.GetEncoding` required a full path but we were passing it a relative path. Make that method take a repository and a relative path to try to make the API clearer.

Fixes #1137 (again)