### PR TITLE
Don't statically cache InUnitTestRunner.

### DIFF
--- a/src/GitHub.Extensions/Guard.cs
+++ b/src/GitHub.Extensions/Guard.cs
@@ -60,6 +60,6 @@ namespace GitHub.Extensions
 
         // Borrowed from Splat.
 
-        public static bool InUnitTestRunner { get; } = Splat.ModeDetector.InUnitTestRunner();
+        public static bool InUnitTestRunner => Splat.ModeDetector.InUnitTestRunner();
     }
 }


### PR DESCRIPTION
This was causing random test failures.

Fixes #1136