### PR TITLE
Fix implementation of IsHeadPushed. 

### DIFF
--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -424,16 +424,7 @@ namespace GitHub.Services
 
             return Task.Factory.StartNew(() =>
             {
-                if (repo.Head.IsTracking)
-                {
-                    var trackedBranchTip = repo.Head.TrackedBranch.Tip;
-                    if (trackedBranchTip != null)
-                    {
-                        return repo.Head.Tip.Sha == trackedBranchTip.Sha;
-                    }
-                }
-
-                return false;
+                return repo.Head.TrackingDetails.AheadBy == 0;
             });
         }
 

--- a/src/UnitTests/GitHub.App/Services/GitClientTests.cs
+++ b/src/UnitTests/GitHub.App/Services/GitClientTests.cs
@@ -14,45 +14,28 @@ public class GitClientTests
     public class TheIsHeadPushedMethod : TestBaseClass
     {
         [Theory]
-        [InlineData(true, "sha", "sha", true)]
-        [InlineData(true, "xxx", "yyy", false)]
-        [InlineData(true, "headSha", null, false)]
-        [InlineData(false, "sha", "sha", false)]
-        public async Task IsHeadPushed(bool istracking, string headSha, string trackedBranchSha, bool expectHeadPushed)
+        [InlineData(0, true)]
+        [InlineData(2, false)]
+        [InlineData(null, false)]
+        public async Task IsHeadPushed(int? aheadBy, bool expected)
         {
             var gitClient = new GitClient(Substitute.For<IGitHubCredentialProvider>());
-            var repository = MockTrackedBranchRepository(istracking, headSha, trackedBranchSha);
+            var repository = MockTrackedBranchRepository(aheadBy);
 
             var isHeadPushed = await gitClient.IsHeadPushed(repository);
 
-            Assert.Equal(expectHeadPushed, isHeadPushed);
+            Assert.Equal(expected, isHeadPushed);
         }
 
-        static IRepository MockTrackedBranchRepository(bool isTracking, string headSha, string trackedBranchSha)
+        static IRepository MockTrackedBranchRepository(int? aheadBy)
         {
-            var trackedBranch = Substitute.For<Branch>();
-            var trackedBranchTip = MockCommitOrNull(trackedBranchSha);
-            trackedBranch.Tip.Returns(trackedBranchTip);
             var headBranch = Substitute.For<Branch>();
-            var headTip = MockCommitOrNull(headSha);
-            headBranch.Tip.Returns(headTip);
-            headBranch.IsTracking.Returns(isTracking);
-            headBranch.TrackedBranch.Returns(trackedBranch);
+            var trackingDetails = Substitute.For<BranchTrackingDetails>();
+            trackingDetails.AheadBy.Returns(aheadBy);
+            headBranch.TrackingDetails.Returns(trackingDetails);
             var repository = Substitute.For<IRepository>();
             repository.Head.Returns(headBranch);
             return repository;
-        }
-
-        static Commit MockCommitOrNull(string sha)
-        {
-            if (sha != null)
-            {
-                var commit = Substitute.For<Commit>();
-                commit.Sha.Returns(sha);
-                return commit;
-            }
-
-            return null;
         }
     }
 


### PR DESCRIPTION
Previously we were checking if head and the remote tracking branch were on the same commit. Instead check whether head is not ahead by any commits.

Fixes #1155
Depends on #1150