### PR TITLE
Post comments to correct repository when on a fork.

### DIFF
--- a/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
+++ b/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
@@ -333,6 +333,10 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NLog, Version=3.1.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NLog.3.1.0.0\lib\net45\NLog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="rothko, Version=0.0.2.0, Culture=neutral, PublicKeyToken=9f664c41f503810a, processorArchitecture=MSIL">

--- a/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
@@ -86,6 +86,7 @@ namespace GitHub.InlineReviews.Services
         /// Posts a new PR review comment.
         /// </summary>
         /// <param name="repository">The repository.</param>
+        /// <param name="repositoryOwner">The owner of the repository fork to post to.</param>
         /// <param name="user">The user posting the comment.</param>
         /// <param name="number">The pull request number.</param>
         /// <param name="body">The comment body.</param>
@@ -95,6 +96,7 @@ namespace GitHub.InlineReviews.Services
         /// <returns>A model representing the posted comment.</returns>
         Task<IPullRequestReviewCommentModel> PostReviewComment(
             ILocalRepositoryModel repository,
+            string repositoryOwner,
             IAccount user,
             int number,
             string body,
@@ -106,6 +108,7 @@ namespace GitHub.InlineReviews.Services
         /// Posts a PR review comment reply.
         /// </summary>
         /// <param name="repository">The repository.</param>
+        /// <param name="repositoryOwner">The owner of the repository fork to post to.</param>
         /// <param name="user">The user posting the comment.</param>
         /// <param name="number">The pull request number.</param>
         /// <param name="body">The comment body.</param>
@@ -113,6 +116,7 @@ namespace GitHub.InlineReviews.Services
         /// <returns>A model representing the posted comment.</returns>
         Task<IPullRequestReviewCommentModel> PostReviewComment(
             ILocalRepositoryModel repository,
+            string repositoryOwner,
             IAccount user,
             int number,
             string body,

--- a/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
@@ -85,8 +85,8 @@ namespace GitHub.InlineReviews.Services
         /// <summary>
         /// Posts a new PR review comment.
         /// </summary>
-        /// <param name="repository">The repository.</param>
-        /// <param name="repositoryOwner">The owner of the repository fork to post to.</param>
+        /// <param name="localRepository">The local repository.</param>
+        /// <param name="remoteRepositoryOwner">The owner of the repository fork to post to.</param>
         /// <param name="user">The user posting the comment.</param>
         /// <param name="number">The pull request number.</param>
         /// <param name="body">The comment body.</param>
@@ -95,8 +95,8 @@ namespace GitHub.InlineReviews.Services
         /// <param name="position">The line index in the diff to comment on.</param>
         /// <returns>A model representing the posted comment.</returns>
         Task<IPullRequestReviewCommentModel> PostReviewComment(
-            ILocalRepositoryModel repository,
-            string repositoryOwner,
+            ILocalRepositoryModel localRepository,
+            string remoteRepositoryOwner,
             IAccount user,
             int number,
             string body,
@@ -107,16 +107,16 @@ namespace GitHub.InlineReviews.Services
         /// <summary>
         /// Posts a PR review comment reply.
         /// </summary>
-        /// <param name="repository">The repository.</param>
-        /// <param name="repositoryOwner">The owner of the repository fork to post to.</param>
+        /// <param name="localRepository">The local repository.</param>
+        /// <param name="remoteRepositoryOwner">The owner of the repository fork to post to.</param>
         /// <param name="user">The user posting the comment.</param>
         /// <param name="number">The pull request number.</param>
         /// <param name="body">The comment body.</param>
         /// <param name="inReplyTo">The comment ID to reply to.</param>
         /// <returns>A model representing the posted comment.</returns>
         Task<IPullRequestReviewCommentModel> PostReviewComment(
-            ILocalRepositoryModel repository,
-            string repositoryOwner,
+            ILocalRepositoryModel localRepository,
+            string remoteRepositoryOwner,
             IAccount user,
             int number,
             string body,

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -121,6 +121,7 @@ namespace GitHub.InlineReviews.Services
         {
             var model = await service.PostReviewComment(
                 LocalRepository,
+                RepositoryOwner,
                 User,
                 PullRequest.Number,
                 body,
@@ -136,6 +137,7 @@ namespace GitHub.InlineReviews.Services
         {
             var model = await service.PostReviewComment(
                 LocalRepository,
+                RepositoryOwner,
                 User,
                 PullRequest.Number,
                 body,

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -138,6 +138,7 @@ namespace GitHub.InlineReviews.Services
         /// <inheritdoc/>
         public async Task<IPullRequestReviewCommentModel> PostReviewComment(
             ILocalRepositoryModel repository,
+            string repositoryOwner,
             IAccount user,
             int number,
             string body,
@@ -149,7 +150,7 @@ namespace GitHub.InlineReviews.Services
             var apiClient = await apiClientFactory.Create(address);
 
             var result = await apiClient.CreatePullRequestReviewComment(
-                repository.Owner,
+                repositoryOwner,
                 repository.Name,
                 number,
                 body,
@@ -177,6 +178,7 @@ namespace GitHub.InlineReviews.Services
         /// <inheritdoc/>
         public async Task<IPullRequestReviewCommentModel> PostReviewComment(
             ILocalRepositoryModel repository,
+            string repositoryOwner,
             IAccount user,
             int number,
             string body,
@@ -186,7 +188,7 @@ namespace GitHub.InlineReviews.Services
             var apiClient = await apiClientFactory.Create(address);
 
             var result = await apiClient.CreatePullRequestReviewComment(
-                repository.Owner,
+                repositoryOwner,
                 repository.Name,
                 number,
                 body,

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -137,8 +137,8 @@ namespace GitHub.InlineReviews.Services
 
         /// <inheritdoc/>
         public async Task<IPullRequestReviewCommentModel> PostReviewComment(
-            ILocalRepositoryModel repository,
-            string repositoryOwner,
+            ILocalRepositoryModel localRepository,
+            string remoteRepositoryOwner,
             IAccount user,
             int number,
             string body,
@@ -146,12 +146,12 @@ namespace GitHub.InlineReviews.Services
             string path,
             int position)
         {
-            var address = HostAddress.Create(repository.CloneUrl.Host);
+            var address = HostAddress.Create(localRepository.CloneUrl.Host);
             var apiClient = await apiClientFactory.Create(address);
 
             var result = await apiClient.CreatePullRequestReviewComment(
-                repositoryOwner,
-                repository.Name,
+                remoteRepositoryOwner,
+                localRepository.Name,
                 number,
                 body,
                 commitId,
@@ -177,19 +177,19 @@ namespace GitHub.InlineReviews.Services
 
         /// <inheritdoc/>
         public async Task<IPullRequestReviewCommentModel> PostReviewComment(
-            ILocalRepositoryModel repository,
-            string repositoryOwner,
+            ILocalRepositoryModel localRepository,
+            string remoteRepositoryOwner,
             IAccount user,
             int number,
             string body,
             int inReplyTo)
         {
-            var address = HostAddress.Create(repository.CloneUrl.Host);
+            var address = HostAddress.Create(localRepository.CloneUrl.Host);
             var apiClient = await apiClientFactory.Create(address);
 
             var result = await apiClient.CreatePullRequestReviewComment(
-                repositoryOwner,
-                repository.Name,
+                remoteRepositoryOwner,
+                localRepository.Name,
                 number,
                 body,
                 inReplyTo);

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -9,6 +9,7 @@ using GitHub.Models;
 using GitHub.Primitives;
 using GitHub.Services;
 using LibGit2Sharp;
+using NLog;
 
 namespace GitHub.InlineReviews.Services
 {

--- a/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using GitHub.Extensions;
 using GitHub.Models;
 using GitHub.UI;
+using NLog;
 using Octokit;
 using ReactiveUI;
 
@@ -17,6 +18,7 @@ namespace GitHub.InlineReviews.ViewModels
     /// </summary>
     public class CommentViewModel : ReactiveObject, ICommentViewModel
     {
+        static readonly Logger log = LogManager.GetCurrentClassLogger();
         string body;
         string errorMessage;
         bool isReadOnly;
@@ -167,6 +169,7 @@ namespace GitHub.InlineReviews.ViewModels
                 }
 
                 ErrorMessage = message;
+                log.Error("Error posting inline comment.", e);
             }
         }
 

--- a/src/GitHub.InlineReviews/packages.config
+++ b/src/GitHub.InlineReviews/packages.config
@@ -30,6 +30,7 @@
   <package id="Microsoft.VisualStudio.Utilities" version="14.3.25407" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net452" />
   <package id="Microsoft.VSSDK.BuildTools" version="14.3.25407" targetFramework="net452" developmentDependency="true" />
+  <package id="NLog" version="3.1.0.0" targetFramework="net461" />
   <package id="Rothko" version="0.0.2-ghfvs" targetFramework="net461" />
   <package id="Rx-Core" version="2.2.5-custom" targetFramework="net461" />
   <package id="Rx-Interfaces" version="2.2.5-custom" targetFramework="net461" />


### PR DESCRIPTION
If the user had a forked repo checked out and was viewing the parent repo's PRs, posting a comment was erroneously trying to post the comment to the _fork_ repo, resulting in a "Not Found" exception.

Fixes #1195.