### PR TITLE
Remove unused code.

### DIFF
--- a/src/GitHub.InlineReviews/ViewModels/CommentThreadViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/CommentThreadViewModel.cs
@@ -9,10 +9,9 @@ namespace GitHub.InlineReviews.ViewModels
     /// <summary>
     /// Base view model for a thread of comments.
     /// </summary>
-    public abstract class CommentThreadViewModel : ReactiveObject, ICommentThreadViewModel, IDisposable
+    public abstract class CommentThreadViewModel : ReactiveObject, ICommentThreadViewModel
     {
         ReactiveCommand<ICommentModel> postComment;
-        IDisposable placeholderSubscription;
 
         /// <summary>
         /// Intializes a new instance of the <see cref="CommentThreadViewModel"/> class.
@@ -48,21 +47,7 @@ namespace GitHub.InlineReviews.ViewModels
         /// <inheritdoc/>
         public IAccount CurrentUser { get; }
 
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
         /// <inheritdoc/>
         public abstract Uri GetCommentUrl(int id);
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                placeholderSubscription?.Dispose();
-            }
-        }
     }
 }

--- a/src/GitHub.InlineReviews/ViewModels/NewInlineCommentThreadViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/NewInlineCommentThreadViewModel.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Linq;
-using System.Reactive;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using System.Threading.Tasks;
-using GitHub.Api;
 using GitHub.Extensions;
 using GitHub.Models;
 using GitHub.Services;
@@ -17,7 +14,6 @@ namespace GitHub.InlineReviews.ViewModels
     /// </summary>
     public class NewInlineCommentThreadViewModel : CommentThreadViewModel
     {
-        readonly Subject<Unit> finished = new Subject<Unit>();
         bool needsPush;
 
         /// <summary>
@@ -116,7 +112,6 @@ namespace GitHub.InlineReviews.ViewModels
                 File.RelativePath.Replace("\\", "/"),
                 diffPosition.DiffLineNumber);
 
-            finished.OnNext(Unit.Default);
             return model;
         }
     }


### PR DESCRIPTION
VS2017 was finding unused code that CA wasn't finding. This also fixes the build on VS2017.