### PR TITLE
Write to log when error is shown in PR detail view

### DIFF
--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -98,7 +98,7 @@ namespace GitHub.Services
                     var remote = repository.Network.Remotes[remoteName];
                     repository.Network.Fetch(remote, refspecs, fetchOptions);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     log.Error("Failed to fetch", ex);
 #if DEBUG
@@ -394,7 +394,7 @@ namespace GitHub.Services
                 baseCommit = repo.Lookup<Commit>(baseSha);
                 if (baseCommit == null)
                 {
-                    return null;
+                    throw new NotFoundException($"Couldn't find {baseSha} after fetching from {baseCloneUrl}:{baseRef}.");
                 }
             }
 
@@ -405,14 +405,14 @@ namespace GitHub.Services
                 headCommit = repo.Lookup<Commit>(headSha);
                 if (headCommit == null)
                 {
-                    return null;
+                    throw new NotFoundException($"Couldn't find {headSha} after fetching from {headCloneUrl}:{headRef}.");
                 }
             }
 
             var mergeBaseCommit = repo.ObjectDatabase.FindMergeBase(baseCommit, headCommit);
-            if(mergeBaseCommit == null)
+            if (mergeBaseCommit == null)
             {
-                return null;
+                throw new NotFoundException($"Couldn't find merge base between {baseCommit} and {headCommit}.");
             }
 
             return mergeBaseCommit.Sha;

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -321,7 +321,7 @@ namespace GitHub.Services
                     }
                     catch (NotFoundException ex)
                     {
-                        throw new NotFoundException($"The Pull Request file failed to load. Please check your network connection and click refresh to try again.", ex);
+                        throw new NotFoundException($"The Pull Request file failed to load. Please check your network connection and click refresh to try again. If this issue persists, please let us know at support@github.com", ex);
                     }
                 }
 

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -316,11 +316,6 @@ namespace GitHub.Services
                         pullRequest.Head.Sha,
                         pullRequest.Base.Ref,
                         pullRequest.Head.Ref);
-
-                    if (sha == null)
-                    {
-                        throw new NotFoundException($"Couldn't find merge base between {pullRequest.Base.Sha} and {pullRequest.Head.Sha}.");
-                    }
                 }
 
                 var file = await ExtractToTempFile(repo, pullRequest.Number, sha, fileName, encoding);
@@ -350,7 +345,7 @@ namespace GitHub.Services
             {
                 foreach (var b in encoding.GetPreamble())
                 {
-                    if(b != stream.ReadByte())
+                    if (b != stream.ReadByte())
                     {
                         return false;
                     }
@@ -473,7 +468,7 @@ namespace GitHub.Services
         {
             var prConfigKey = $"branch.{branchName}.{SettingGHfVSPullRequest}";
             var value = ParseGHfVSConfigKeyValue(await gitClient.GetConfig<string>(repo, prConfigKey));
-            return value != null && 
+            return value != null &&
                 value.Item1 == pullRequest.Base.RepositoryCloneUrl.Owner &&
                 value.Item2 == pullRequest.Number;
         }

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -308,14 +308,21 @@ namespace GitHub.Services
                 }
                 else
                 {
-                    sha = await gitClient.GetPullRequestMergeBase(
-                        repo,
-                        pullRequest.Base.RepositoryCloneUrl,
-                        pullRequest.Head.RepositoryCloneUrl,
-                        pullRequest.Base.Sha,
-                        pullRequest.Head.Sha,
-                        pullRequest.Base.Ref,
-                        pullRequest.Head.Ref);
+                    try
+                    {
+                        sha = await gitClient.GetPullRequestMergeBase(
+                            repo,
+                            pullRequest.Base.RepositoryCloneUrl,
+                            pullRequest.Head.RepositoryCloneUrl,
+                            pullRequest.Base.Sha,
+                            pullRequest.Head.Sha,
+                            pullRequest.Base.Ref,
+                            pullRequest.Head.Ref);
+                    }
+                    catch (NotFoundException ex)
+                    {
+                        throw new NotFoundException($"Couldn't find merge base. Please check your network connection and try again.", ex);
+                    }
                 }
 
                 var file = await ExtractToTempFile(repo, pullRequest.Number, sha, fileName, encoding);

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -321,7 +321,7 @@ namespace GitHub.Services
                     }
                     catch (NotFoundException ex)
                     {
-                        throw new NotFoundException($"Couldn't find merge base. Please check your network connection and try again.", ex);
+                        throw new NotFoundException($"The Pull Request file failed to load. Please check your network connection and click refresh to try again.", ex);
                     }
                 }
 

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -16,6 +16,7 @@ using GitHub.Services;
 using GitHub.UI;
 using LibGit2Sharp;
 using ReactiveUI;
+using NLog;
 
 namespace GitHub.ViewModels
 {
@@ -26,6 +27,8 @@ namespace GitHub.ViewModels
     [PartCreationPolicy(CreationPolicy.NonShared)]
     public class PullRequestDetailViewModel : PanePageViewModelBase, IPullRequestDetailViewModel
     {
+        static readonly Logger log = LogManager.GetCurrentClassLogger();
+
         readonly IModelService modelService;
         readonly IPullRequestService pullRequestsService;
         readonly IPullRequestSessionManager sessionManager;
@@ -93,7 +96,7 @@ namespace GitHub.ViewModels
             Checkout = ReactiveCommand.CreateAsyncObservable(
                 this.WhenAnyValue(x => x.CheckoutState)
                     .Cast<CheckoutCommandState>()
-                    .Select(x => x != null && x.IsEnabled), 
+                    .Select(x => x != null && x.IsEnabled),
                 DoCheckout);
             Checkout.IsExecuting.Subscribe(x => isInCheckout = x);
             SubscribeOperationError(Checkout);
@@ -351,6 +354,7 @@ namespace GitHub.ViewModels
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Catch<IPullRequestModel, Exception>(ex =>
                 {
+                    log.Error("Error observing GetPullRequest", ex);
                     ErrorMessage = ex.Message.Trim();
                     IsLoading = IsBusy = false;
                     return Observable.Empty<IPullRequestModel>();
@@ -460,6 +464,7 @@ namespace GitHub.ViewModels
             }
             catch (Exception ex)
             {
+                log.Error("Error loading PullRequestModel", ex);
                 ErrorMessage = ex.Message.Trim();
             }
             finally

--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -197,6 +197,7 @@ namespace GitHub.Services
         /// <returns>
         /// The merge base SHA or null.
         /// </returns>
+        /// <exception cref="LibGit2Sharp.NotFoundException">Thrown when the merge base can't be found.</exception>
         Task<string> GetPullRequestMergeBase(IRepository repo, UriString baseCloneUrl, UriString headCloneUrl, string baseSha, string headSha, string baseRef, string headRef);
 
         /// Checks whether the current head is pushed to its remote tracking branch.

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -127,12 +127,8 @@ namespace GitHub.InlineReviews.Services
             var baseRef = pullRequest.Base.Ref;
             var headRef = pullRequest.Head.Ref;
             mergeBase = await gitClient.GetPullRequestMergeBase(repo, baseUrl, headUrl, baseSha, headSha, baseRef, headRef);
-            if (mergeBase != null)
-            {
-                return mergeBaseCache[key] = mergeBase;
-            }
 
-            throw new FileNotFoundException($"Couldn't find merge base between {baseSha} and {headSha}.");
+            return mergeBaseCache[key] = mergeBase;
         }
 
         /// <inheritdoc/>

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -132,7 +132,7 @@ namespace GitHub.InlineReviews.Services
             }
             catch (NotFoundException ex)
             {
-                throw new NotFoundException("Couldn't find merge base. Please check your network connection and try again.", ex);
+                throw new NotFoundException("The Pull Request failed to load. Please check your network connection and click refresh to try again.", ex);
             }
 
             return mergeBaseCache[key] = mergeBase;

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -132,7 +132,7 @@ namespace GitHub.InlineReviews.Services
             }
             catch (NotFoundException ex)
             {
-                throw new NotFoundException("The Pull Request failed to load. Please check your network connection and click refresh to try again.", ex);
+                throw new NotFoundException("The Pull Request failed to load. Please check your network connection and click refresh to try again. If this issue persists, please let us know at support@github.com", ex);
             }
 
             return mergeBaseCache[key] = mergeBase;

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -126,7 +126,14 @@ namespace GitHub.InlineReviews.Services
             var headUrl = pullRequest.Head.RepositoryCloneUrl;
             var baseRef = pullRequest.Base.Ref;
             var headRef = pullRequest.Head.Ref;
-            mergeBase = await gitClient.GetPullRequestMergeBase(repo, baseUrl, headUrl, baseSha, headSha, baseRef, headRef);
+            try
+            {
+                mergeBase = await gitClient.GetPullRequestMergeBase(repo, baseUrl, headUrl, baseSha, headSha, baseRef, headRef);
+            }
+            catch (NotFoundException ex)
+            {
+                throw new NotFoundException("Couldn't find merge base. Please check your network connection and try again.", ex);
+            }
 
             return mergeBaseCache[key] = mergeBase;
         }

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -115,7 +115,7 @@ namespace GitHub.InlineReviews.Services
             var key = new Tuple<string, string>(baseSha, headSha);
 
             string mergeBase;
-            if(mergeBaseCache.TryGetValue(key, out mergeBase))
+            if (mergeBaseCache.TryGetValue(key, out mergeBase))
             {
                 return mergeBase;
             }
@@ -123,7 +123,6 @@ namespace GitHub.InlineReviews.Services
             var repo = await GetRepository(repository);
             var baseUrl = pullRequest.Base.RepositoryCloneUrl;
             var headUrl = pullRequest.Head.RepositoryCloneUrl;
-            var headCloneUrl = pullRequest.Head.RepositoryCloneUrl;
             var baseRef = pullRequest.Base.Ref;
             var headRef = pullRequest.Head.Ref;
             mergeBase = await gitClient.GetPullRequestMergeBase(repo, baseUrl, headUrl, baseSha, headSha, baseRef, headRef);

--- a/src/UnitTests/GitHub.App/Services/GitClientTests.cs
+++ b/src/UnitTests/GitHub.App/Services/GitClientTests.cs
@@ -54,7 +54,7 @@ public class GitClientTests
 
             await gitClient.Push(repository, "master", "origin");
 
-            repository.Network.Received().Push(origin,"HEAD", @"refs/heads/master", Arg.Any<PushOptions>());
+            repository.Network.Received().Push(origin, "HEAD", @"refs/heads/master", Arg.Any<PushOptions>());
         }
 
         [Fact]
@@ -194,7 +194,11 @@ public class GitClientTests
             repo.Network.Remotes.Add(null, null).ReturnsForAnyArgs(remote);
             var gitClient = new GitClient(Substitute.For<IGitHubCredentialProvider>());
 
-            await gitClient.GetPullRequestMergeBase(repo, baseUri, headUri, baseSha, headSha, baseRef, headRef);
+            try
+            {
+                await gitClient.GetPullRequestMergeBase(repo, baseUri, headUri, baseSha, headSha, baseRef, headRef);
+            }
+            catch (NotFoundException) { }
 
             repo.Network.Received(receivedFetch).Fetch(Arg.Any<Remote>(), Arg.Any<string[]>(), Arg.Any<FetchOptions>());
         }
@@ -210,7 +214,11 @@ public class GitClientTests
             var headUrl = new UriString("https://github.com/owner/repo");
             var gitClient = new GitClient(Substitute.For<IGitHubCredentialProvider>());
 
-            await gitClient.GetPullRequestMergeBase(repo, baseUrl, headUrl, baseSha, headSha, baseRef, headRef);
+            try
+            {
+                await gitClient.GetPullRequestMergeBase(repo, baseUrl, headUrl, baseSha, headSha, baseRef, headRef);
+            }
+            catch (NotFoundException) { }
 
             repo.Network.Received(1).Fetch(Arg.Any<Remote>(), Arg.Is<IEnumerable<string>>(x => x.Contains(expectRefSpec)), Arg.Any<FetchOptions>());
         }

--- a/src/UnitTests/GitHub.App/Services/GitClientTests.cs
+++ b/src/UnitTests/GitHub.App/Services/GitClientTests.cs
@@ -198,7 +198,7 @@ public class GitClientTests
             {
                 await gitClient.GetPullRequestMergeBase(repo, baseUri, headUri, baseSha, headSha, baseRef, headRef);
             }
-            catch (NotFoundException) { }
+            catch (NotFoundException) { /* We're interested in calls to Fetch even if it throws */ }
 
             repo.Network.Received(receivedFetch).Fetch(Arg.Any<Remote>(), Arg.Any<string[]>(), Arg.Any<FetchOptions>());
         }
@@ -218,7 +218,7 @@ public class GitClientTests
             {
                 await gitClient.GetPullRequestMergeBase(repo, baseUrl, headUrl, baseSha, headSha, baseRef, headRef);
             }
-            catch (NotFoundException) { }
+            catch (NotFoundException) { /* We're interested in calls to Fetch even if it throws */ }
 
             repo.Network.Received(1).Fetch(Arg.Any<Remote>(), Arg.Is<IEnumerable<string>>(x => x.Contains(expectRefSpec)), Arg.Any<FetchOptions>());
         }

--- a/src/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
+++ b/src/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
@@ -54,7 +54,7 @@ public class PullRequestServiceTests : TestBaseClass
         }
 
         [Fact]
-        public async void MergeBaseNotAvailable_ThrowsFileNotFoundException()
+        public async void MergeBaseNotAvailable_ThrowsNotFoundException()
         {
             var baseFileContent = "baseFileContent";
             var headFileContent = "headFileContent";
@@ -64,7 +64,7 @@ public class PullRequestServiceTests : TestBaseClass
             var headSha = "headSha";
             var mergeBaseSha = null as string;
             var head = false;
-            var expectMessage = $"Couldn't find merge base between {baseSha} and {headSha}.";
+            var expectMessage = $"Couldn't find merge base. Please check your network connection and try again.";
             var mergeBaseException = new NotFoundException(expectMessage);
 
             var ex = await Assert.ThrowsAsync<NotFoundException>(() => ExtractFile(baseSha, baseFileContent, headSha, headFileContent, mergeBaseSha, mergeBaseFileContent,

--- a/src/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
+++ b/src/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
@@ -64,12 +64,10 @@ public class PullRequestServiceTests : TestBaseClass
             var headSha = "headSha";
             var mergeBaseSha = null as string;
             var head = false;
-            var expectMessage = $"Couldn't find merge base. Please check your network connection and try again.";
-            var mergeBaseException = new NotFoundException(expectMessage);
+            var mergeBaseException = new NotFoundException();
 
             var ex = await Assert.ThrowsAsync<NotFoundException>(() => ExtractFile(baseSha, baseFileContent, headSha, headFileContent, mergeBaseSha, mergeBaseFileContent,
                                 fileName, head, Encoding.UTF8, mergeBaseException: mergeBaseException));
-            Assert.Equal(expectMessage, ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
These commits were originally intended to help track down the 'Couldn't find merge base' issue #1190. This issue hasn't been resolved yet, but I think having the extra logging and exception detail will be useful stand alone.

When the following error is displayed, the exception detail will also be written to the log.
![couldnt find merge base](https://user-images.githubusercontent.com/10103121/29629911-510b1fce-87ef-11e7-8977-6e9c81d3f5fa.png)