### PR TITLE
Open PR link to the selected (not active) repo on GitHub

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestListViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestListViewModelDesigner.cs
@@ -34,7 +34,7 @@ namespace GitHub.SampleData
                 Assignee = new AccountDesigner { Login = "haacked", IsUser = true },
             });
             prs.Add(new PullRequestModel(409, "Fix publish button style and a really, really long name for this thing... OMG look how long this name is yusssss",
-                new AccountDesigner { Login = "shana", IsUser = true },                
+                new AccountDesigner { Login = "shana", IsUser = true },
                 DateTimeOffset.Now - TimeSpan.FromHours(5))
             {
                 CommentCount = 27,
@@ -76,5 +76,6 @@ namespace GitHub.SampleData
 
         public ReactiveCommand<object> OpenPullRequest { get; }
         public ReactiveCommand<object> CreatePullRequest { get; }
+        public ReactiveCommand<object> OpenPROnGitHub { get; }
     }
 }

--- a/src/GitHub.App/SampleData/PullRequestListViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestListViewModelDesigner.cs
@@ -76,6 +76,6 @@ namespace GitHub.SampleData
 
         public ReactiveCommand<object> OpenPullRequest { get; }
         public ReactiveCommand<object> CreatePullRequest { get; }
-        public ReactiveCommand<object> OpenPROnGitHub { get; }
+        public ReactiveCommand<object> OpenPullRequestOnGitHub { get; }
     }
 }

--- a/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
@@ -114,7 +114,7 @@ namespace GitHub.ViewModels
 
             OpenPROnGitHub = new RelayCommand(x =>
             {
-                var repo = serviceProvider.TryGetService<ITeamExplorerServiceHolder>()?.ActiveRepo;
+                var repo = SelectedRepository;
                 var browser = serviceProvider.TryGetService<IVisualStudioBrowser>();
                 Debug.Assert(repo != null, "No active repo, cannot open PR on GitHub");
                 Debug.Assert(browser != null, "No browser service, cannot open PR on GitHub");

--- a/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -346,16 +345,10 @@ namespace GitHub.ViewModels
 
         void DoOpenPROnGitHub(int pullRequest)
         {
-            var repo = SelectedRepository;
             var browser = serviceProvider.TryGetService<IVisualStudioBrowser>();
-            Debug.Assert(repo != null, "No active repo, cannot open PR on GitHub");
-            Debug.Assert(browser != null, "No browser service, cannot open PR on GitHub");
-            if (repo == null || browser == null)
-            {
-                return;
-            }
-            var url = repo.CloneUrl.ToRepositoryUrl().Append("pull/" + pullRequest);
-            browser.OpenUrl(url);
+            var repoUrl = SelectedRepository.CloneUrl.ToRepositoryUrl();
+            var url = repoUrl.Append("pull/" + pullRequest);
+            browser?.OpenUrl(url);
         }
     }
 }

--- a/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
@@ -31,7 +31,7 @@ namespace GitHub.ViewModels
         readonly TrackingCollection<IAccount> trackingAuthors;
         readonly TrackingCollection<IAccount> trackingAssignees;
         readonly IPackageSettings settings;
-        readonly IGitHubServiceProvider serviceProvider;
+        readonly IVisualStudioBrowser visualStudioBrowser;
         readonly PullRequestListUIState listSettings;
         readonly bool constructing;
         IRemoteRepositoryModel remoteRepository;
@@ -41,8 +41,8 @@ namespace GitHub.ViewModels
             IConnectionRepositoryHostMap connectionRepositoryHostMap,
             ITeamExplorerServiceHolder teservice,
             IPackageSettings settings,
-            IGitHubServiceProvider serviceProvider)
-            : this(connectionRepositoryHostMap.CurrentRepositoryHost, teservice.ActiveRepo, settings, serviceProvider)
+            IVisualStudioBrowser visualStudioBrowser)
+            : this(connectionRepositoryHostMap.CurrentRepositoryHost, teservice.ActiveRepo, settings, visualStudioBrowser)
         {
             Guard.ArgumentNotNull(connectionRepositoryHostMap, nameof(connectionRepositoryHostMap));
             Guard.ArgumentNotNull(teservice, nameof(teservice));
@@ -53,7 +53,7 @@ namespace GitHub.ViewModels
             IRepositoryHost repositoryHost,
             ILocalRepositoryModel repository,
             IPackageSettings settings,
-            IGitHubServiceProvider serviceProvider)
+            IVisualStudioBrowser visualStudioBrowser)
         {
             Guard.ArgumentNotNull(repositoryHost, nameof(repositoryHost));
             Guard.ArgumentNotNull(repository, nameof(repository));
@@ -63,7 +63,7 @@ namespace GitHub.ViewModels
             this.repositoryHost = repositoryHost;
             this.localRepository = repository;
             this.settings = settings;
-            this.serviceProvider = serviceProvider;
+            this.visualStudioBrowser = visualStudioBrowser;
 
             Title = Resources.PullRequestsNavigationItemText;
 
@@ -345,10 +345,9 @@ namespace GitHub.ViewModels
 
         void DoOpenPROnGitHub(int pullRequest)
         {
-            var browser = serviceProvider.TryGetService<IVisualStudioBrowser>();
             var repoUrl = SelectedRepository.CloneUrl.ToRepositoryUrl();
             var url = repoUrl.Append("pull/" + pullRequest);
-            browser?.OpenUrl(url);
+            visualStudioBrowser.OpenUrl(url);
         }
     }
 }

--- a/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
@@ -112,8 +112,8 @@ namespace GitHub.ViewModels
             CreatePullRequest = ReactiveCommand.Create();
             CreatePullRequest.Subscribe(_ => DoCreatePullRequest());
 
-            OpenPROnGitHub = ReactiveCommand.Create();
-            OpenPROnGitHub.Subscribe(x => DoOpenPROnGitHub((int)x));
+            OpenPullRequestOnGitHub = ReactiveCommand.Create();
+            OpenPullRequestOnGitHub.Subscribe(x => DoOpenPROnGitHub((int)x));
 
             constructing = false;
         }
@@ -276,7 +276,7 @@ namespace GitHub.ViewModels
         public ReactiveCommand<object> OpenPullRequest { get; }
         public ReactiveCommand<object> CreatePullRequest { get; }
 
-        public ReactiveCommand<object> OpenPROnGitHub { get; }
+        public ReactiveCommand<object> OpenPullRequestOnGitHub { get; }
 
         bool disposed;
         protected void Dispose(bool disposing)

--- a/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
@@ -58,6 +58,7 @@ namespace GitHub.ViewModels
             Guard.ArgumentNotNull(repositoryHost, nameof(repositoryHost));
             Guard.ArgumentNotNull(repository, nameof(repository));
             Guard.ArgumentNotNull(settings, nameof(settings));
+            Guard.ArgumentNotNull(visualStudioBrowser, nameof(visualStudioBrowser));
 
             constructing = true;
             this.repositoryHost = repositoryHost;

--- a/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestListViewModel.cs
@@ -113,7 +113,7 @@ namespace GitHub.ViewModels
             CreatePullRequest.Subscribe(_ => DoCreatePullRequest());
 
             OpenPullRequestOnGitHub = ReactiveCommand.Create();
-            OpenPullRequestOnGitHub.Subscribe(x => DoOpenPROnGitHub((int)x));
+            OpenPullRequestOnGitHub.Subscribe(x => DoOpenPullRequestOnGitHub((int)x));
 
             constructing = false;
         }
@@ -344,7 +344,7 @@ namespace GitHub.ViewModels
             navigate.OnNext(d);
         }
 
-        void DoOpenPROnGitHub(int pullRequest)
+        void DoOpenPullRequestOnGitHub(int pullRequest)
         {
             var repoUrl = SelectedRepository.CloneUrl.ToRepositoryUrl();
             var url = repoUrl.Append("pull/" + pullRequest);

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestListViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestListViewModel.cs
@@ -41,5 +41,6 @@ namespace GitHub.ViewModels
         IAccount SelectedAssignee { get; set; }
         ReactiveCommand<object> OpenPullRequest { get; }
         ReactiveCommand<object> CreatePullRequest { get; }
+        ReactiveCommand<object> OpenPROnGitHub { get; }
     }
 }

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestListViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestListViewModel.cs
@@ -41,6 +41,6 @@ namespace GitHub.ViewModels
         IAccount SelectedAssignee { get; set; }
         ReactiveCommand<object> OpenPullRequest { get; }
         ReactiveCommand<object> CreatePullRequest { get; }
-        ReactiveCommand<object> OpenPROnGitHub { get; }
+        ReactiveCommand<object> OpenPullRequestOnGitHub { get; }
     }
 }

--- a/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
@@ -9,47 +9,47 @@
                     xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
                     xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI">
 
-    <ResourceDictionary.MergedDictionaries>
-        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml"/>
-        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
-    </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml"/>
+    <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+  </ResourceDictionary.MergedDictionaries>
+  
+  <DataTemplate x:Key="PullRequestItemTemplate" DataType="models:IPullRequestModel">
+    <Grid>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="Auto" />
+      </Grid.RowDefinitions>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+        <ColumnDefinition Width="12" />
+        <ColumnDefinition Width="11" />
+      </Grid.ColumnDefinitions>
 
-    <DataTemplate x:Key="PullRequestItemTemplate" DataType="models:IPullRequestModel">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="12" />
-                <ColumnDefinition Width="11" />
-            </Grid.ColumnDefinitions>
-
-            <Grid 
+      <Grid 
           Grid.Row="0"
           Grid.RowSpan="2"
           Grid.Column="0"
           VerticalAlignment="Top">
 
-                <Border Name="avatarMask" Background="White" CornerRadius="3" Width="20" />
+          <Border Name="avatarMask" Background="White" CornerRadius="3" Width="20" />
 
-                <StackPanel>
-                    <StackPanel.OpacityMask>
-                        <VisualBrush Visual="{Binding ElementName=avatarMask}" />
-                    </StackPanel.OpacityMask>
-                    <Image x:Name="avatar"
+          <StackPanel>
+              <StackPanel.OpacityMask>
+                  <VisualBrush Visual="{Binding ElementName=avatarMask}" />
+              </StackPanel.OpacityMask>
+              <Image x:Name="avatar"
                      Width="30"
                      Margin="0,0,10,0"
                      Height="30"
                      RenderOptions.BitmapScalingMode="HighQuality"
                      Source="{Binding Author.Avatar}" />
-                </StackPanel>
-            </Grid>
+          </StackPanel>
+      </Grid>
 
-            <ui:GitHubActionLink x:Name="title"
+      <ui:GitHubActionLink x:Name="title"
             Grid.Row="0"
             Grid.Column="1"
             HorizontalAlignment="Left"
@@ -61,8 +61,8 @@
             ToolTip="{Binding Title}"
             Command="{Binding ViewModel.OpenPullRequest, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"
             CommandParameter="{Binding Number}"/>
-
-            <ui:OcticonImage x:Name="comment_icon"
+        
+        <ui:OcticonImage x:Name="comment_icon"
                    Grid.Row="0"
                    Grid.RowSpan="2"
                    Grid.Column="2"
@@ -74,7 +74,7 @@
                    Foreground="{DynamicResource GitHubVsToolWindowText}"
                    Visibility="{Binding CommentCount, Converter={ui:CountToVisibilityConverter}}" />
 
-            <TextBlock x:Name="comment_count"
+      <TextBlock x:Name="comment_count"
                  Grid.Row="0"
                  Grid.RowSpan="2"
                  Grid.Column="3"
@@ -85,7 +85,7 @@
                  Text="{Binding CommentCount}"
                  Visibility="{Binding CommentCount, Converter={ui:CountToVisibilityConverter}}" />
 
-            <ui:OcticonImage x:Name="comment_new"
+      <ui:OcticonImage x:Name="comment_new"
                        Grid.Row="0"
                        Grid.RowSpan="2"
                        Grid.Column="4"
@@ -97,16 +97,16 @@
                        Foreground="Green"
                        Icon="primitive_dot"
                        Visibility="{Binding HasNewComments, Converter={ui:BooleanToVisibilityConverter}}" />
-            <Grid x:Name="status"
+      <Grid x:Name="status"
             Grid.Row="1"
             Grid.Column="1"
             HorizontalAlignment="Left"
             VerticalAlignment="Top">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <Button x:Name="prHashtagLink"
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Button x:Name="prHashtagLink"
                 Grid.Column="0"
                 Command="{Binding ViewModel.OpenPROnGitHub, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"
                 CommandParameter="{Binding Number}"
@@ -114,36 +114,36 @@
                 ToolTip="{x:Static prop:Resources.OpenPROnGitHubToolTip}"
                 FontFamily="Segoe UI"
                 Style="{StaticResource HashtagActionLink}" />
-                <TextBlock x:Name="description"
+        <TextBlock x:Name="description"
                    Grid.Column="1"
                    FontFamily="Segoe UI"
                    Margin="0,0,10,0"
                    TextTrimming="CharacterEllipsis"
                    Foreground="{DynamicResource GitHubVsGrayText}">
+          <TextBlock.Text>
+            <MultiBinding StringFormat="{} {0} {1} {2}">
+              <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
+              <Binding Source="{x:Static i18n:Resources.prUpdatedByText}" />
+              <Binding Path="Author.Login" />
+            </MultiBinding>
+          </TextBlock.Text>
+
+          <TextBlock.ToolTip>
+            <ToolTip>
+                <TextBlock>
                     <TextBlock.Text>
-                        <MultiBinding StringFormat="{} {0} {1} {2}">
-                            <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
-                            <Binding Source="{x:Static i18n:Resources.prUpdatedByText}" />
-                            <Binding Path="Author.Login" />
+                       <MultiBinding StringFormat="{} {0} {1} {2} {3}">
+                          <Binding Source="{x:Static i18n:Resources.prUpdatedText}" />
+                          <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
+                          <Binding Source="{x:Static i18n:Resources.prUpdatedByText}" />
+                          <Binding Path="Author.Login" />
                         </MultiBinding>
                     </TextBlock.Text>
-
-                    <TextBlock.ToolTip>
-                        <ToolTip>
-                            <TextBlock>
-                                <TextBlock.Text>
-                                    <MultiBinding StringFormat="{} {0} {1} {2} {3}">
-                                        <Binding Source="{x:Static i18n:Resources.prUpdatedText}" />
-                                        <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
-                                        <Binding Source="{x:Static i18n:Resources.prUpdatedByText}" />
-                                        <Binding Path="Author.Login" />
-                                    </MultiBinding>
-                                </TextBlock.Text>
-                            </TextBlock>
-                        </ToolTip>
-                    </TextBlock.ToolTip>
+                </TextBlock>
+            </ToolTip>
+          </TextBlock.ToolTip>
         </TextBlock>
-            </Grid>
-        </Grid>
-    </DataTemplate>
+      </Grid>
+    </Grid>
+  </DataTemplate>
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
@@ -9,47 +9,47 @@
                     xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
                     xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI">
 
-  <ResourceDictionary.MergedDictionaries>
-    <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml"/>
-    <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
-  </ResourceDictionary.MergedDictionaries>
-  
-  <DataTemplate x:Key="PullRequestItemTemplate" DataType="models:IPullRequestModel">
-    <Grid>
-      <Grid.RowDefinitions>
-        <RowDefinition Height="Auto" />
-        <RowDefinition Height="Auto" />
-      </Grid.RowDefinitions>
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="Auto" />
-        <ColumnDefinition Width="*" />
-        <ColumnDefinition Width="Auto" />
-        <ColumnDefinition Width="12" />
-        <ColumnDefinition Width="11" />
-      </Grid.ColumnDefinitions>
+    <ResourceDictionary.MergedDictionaries>
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml"/>
+        <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+    </ResourceDictionary.MergedDictionaries>
 
-      <Grid 
+    <DataTemplate x:Key="PullRequestItemTemplate" DataType="models:IPullRequestModel">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="12" />
+                <ColumnDefinition Width="11" />
+            </Grid.ColumnDefinitions>
+
+            <Grid 
           Grid.Row="0"
           Grid.RowSpan="2"
           Grid.Column="0"
           VerticalAlignment="Top">
 
-          <Border Name="avatarMask" Background="White" CornerRadius="3" Width="20" />
+                <Border Name="avatarMask" Background="White" CornerRadius="3" Width="20" />
 
-          <StackPanel>
-              <StackPanel.OpacityMask>
-                  <VisualBrush Visual="{Binding ElementName=avatarMask}" />
-              </StackPanel.OpacityMask>
-              <Image x:Name="avatar"
+                <StackPanel>
+                    <StackPanel.OpacityMask>
+                        <VisualBrush Visual="{Binding ElementName=avatarMask}" />
+                    </StackPanel.OpacityMask>
+                    <Image x:Name="avatar"
                      Width="30"
                      Margin="0,0,10,0"
                      Height="30"
                      RenderOptions.BitmapScalingMode="HighQuality"
                      Source="{Binding Author.Avatar}" />
-          </StackPanel>
-      </Grid>
+                </StackPanel>
+            </Grid>
 
-      <ui:GitHubActionLink x:Name="title"
+            <ui:GitHubActionLink x:Name="title"
             Grid.Row="0"
             Grid.Column="1"
             HorizontalAlignment="Left"
@@ -61,8 +61,8 @@
             ToolTip="{Binding Title}"
             Command="{Binding ViewModel.OpenPullRequest, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"
             CommandParameter="{Binding Number}"/>
-        
-        <ui:OcticonImage x:Name="comment_icon"
+
+            <ui:OcticonImage x:Name="comment_icon"
                    Grid.Row="0"
                    Grid.RowSpan="2"
                    Grid.Column="2"
@@ -74,7 +74,7 @@
                    Foreground="{DynamicResource GitHubVsToolWindowText}"
                    Visibility="{Binding CommentCount, Converter={ui:CountToVisibilityConverter}}" />
 
-      <TextBlock x:Name="comment_count"
+            <TextBlock x:Name="comment_count"
                  Grid.Row="0"
                  Grid.RowSpan="2"
                  Grid.Column="3"
@@ -85,7 +85,7 @@
                  Text="{Binding CommentCount}"
                  Visibility="{Binding CommentCount, Converter={ui:CountToVisibilityConverter}}" />
 
-      <ui:OcticonImage x:Name="comment_new"
+            <ui:OcticonImage x:Name="comment_new"
                        Grid.Row="0"
                        Grid.RowSpan="2"
                        Grid.Column="4"
@@ -97,53 +97,53 @@
                        Foreground="Green"
                        Icon="primitive_dot"
                        Visibility="{Binding HasNewComments, Converter={ui:BooleanToVisibilityConverter}}" />
-      <Grid x:Name="status"
+            <Grid x:Name="status"
             Grid.Row="1"
             Grid.Column="1"
             HorizontalAlignment="Left"
             VerticalAlignment="Top">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <Button x:Name="prHashtagLink"
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Button x:Name="prHashtagLink"
                 Grid.Column="0"
-                Command="{Binding OpenPROnGitHub, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"
+                Command="{Binding ViewModel.OpenPROnGitHub, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"
                 CommandParameter="{Binding Number}"
                 Content="{Binding Number}"
                 ToolTip="{x:Static prop:Resources.OpenPROnGitHubToolTip}"
                 FontFamily="Segoe UI"
                 Style="{StaticResource HashtagActionLink}" />
-        <TextBlock x:Name="description"
+                <TextBlock x:Name="description"
                    Grid.Column="1"
                    FontFamily="Segoe UI"
                    Margin="0,0,10,0"
                    TextTrimming="CharacterEllipsis"
                    Foreground="{DynamicResource GitHubVsGrayText}">
-          <TextBlock.Text>
-            <MultiBinding StringFormat="{} {0} {1} {2}">
-              <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
-              <Binding Source="{x:Static i18n:Resources.prUpdatedByText}" />
-              <Binding Path="Author.Login" />
-            </MultiBinding>
-          </TextBlock.Text>
-
-          <TextBlock.ToolTip>
-            <ToolTip>
-                <TextBlock>
                     <TextBlock.Text>
-                       <MultiBinding StringFormat="{} {0} {1} {2} {3}">
-                          <Binding Source="{x:Static i18n:Resources.prUpdatedText}" />
-                          <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
-                          <Binding Source="{x:Static i18n:Resources.prUpdatedByText}" />
-                          <Binding Path="Author.Login" />
+                        <MultiBinding StringFormat="{} {0} {1} {2}">
+                            <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
+                            <Binding Source="{x:Static i18n:Resources.prUpdatedByText}" />
+                            <Binding Path="Author.Login" />
                         </MultiBinding>
                     </TextBlock.Text>
-                </TextBlock>
-            </ToolTip>
-          </TextBlock.ToolTip>
+
+                    <TextBlock.ToolTip>
+                        <ToolTip>
+                            <TextBlock>
+                                <TextBlock.Text>
+                                    <MultiBinding StringFormat="{} {0} {1} {2} {3}">
+                                        <Binding Source="{x:Static i18n:Resources.prUpdatedText}" />
+                                        <Binding Converter="{ui:DurationToStringConverter}" Path="UpdatedAt" />
+                                        <Binding Source="{x:Static i18n:Resources.prUpdatedByText}" />
+                                        <Binding Path="Author.Login" />
+                                    </MultiBinding>
+                                </TextBlock.Text>
+                            </TextBlock>
+                        </ToolTip>
+                    </TextBlock.ToolTip>
         </TextBlock>
-      </Grid>
-    </Grid>
-  </DataTemplate>
+            </Grid>
+        </Grid>
+    </DataTemplate>
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
+++ b/src/GitHub.VisualStudio/UI/Views/Controls/PullRequestListItem.xaml
@@ -108,7 +108,7 @@
         </Grid.ColumnDefinitions>
         <Button x:Name="prHashtagLink"
                 Grid.Column="0"
-                Command="{Binding ViewModel.OpenPROnGitHub, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"
+                Command="{Binding ViewModel.OpenPullRequestOnGitHub, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"
                 CommandParameter="{Binding Number}"
                 Content="{Binding Number}"
                 ToolTip="{x:Static prop:Resources.OpenPROnGitHubToolTip}"

--- a/src/GitHub.VisualStudio/UI/Views/PullRequestListView.xaml.cs
+++ b/src/GitHub.VisualStudio/UI/Views/PullRequestListView.xaml.cs
@@ -26,36 +26,15 @@ namespace GitHub.VisualStudio.UI.Views
         readonly Subject<int> open = new Subject<int>();
         readonly Subject<object> create = new Subject<object>();
 
+        [ImportingConstructor]
         public PullRequestListView()
         {
             InitializeComponent();
-        }
-
-        [ImportingConstructor]
-        public PullRequestListView(IGitHubServiceProvider serviceProvider)
-        {
-            InitializeComponent();
-
-            OpenPROnGitHub = new RelayCommand(x =>
-            {
-                var repo = serviceProvider.TryGetService<ITeamExplorerServiceHolder>()?.ActiveRepo;
-                var browser = serviceProvider.TryGetService<IVisualStudioBrowser>();
-                Debug.Assert(repo != null, "No active repo, cannot open PR on GitHub");
-                Debug.Assert(browser != null, "No browser service, cannot open PR on GitHub");
-                if (repo == null || browser == null)
-                {
-                    return;
-                }
-                var url = repo.CloneUrl.ToRepositoryUrl().Append("pull/" + x);
-                browser.OpenUrl(url);
-            });
 
             this.WhenActivated(d =>
             {
             });
         }
-
-        public ICommand OpenPROnGitHub { get; set; }
 
         bool disposed;
         protected override void Dispose(bool disposing)

--- a/src/UnitTests/GitHub.App/ViewModels/PullRequestListViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/PullRequestListViewModelTests.cs
@@ -20,7 +20,8 @@ namespace UnitTests.GitHub.App.ViewModels
             var repositoryHost = CreateRepositoryHost();
             var repository = Substitute.For<ILocalRepositoryModel>();
             var settings = CreateSettings();
-            var prViewModel = new PullRequestListViewModel(repositoryHost, repository, settings);
+            var browser = Substitute.For<IVisualStudioBrowser>();
+            var prViewModel = new PullRequestListViewModel(repositoryHost, repository, settings, browser);
 
             prViewModel.Initialize(null);
             prViewModel.PullRequests.Received(1).Filter = AnyFilter;
@@ -35,7 +36,8 @@ namespace UnitTests.GitHub.App.ViewModels
             var repositoryHost = CreateRepositoryHost();
             var repository = Substitute.For<ILocalRepositoryModel>();
             var settings = CreateSettings();
-            var prViewModel = new PullRequestListViewModel(repositoryHost, repository, settings);
+            var browser = Substitute.For<IVisualStudioBrowser>();
+            var prViewModel = new PullRequestListViewModel(repositoryHost, repository, settings, browser);
 
             prViewModel.Initialize(null);
             prViewModel.PullRequests.Received(1).Filter = AnyFilter;
@@ -56,7 +58,8 @@ namespace UnitTests.GitHub.App.ViewModels
             var repositoryHost = CreateRepositoryHost();
             var repository = Substitute.For<ILocalRepositoryModel>();
             var settings = CreateSettings();
-            var prViewModel = new PullRequestListViewModel(repositoryHost, repository, settings);
+            var browser = Substitute.For<IVisualStudioBrowser>();
+            var prViewModel = new PullRequestListViewModel(repositoryHost, repository, settings, browser);
 
             prViewModel.Initialize(null);
             prViewModel.PullRequests.Received(1).Filter = AnyFilter;
@@ -71,7 +74,8 @@ namespace UnitTests.GitHub.App.ViewModels
             var repositoryHost = CreateRepositoryHost();
             var repository = Substitute.For<ILocalRepositoryModel>();
             var settings = CreateSettings();
-            var prViewModel = new PullRequestListViewModel(repositoryHost, repository, settings);
+            var browser = Substitute.For<IVisualStudioBrowser>();
+            var prViewModel = new PullRequestListViewModel(repositoryHost, repository, settings, browser);
 
             prViewModel.Initialize(null);
             prViewModel.PullRequests.Received(1).Filter = AnyFilter;

--- a/src/UnitTests/GitHub.App/ViewModels/PullRequestListViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/PullRequestListViewModelTests.cs
@@ -7,6 +7,7 @@ using GitHub.Models;
 using GitHub.Services;
 using GitHub.Settings;
 using GitHub.ViewModels;
+using GitHub.Primitives;
 using NSubstitute;
 using Xunit;
 
@@ -88,6 +89,23 @@ namespace UnitTests.GitHub.App.ViewModels
             // the selection in the view to be set to null which will reset the filter.
             prViewModel.SelectedAuthor = prViewModel.EmptyUser;
             prViewModel.PullRequests.Received(2).Filter = AnyFilter;
+        }
+
+        [Theory]
+        [InlineData("https://github.com/owner/repo", 666, "https://github.com/owner/repo/pull/666")]
+        public void OpenPROnGitHubShouldOpenBrowser(string cloneUrl, int pullNumber, string expectUrl)
+        {
+            var repositoryHost = CreateRepositoryHost();
+            var repository = Substitute.For<ILocalRepositoryModel>();
+            var settings = CreateSettings();
+            var browser = Substitute.For<IVisualStudioBrowser>();
+            var prViewModel = new PullRequestListViewModel(repositoryHost, repository, settings, browser);
+            prViewModel.SelectedRepository = Substitute.For<IRemoteRepositoryModel>();
+            prViewModel.SelectedRepository.CloneUrl.Returns(new UriString(cloneUrl));
+
+            prViewModel.OpenPROnGitHub.Execute(pullNumber);
+
+            browser.ReceivedWithAnyArgs(1).OpenUrl(new Uri(expectUrl));
         }
 
         Func<IPullRequestModel, int, IList<IPullRequestModel>, bool> AnyFilter =>

--- a/src/UnitTests/GitHub.App/ViewModels/PullRequestListViewModelTests.cs
+++ b/src/UnitTests/GitHub.App/ViewModels/PullRequestListViewModelTests.cs
@@ -93,7 +93,7 @@ namespace UnitTests.GitHub.App.ViewModels
 
         [Theory]
         [InlineData("https://github.com/owner/repo", 666, "https://github.com/owner/repo/pull/666")]
-        public void OpenPROnGitHubShouldOpenBrowser(string cloneUrl, int pullNumber, string expectUrl)
+        public void OpenPullRequestOnGitHubShouldOpenBrowser(string cloneUrl, int pullNumber, string expectUrl)
         {
             var repositoryHost = CreateRepositoryHost();
             var repository = Substitute.For<ILocalRepositoryModel>();
@@ -103,7 +103,7 @@ namespace UnitTests.GitHub.App.ViewModels
             prViewModel.SelectedRepository = Substitute.For<IRemoteRepositoryModel>();
             prViewModel.SelectedRepository.CloneUrl.Returns(new UriString(cloneUrl));
 
-            prViewModel.OpenPROnGitHub.Execute(pullNumber);
+            prViewModel.OpenPullRequestOnGitHub.Execute(pullNumber);
 
             browser.ReceivedWithAnyArgs(1).OpenUrl(new Uri(expectUrl));
         }


### PR DESCRIPTION
Previously the # link in the PR list wasn't taking account of the selected repo (i.e. fork or target repo). This meant that if you tried to open a PR that you'd submitted from a fork, you'd get a 404 rather than the PR you'd submitted opening. Alternatively you might get the wrong PR, if a PR/issue with the same number exists in your local repo.

For example, the link highlighted below attempts to open `jcansdale/VsixUtil` not `jaredpar/VsixUtil`:

![image](https://user-images.githubusercontent.com/11719160/29965794-07408a90-8f07-11e7-9492-4c1ea3cd2266.png)

This PR changes it to open the selected repo. It also moves the OpenPROnGitHub command from the View to ViewModel (with the other commands).

I'm also planning to refactor the command to use Rx for consistency with the other commands in the ViewModel.

Fixes #1208