### PR TITLE
Fix opening links on enterprise instances.

### DIFF
--- a/src/GitHub.VisualStudio/Menus/MenuBase.cs
+++ b/src/GitHub.VisualStudio/Menus/MenuBase.cs
@@ -131,7 +131,8 @@ namespace GitHub.VisualStudio
             if (!isdotcom)
             {
                 var repo = await SimpleApiClient.GetRepository();
-                return (repo.FullName == ActiveRepo.Name || repo.Id == 0) && SimpleApiClient.IsEnterprise();
+                var activeRepoFullName = ActiveRepo.Owner + '/' + ActiveRepo.Name;
+                return (repo.FullName == activeRepoFullName || repo.Id == 0) && SimpleApiClient.IsEnterprise();
             }
             return isdotcom;
         }


### PR DESCRIPTION
Correctly compare repository full name.

Previously we were comparing `repo.FullName == ActiveRepo.Name` which always failed as `repo.FullName` returns `owner/name` whereas `ActiveRepo.Name` just returns the `name` portion. Construct a full name for the active repo and check that.

Fixes #1291