### PR TITLE
Add using to avoid crash in Release mode

### DIFF
--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -102,9 +102,13 @@ namespace GitHub.Services
 
         public IObservable<bool> IsWorkingDirectoryClean(ILocalRepositoryModel repository)
         {
-            var repo = gitService.GetRepository(repository.LocalPath);
-            var isClean = !IsFilthy(repo.RetrieveStatus());
-            return Observable.Return(isClean);
+            // The `using` appears to resolve this issue:
+            // https://github.com/github/VisualStudio/issues/1306
+            using (var repo = gitService.GetRepository(repository.LocalPath))
+            {
+                var isClean = !IsFilthy(repo.RetrieveStatus());
+                return Observable.Return(isClean);
+            }
         }
 
         static bool IsFilthy(RepositoryStatus status)


### PR DESCRIPTION
Somehow putting the `repo` object in a `using` avoids the following issue: https://github.com/github/VisualStudio/issues/1306

Fixes #1306
