### PR TITLE
Bump version to 2.3.4.40

### DIFF
--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -11,7 +11,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
-    <ApplicationVersion>2.3.3.40</ApplicationVersion>
+    <ApplicationVersion>2.3.4.40</ApplicationVersion>
     <OutputPath>..\..\build\$(Configuration)\</OutputPath>
     <VsixType>v3</VsixType>
     <IsProductComponent>false</IsProductComponent>

--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="c3d3dc68-c977-411f-b3e8-03b0dccf7dfc" Version="2.3.3.40" Language="en-US" Publisher="GitHub, Inc" />
+    <Identity Id="c3d3dc68-c977-411f-b3e8-03b0dccf7dfc" Version="2.3.4.40" Language="en-US" Publisher="GitHub, Inc" />
     <DisplayName>GitHub Extension for Visual Studio</DisplayName>
     <Description xml:space="preserve">A Visual Studio Extension that brings the GitHub Flow into Visual Studio.</Description>
     <PackageId>GitHub.VisualStudio</PackageId>

--- a/src/MsiInstaller/Version.wxi
+++ b/src/MsiInstaller/Version.wxi
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Include>
-  <?define VersionNumber="2.3.3.40" ?>
+  <?define VersionNumber="2.3.4.40" ?>
 </Include>

--- a/src/common/SolutionInfo.cs
+++ b/src/common/SolutionInfo.cs
@@ -3,8 +3,8 @@ using System.Resources;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyProduct("GitHub Extension for Visual Studio")]
-[assembly: AssemblyVersion("2.3.3.40")]
-[assembly: AssemblyFileVersion("2.3.3.40")]
+[assembly: AssemblyVersion("2.3.4.40")]
+[assembly: AssemblyFileVersion("2.3.4.40")]
 [assembly: ComVisible(false)]
 [assembly: AssemblyCompany("GitHub, Inc.")]
 [assembly: AssemblyCopyright("Copyright © GitHub, Inc. 2014-2016")]
@@ -16,6 +16,6 @@ using System.Runtime.InteropServices;
 namespace System
 {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "2.3.3.40";
+        internal const string Version = "2.3.4.40";
     }
 }


### PR DESCRIPTION
Bump version after v2.3.3.38 was released (v2.3.3.40 didn't make the cut).