### PR TITLE
Handle inline comments in projection buffers.

### DIFF
--- a/src/GitHub.InlineReviews/InlineCommentMarginProvider.cs
+++ b/src/GitHub.InlineReviews/InlineCommentMarginProvider.cs
@@ -13,6 +13,7 @@ using GitHub.InlineReviews.Services;
 using GitHub.InlineReviews.Views;
 using GitHub.Services;
 using GitHub.Settings;
+using Microsoft.VisualStudio.Text.Projection;
 
 namespace GitHub.InlineReviews
 {
@@ -105,6 +106,18 @@ namespace GitHub.InlineReviews
                 if (inlineCommentTagger.ShowMargin)
                 {
                     return true;
+                }
+            }
+
+            var projection = buffer as IProjectionBuffer;
+            if (projection != null)
+            {
+                foreach (var source in projection.SourceBuffers)
+                {
+                    if (IsMarginVisible(source))
+                    {
+                        return true;
+                    }
                 }
             }
 

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
@@ -84,12 +84,14 @@ namespace GitHub.InlineReviews.Services
         public PullRequestTextBufferInfo GetTextBufferInfo(ITextBuffer buffer)
         {
             var projectionBuffer = buffer as IProjectionBuffer;
+            PullRequestTextBufferInfo result;
 
-            if (projectionBuffer == null)
+            if (buffer.Properties.TryGetProperty(typeof(PullRequestTextBufferInfo), out result))
             {
-                return buffer.Properties.GetProperty<PullRequestTextBufferInfo>(typeof(PullRequestTextBufferInfo), null);
+                return result;
             }
-            else
+
+            if (projectionBuffer != null)
             {
                 foreach (var sourceBuffer in projectionBuffer.SourceBuffers)
                 {

--- a/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
@@ -265,7 +265,8 @@ namespace GitHub.InlineReviews.Tags
             if (snapshot == null) return;
 
             var repository = gitService.GetRepository(session.LocalRepository.LocalPath);
-            file = await session.GetFile(relativePath, !leftHandSide ? this : null);
+            var isContentSource = !leftHandSide && !(buffer is IProjectionBuffer);
+            file = await session.GetFile(relativePath, isContentSource ? this : null);
 
             if (file == null) return;
 

--- a/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
@@ -160,7 +160,7 @@ namespace GitHub.InlineReviews.Tags
 
         void Initialize()
         {
-            document = buffer.Properties.GetProperty<ITextDocument>(typeof(ITextDocument));
+            document = TryGetDocument(buffer);
 
             if (document == null)
                 return;
@@ -193,6 +193,27 @@ namespace GitHub.InlineReviews.Tags
             }
 
             initialized = true;
+        }
+
+        static ITextDocument TryGetDocument(ITextBuffer buffer)
+        {
+            ITextDocument result;
+
+            if (buffer.Properties.TryGetProperty(typeof(ITextDocument), out result))
+                return result;
+
+            var projection = buffer as IProjectionBuffer;
+
+            if (projection != null)
+            {
+                foreach (var source in projection.SourceBuffers)
+                {
+                    if ((result = TryGetDocument(source)) != null)
+                        return result;
+                }
+            }
+
+            return null;
         }
 
         static void ForgetWithLogging(Task task)

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestDetailView.xaml.cs
@@ -26,6 +26,7 @@ using ReactiveUI;
 using Task = System.Threading.Tasks.Task;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System.Text;
+using Microsoft.VisualStudio.Text.Projection;
 
 namespace GitHub.VisualStudio.UI.Views
 {
@@ -168,6 +169,16 @@ namespace GitHub.VisualStudio.UI.Views
             buffer.Properties.GetOrCreateSingletonProperty(
                 typeof(PullRequestTextBufferInfo),
                 () => new PullRequestTextBufferInfo(session, path, isLeftBuffer));
+
+            var projection = buffer as IProjectionBuffer;
+
+            if (projection != null)
+            {
+                foreach (var source in projection.SourceBuffers)
+                {
+                    AddBufferTag(source, session, path, isLeftBuffer);
+                }
+            }
         }
 
         void ShowErrorInStatusBar(string message, Exception e)


### PR DESCRIPTION
Previously we were crashing trying to show inline comments when a projection buffer (such as a `.cshtml` file) was opened in a diff. Don't crash, and actually show inline comments.

Fixes #1186