### PR TITLE
Check scopes on login.

### DIFF
--- a/src/GitHub.Api/ApiClientConfiguration.cs
+++ b/src/GitHub.Api/ApiClientConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -32,6 +33,11 @@ namespace GitHub.Api
         /// Gets the application's OAUTH client secret.
         /// </summary>
         public static string ClientSecret { get; private set; }
+
+        /// <summary>
+        /// Gets the scopes required by the application.
+        /// </summary>
+        public static IReadOnlyList<string> RequiredScopes { get; } = new[] { "user", "repo", "gist", "write:public_key" };
 
         /// <summary>
         /// Gets a note that will be stored with the OAUTH token.

--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -46,6 +46,10 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)\src\common\signing.props" />
   <ItemGroup>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.5.0\lib\net46\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
@@ -64,6 +68,7 @@
     <Compile Include="ApiClientConfiguration_User.cs" Condition="$(Buildtype) != 'Internal'" />
     <Compile Include="IKeychain.cs" />
     <Compile Include="ILoginManager.cs" />
+    <Compile Include="IncorrectScopesException.cs" />
     <Compile Include="ITwoFactorChallengeHandler.cs" />
     <Compile Include="LoginManager.cs" />
     <Compile Include="KeychainCredentialStore.cs" />
@@ -98,6 +103,9 @@
       <Project>{8d73575a-a89f-47cc-b153-b47dd06837f0}</Project>
       <Name>GitHub.Logging</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/GitHub.Api/IncorrectScopesException.cs
+++ b/src/GitHub.Api/IncorrectScopesException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace GitHub.Api
+{
+    /// <summary>
+    /// Thrown when the login for a user does not have the required scopes.
+    /// </summary>
+    public class IncorrectScopesException : Exception
+    {
+        public IncorrectScopesException()
+            : this("You need to sign out and back in.")
+        {
+        }
+
+        public IncorrectScopesException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/GitHub.Api/IncorrectScopesException.cs
+++ b/src/GitHub.Api/IncorrectScopesException.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace GitHub.Api
 {
     /// <summary>
     /// Thrown when the login for a user does not have the required scopes.
     /// </summary>
+    [Serializable]
     public class IncorrectScopesException : Exception
     {
         public IncorrectScopesException()
@@ -14,6 +16,16 @@ namespace GitHub.Api
 
         public IncorrectScopesException(string message)
             : base(message)
+        {
+        }
+
+        public IncorrectScopesException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected IncorrectScopesException(SerializationInfo info, StreamingContext context) 
+            : base(info, context)
         {
         }
     }

--- a/src/GitHub.Api/packages.config
+++ b/src/GitHub.Api/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Serilog" version="2.5.0" targetFramework="net461" />
+</packages>

--- a/src/GitHub.App/Api/ApiClient.cs
+++ b/src/GitHub.App/Api/ApiClient.cs
@@ -23,8 +23,6 @@ namespace GitHub.Api
         static readonly ILogger log = LogManager.ForContext<ApiClient>();
 
         readonly IObservableGitHubClient gitHubClient;
-        readonly static Lazy<string> lazyNote = new Lazy<string>(() => ProductName + " on " + GetMachineNameSafe());
-        readonly static Lazy<string> lazyFingerprint = new Lazy<string>(GetFingerprint);
 
         string ClientId { get; set; }
         string ClientSecret { get; set; }

--- a/src/GitHub.App/ViewModels/LoginControlViewModel.cs
+++ b/src/GitHub.App/ViewModels/LoginControlViewModel.cs
@@ -85,8 +85,11 @@ namespace GitHub.ViewModels
 
             foreach (var connection in connectionManager.Connections)
             {
-                result &= ~((connection.HostAddress == HostAddress.GitHubDotComHostAddress) ?
-                    LoginMode.DotComOnly : LoginMode.EnterpriseOnly);
+                if (connection.IsLoggedIn)
+                {
+                    result &= ~((connection.HostAddress == HostAddress.GitHubDotComHostAddress) ?
+                        LoginMode.DotComOnly : LoginMode.EnterpriseOnly);
+                }
             }
 
             LoginMode = result;

--- a/src/GitHub.App/ViewModels/LoginTabViewModel.cs
+++ b/src/GitHub.App/ViewModels/LoginTabViewModel.cs
@@ -142,7 +142,7 @@ namespace GitHub.ViewModels
             {
                 if (hostAddress != null)
                 {
-                    if (await ConnectionManager.IsLoggedIn(hostAddress))
+                    if (await ConnectionManager.GetConnection(hostAddress) != null)
                     {
                         await ConnectionManager.LogOut(hostAddress);
                     }

--- a/src/GitHub.Exports.Reactive/Api/IApiClient.cs
+++ b/src/GitHub.Exports.Reactive/Api/IApiClient.cs
@@ -27,11 +27,6 @@ namespace GitHub.Api
         /// </summary>
         /// <returns></returns>
         IObservable<Repository> GetRepositoriesForOrganization(string organization);
-        IObservable<ApplicationAuthorization> GetOrCreateApplicationAuthenticationCode(
-            Func<TwoFactorAuthorizationException, IObservable<TwoFactorChallengeResult>> twoFactorChallengeHander,
-            string authenticationCode = null,
-            bool useOldScopes = false,
-            bool useFingerprint = true);
 
         IObservable<string> GetGitIgnoreTemplates();
         IObservable<LicenseMetadata> GetLicenses();

--- a/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
@@ -42,6 +42,16 @@ namespace GitHub.Extensions
             return Observable.Return(connection?.IsLoggedIn ?? false);
         }
 
+        public static IObservable<IConnection> GetConnection(this IConnectionManager cm, HostAddress address)
+        {
+            Guard.ArgumentNotNull(cm, nameof(cm));
+            Guard.ArgumentNotNull(address, nameof(address));
+
+            return cm.GetLoadedConnections()
+                .ToObservable()
+                .Select(x => x.FirstOrDefault(y => y.HostAddress == address));
+        }
+
         public static IObservable<IConnection> GetLoggedInConnections(this IConnectionManager cm)
         {
             Guard.ArgumentNotNull(cm, nameof(cm));

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -174,7 +174,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
         protected void Refresh(IConnection connection)
         {
-            if (connection == null)
+            if (connection == null || !connection.IsLoggedIn)
             {
                 LoggedIn = false;
                 IsVisible = false;

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubInvitationSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubInvitationSection.cs
@@ -11,6 +11,7 @@ using System.ComponentModel.Composition;
 using System.Windows;
 using System.Windows.Media;
 using GitHub.VisualStudio.UI;
+using System.Linq;
 
 namespace GitHub.VisualStudio.TeamExplorer.Connect
 {
@@ -40,9 +41,9 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                 OnThemeChanged();
             };
 
-            IsVisible = cm.Connections.Count == 0;
+            IsVisible = !cm.Connections.Where(x => x.IsLoggedIn).Any();
 
-            cm.Connections.CollectionChanged += (s, e) => IsVisible = cm.Connections.Count == 0;
+            cm.Connections.CollectionChanged += (s, e) => IsVisible = !cm.Connections.Where(x => x.IsLoggedIn).Any();
         }
 
         public override void Connect()

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -220,6 +220,7 @@ namespace GitHub.VisualStudio
                     twoFaHandler,
                     ApiClientConfiguration.ClientId,
                     ApiClientConfiguration.ClientSecret,
+                    ApiClientConfiguration.RequiredScopes,
                     ApiClientConfiguration.AuthorizationNote,
                     ApiClientConfiguration.MachineFingerprint);
             }

--- a/src/GitHub.VisualStudio/Services/ConnectionManager.cs
+++ b/src/GitHub.VisualStudio/Services/ConnectionManager.cs
@@ -71,7 +71,7 @@ namespace GitHub.VisualStudio
 
             if (conns.Any(x => x.HostAddress == address))
             {
-                throw new InvalidOperationException($"A connection to {address} already exists.");
+                throw new InvalidOperationException($"A connection to {address.Title} already exists.");
             }
 
             var client = CreateClient(address);
@@ -91,7 +91,7 @@ namespace GitHub.VisualStudio
 
             if (connection == null)
             {
-                throw new KeyNotFoundException($"Could not find a connection to {address}.");
+                throw new KeyNotFoundException($"Could not find a connection to {address.Title}.");
             }
 
             var client = CreateClient(address);

--- a/test/UnitTests/GitHub.App/ViewModels/LoginControlViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/LoginControlViewModelTests.cs
@@ -96,6 +96,8 @@ public class LoginControlViewModelTests
             connectionManager.Connections.Returns(connections);
             gitHubConnection.HostAddress.Returns(HostAddress.GitHubDotComHostAddress);
             enterpriseConnection.HostAddress.Returns(HostAddress.Create("https://enterprise.url"));
+            gitHubConnection.IsLoggedIn.Returns(true);
+            enterpriseConnection.IsLoggedIn.Returns(true);
 
             var loginViewModel = new LoginControlViewModel(connectionManager, gitHubLogin, enterpriseLogin);
 


### PR DESCRIPTION
When performing a login, check that the scopes returned are what we expect, otherwise throw an exception causing a new login to be required.

Fixes #1332