### PR TITLE
Harden InlineCommentNavigationCommand.GetCurrentTextViews

### DIFF
--- a/src/GitHub.InlineReviews/Commands/InlineCommentNavigationCommand.cs
+++ b/src/GitHub.InlineReviews/Commands/InlineCommentNavigationCommand.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using GitHub.Extensions;
 using GitHub.InlineReviews.Services;
 using GitHub.InlineReviews.Tags;
+using GitHub.VisualStudio;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
@@ -98,72 +99,83 @@ namespace GitHub.InlineReviews.Commands
         /// </remarks>
         protected IEnumerable<ITextView> GetCurrentTextViews()
         {
-            var serviceProvider = Package;
-            var monitorSelection = (IVsMonitorSelection)serviceProvider.GetService(typeof(SVsShellMonitorSelection));
-            if (monitorSelection == null)
-            {
-                yield break;
-            }
+            var result = new List<ITextView>();
 
-            object curDocument;
-            if (ErrorHandler.Failed(monitorSelection.GetCurrentElementValue((uint)VSConstants.VSSELELEMID.SEID_DocumentFrame, out curDocument)))
+            try
             {
-                yield break;
-            }
-
-            IVsWindowFrame frame = curDocument as IVsWindowFrame;
-            if (frame == null)
-            {
-                yield break;
-            }
-
-            object docView = null;
-            if (ErrorHandler.Failed(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out docView)))
-            {
-                yield break;
-            }
-
-            if (docView is IVsDifferenceCodeWindow)
-            {
-                var diffWindow = (IVsDifferenceCodeWindow)docView;
-                
-                switch (diffWindow.DifferenceViewer.ViewMode)
+                var serviceProvider = Package;
+                var monitorSelection = (IVsMonitorSelection)serviceProvider.GetService(typeof(SVsShellMonitorSelection));
+                if (monitorSelection == null)
                 {
-                    case DifferenceViewMode.Inline:
-                        yield return diffWindow.DifferenceViewer.InlineView;
-                        break;
-                    case DifferenceViewMode.SideBySide:
-                        switch (diffWindow.DifferenceViewer.ActiveViewType)
-                        {
-                            case DifferenceViewType.LeftView:
-                                yield return diffWindow.DifferenceViewer.LeftView;
-                                yield return diffWindow.DifferenceViewer.RightView;
-                                break;
-                            case DifferenceViewType.RightView:
-                                yield return diffWindow.DifferenceViewer.RightView;
-                                yield return diffWindow.DifferenceViewer.LeftView;
-                                break;
-                        }
-                        yield return diffWindow.DifferenceViewer.LeftView;
-                        break;
-                    case DifferenceViewMode.RightViewOnly:
-                        yield return diffWindow.DifferenceViewer.RightView;
-                        break;
-                }
-            }
-            else if (docView is IVsCodeWindow)
-            {
-                IVsTextView textView;
-                if (ErrorHandler.Failed(((IVsCodeWindow)docView).GetPrimaryView(out textView)))
-                {
-                    yield break;
+                    return result;
                 }
 
-                var model = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
-                var adapterFactory = model.GetService<IVsEditorAdaptersFactoryService>();
-                var wpfTextView = adapterFactory.GetWpfTextView(textView);
-                yield return wpfTextView;
+                object curDocument;
+                if (ErrorHandler.Failed(monitorSelection.GetCurrentElementValue((uint)VSConstants.VSSELELEMID.SEID_DocumentFrame, out curDocument)))
+                {
+                    return result;
+                }
+
+                IVsWindowFrame frame = curDocument as IVsWindowFrame;
+                if (frame == null)
+                {
+                    return result;
+                }
+
+                object docView = null;
+                if (ErrorHandler.Failed(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out docView)))
+                {
+                    return result;
+                }
+
+                if (docView is IVsDifferenceCodeWindow)
+                {
+                    var diffWindow = (IVsDifferenceCodeWindow)docView;
+
+                    switch (diffWindow.DifferenceViewer.ViewMode)
+                    {
+                        case DifferenceViewMode.Inline:
+                            result.Add(diffWindow.DifferenceViewer.InlineView);
+                            break;
+                        case DifferenceViewMode.SideBySide:
+                            switch (diffWindow.DifferenceViewer.ActiveViewType)
+                            {
+                                case DifferenceViewType.LeftView:
+                                    result.Add(diffWindow.DifferenceViewer.LeftView);
+                                    result.Add(diffWindow.DifferenceViewer.RightView);
+                                    break;
+                                case DifferenceViewType.RightView:
+                                    result.Add(diffWindow.DifferenceViewer.RightView);
+                                    result.Add(diffWindow.DifferenceViewer.LeftView);
+                                    break;
+                            }
+                            result.Add(diffWindow.DifferenceViewer.LeftView);
+                            break;
+                        case DifferenceViewMode.RightViewOnly:
+                            result.Add(diffWindow.DifferenceViewer.RightView);
+                            break;
+                    }
+                }
+                else if (docView is IVsCodeWindow)
+                {
+                    IVsTextView textView;
+                    if (ErrorHandler.Failed(((IVsCodeWindow)docView).GetPrimaryView(out textView)))
+                    {
+                        return result;
+                    }
+
+                    var model = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
+                    var adapterFactory = model.GetService<IVsEditorAdaptersFactoryService>();
+                    var wpfTextView = adapterFactory.GetWpfTextView(textView);
+                    result.Add(wpfTextView);
+                }
             }
+            catch (Exception e)
+            {
+                VsOutputLogger.WriteLine("Exception in InlineCommentNavigationCommand.GetCurrentTextViews(): {0}", e);
+            }
+
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
#1163 reported an NRE in `InlineCommentNavigationCommand.GetCurrentTextViews`. I can't see anywhere obvious where this might occur, so hardened the method against exceptions and logged any errors that occur.

Fixes #1163