### PR TITLE
Allow null items in RepositoryGroupDescription.

### DIFF
--- a/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/RepositoryCloneControl.xaml.cs
@@ -88,11 +88,10 @@ namespace GitHub.VisualStudio.UI.Views.Controls
 
             public override object GroupNameFromItem(object item, int level, System.Globalization.CultureInfo culture)
             {
-                Guard.ArgumentNotNull(item, nameof(item));
                 Guard.ArgumentNotNull(culture, nameof(culture));
 
                 var repo = item as IRemoteRepositoryModel;
-                var name = repo.Owner;
+                var name = repo?.Owner ?? string.Empty;
                 RepositoryGroup group;
 
                 if (!owner.groups.TryGetValue(name, out group))


### PR DESCRIPTION
Not sure why, but null items are occasionally getting passed to `RepositoryGroupDescription.GroupNameFromItem`. There seems to be no consistent repro for this, so if it happens assign them to an "empty string" group and hope nothing else blows up!

Fixes #1159