### PR TITLE
Add additional null check in InlineCommentTagger.GetTags.

### DIFF
--- a/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
@@ -102,7 +102,7 @@ namespace GitHub.InlineReviews.Tags
                 // Sucessful initialization will call NotifyTagsChanged, causing this method to be re-called.
                 Initialize();
             }
-            else if (file != null)
+            else if (file != null && session != null)
             {
                 foreach (var span in spans)
                 {


### PR DESCRIPTION
I don't understand how `session` can be null at this point without `file` also being null, however #1124 says this is happening, so put an extra null check for `session` in here.

Fixes #1124.