### PR TITLE
Don't make temp files readonly.

### DIFF
--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -446,7 +446,6 @@ namespace GitHub.Services
 
             Directory.CreateDirectory(tempDir);
             File.WriteAllText(tempFile, contents, encoding);
-            File.SetAttributes(tempFile, FileAttributes.ReadOnly);
             return tempFile;
         }
 


### PR DESCRIPTION
It was causing problems in VS2017 with certain files (`.xaml` and `.xaml.cs` files?)

Fixes #1168