### PR TITLE
Prevent Repository objects from being prematurely GCed

### DIFF
--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -214,7 +214,7 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                // TODO: Find out if BranchTrackingDetails depends on Repository
+                // BranchTrackingDetails doesn't keep a reference to Repository
                 using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
                     var remoteName = repo.Head.RemoteName;
@@ -233,7 +233,7 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                // TODO: Find out if TreeChanges depends on Repository
+                // TreeChanges doesn't keep a reference to Repository
                 using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
                     var remote = await gitClient.GetHttpRemote(repo, "origin");
@@ -248,7 +248,7 @@ namespace GitHub.Services
         {
             return Observable.Defer(() =>
             {
-                // TODO: Find out if IBranch depends on Repository
+                // BranchModel doesn't keep a reference to repo
                 using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
                     var result = GetLocalBranchesInternal(repository, repo, pullRequest).Select(x => new BranchModel(x, repository));
@@ -325,7 +325,6 @@ namespace GitHub.Services
 
                         await gitClient.Checkout(repo, branchName);
                         await MarkBranchAsPullRequest(repo, branchName, pullRequest);
-
                     }
                 }
 
@@ -556,7 +555,7 @@ namespace GitHub.Services
             IBranch sourceBranch, IBranch targetBranch,
             string title, string body)
         {
-            // TODO: Find out if IPullRequestModel depends on Repository
+            // PullRequestModel doesn't keep a reference to repo
             using (var repo = await Task.Run(() => gitService.GetRepository(sourceRepository.LocalPath)))
             {
                 var remote = await gitClient.GetHttpRemote(repo, "origin");

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -93,12 +93,13 @@ namespace GitHub.Services
             string compareBranch,
             int maxCommits)
         {
-            return Observable.Defer(() =>
+            return Observable.Defer(async () =>
             {
                 // CommitMessage doesn't keep a reference to Repository
                 using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
-                    return gitClient.GetMessagesForUniqueCommits(repo, baseBranch, compareBranch, maxCommits).ToObservable();
+                    var messages = await gitClient.GetMessagesForUniqueCommits(repo, baseBranch, compareBranch, maxCommits);
+                    return Observable.Return(messages);
                 }
             });
         }
@@ -130,11 +131,12 @@ namespace GitHub.Services
 
         public IObservable<Unit> Pull(ILocalRepositoryModel repository)
         {
-            return Observable.Defer(() =>
+            return Observable.Defer(async () =>
             {
                 using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
-                    return gitClient.Pull(repo).ToObservable();
+                    await gitClient.Pull(repo);
+                    return Observable.Return(Unit.Default);
                 }
             });
         }
@@ -147,7 +149,8 @@ namespace GitHub.Services
                 {
                     var remoteName = repo.Head.RemoteName;
                     var remote = await gitClient.GetHttpRemote(repo, remoteName);
-                    return gitClient.Push(repo, repo.Head.TrackedBranch.UpstreamBranchCanonicalName, remote.Name).ToObservable();
+                    await gitClient.Push(repo, repo.Head.TrackedBranch.UpstreamBranchCanonicalName, remote.Name);
+                    return Observable.Return(Unit.Default);
                 }
             });
         }

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -95,8 +95,11 @@ namespace GitHub.Services
         {
             return Observable.Defer(() =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                return gitClient.GetMessagesForUniqueCommits(repo, baseBranch, compareBranch, maxCommits).ToObservable();
+                // CommitMessage doesn't keep a reference to Repository
+                using (var repo = gitService.GetRepository(repository.LocalPath))
+                {
+                    return gitClient.GetMessagesForUniqueCommits(repo, baseBranch, compareBranch, maxCommits).ToObservable();
+                }
             });
         }
 
@@ -129,8 +132,10 @@ namespace GitHub.Services
         {
             return Observable.Defer(() =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                return gitClient.Pull(repo).ToObservable();
+                using (var repo = gitService.GetRepository(repository.LocalPath))
+                {
+                    return gitClient.Pull(repo).ToObservable();
+                }
             });
         }
 
@@ -138,10 +143,12 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var remoteName = repo.Head.RemoteName;
-                var remote = await gitClient.GetHttpRemote(repo, remoteName);
-                return gitClient.Push(repo, repo.Head.TrackedBranch.UpstreamBranchCanonicalName, remote.Name).ToObservable();
+                using (var repo = gitService.GetRepository(repository.LocalPath))
+                {
+                    var remoteName = repo.Head.RemoteName;
+                    var remote = await gitClient.GetHttpRemote(repo, remoteName);
+                    return gitClient.Push(repo, repo.Head.TrackedBranch.UpstreamBranchCanonicalName, remote.Name).ToObservable();
+                }
             });
         }
 
@@ -149,35 +156,37 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var existing = repo.Branches[localBranchName];
-
-                if (existing != null)
+                using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
-                    await gitClient.Checkout(repo, localBranchName);
-                }
-                else if (repository.CloneUrl.ToRepositoryUrl() == pullRequest.Head.RepositoryCloneUrl.ToRepositoryUrl())
-                {
-                    var remote = await gitClient.GetHttpRemote(repo, "origin");
-                    await gitClient.Fetch(repo, remote.Name);
-                    await gitClient.Checkout(repo, localBranchName);
-                }
-                else
-                {
-                    var refSpec = $"{pullRequest.Head.Ref}:{localBranchName}";
-                    var remoteName = await CreateRemote(repo, pullRequest.Head.RepositoryCloneUrl);
+                    var existing = repo.Branches[localBranchName];
 
-                    await gitClient.Fetch(repo, remoteName);
-                    await gitClient.Fetch(repo, remoteName, new[] { refSpec });
-                    await gitClient.Checkout(repo, localBranchName);
-                    await gitClient.SetTrackingBranch(repo, localBranchName, $"refs/remotes/{remoteName}/{pullRequest.Head.Ref}");
+                    if (existing != null)
+                    {
+                        await gitClient.Checkout(repo, localBranchName);
+                    }
+                    else if (repository.CloneUrl.ToRepositoryUrl() == pullRequest.Head.RepositoryCloneUrl.ToRepositoryUrl())
+                    {
+                        var remote = await gitClient.GetHttpRemote(repo, "origin");
+                        await gitClient.Fetch(repo, remote.Name);
+                        await gitClient.Checkout(repo, localBranchName);
+                    }
+                    else
+                    {
+                        var refSpec = $"{pullRequest.Head.Ref}:{localBranchName}";
+                        var remoteName = await CreateRemote(repo, pullRequest.Head.RepositoryCloneUrl);
+
+                        await gitClient.Fetch(repo, remoteName);
+                        await gitClient.Fetch(repo, remoteName, new[] { refSpec });
+                        await gitClient.Checkout(repo, localBranchName);
+                        await gitClient.SetTrackingBranch(repo, localBranchName, $"refs/remotes/{remoteName}/{pullRequest.Head.Ref}");
+                    }
+
+                    // Store the PR number in the branch config with the key "ghfvs-pr".
+                    var prConfigKey = $"branch.{localBranchName}.{SettingGHfVSPullRequest}";
+                    await gitClient.SetConfig(repo, prConfigKey, BuildGHfVSConfigKeyValue(pullRequest));
+
+                    return Observable.Return(Unit.Default);
                 }
-
-                // Store the PR number in the branch config with the key "ghfvs-pr".
-                var prConfigKey = $"branch.{localBranchName}.{SettingGHfVSPullRequest}";
-                await gitClient.SetConfig(repo, prConfigKey, BuildGHfVSConfigKeyValue(pullRequest));
-
-                return Observable.Return(Unit.Default);
             });
         }
 
@@ -187,12 +196,14 @@ namespace GitHub.Services
             {
                 var initial = "pr/" + pullRequestNumber + "-" + GetSafeBranchName(pullRequestTitle);
                 var current = initial;
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var index = 2;
-
-                while (repo.Branches[current] != null)
+                using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
-                    current = initial + '-' + index++;
+                    var index = 2;
+
+                    while (repo.Branches[current] != null)
+                    {
+                        current = initial + '-' + index++;
+                    }
                 }
 
                 return Observable.Return(current.TrimEnd('-'));
@@ -203,15 +214,18 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var remoteName = repo.Head.RemoteName;
-                if (remoteName != null)
+                // TODO: Find out if BranchTrackingDetails depends on Repository
+                using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
-                    var remote = await gitClient.GetHttpRemote(repo, remoteName);
-                    await gitClient.Fetch(repo, remote.Name);
-                }
+                    var remoteName = repo.Head.RemoteName;
+                    if (remoteName != null)
+                    {
+                        var remote = await gitClient.GetHttpRemote(repo, remoteName);
+                        await gitClient.Fetch(repo, remote.Name);
+                    }
 
-                return Observable.Return(repo.Head.TrackingDetails);
+                    return Observable.Return(repo.Head.TrackingDetails);
+                }
             });
         }
 
@@ -219,11 +233,14 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var remote = await gitClient.GetHttpRemote(repo, "origin");
-                await gitClient.Fetch(repo, remote.Name);
-                var changes = await gitClient.Compare(repo, pullRequest.Base.Sha, pullRequest.Head.Sha, detectRenames: true);
-                return Observable.Return(changes);
+                // TODO: Find out if TreeChanges depends on Repository
+                using (var repo = gitService.GetRepository(repository.LocalPath))
+                {
+                    var remote = await gitClient.GetHttpRemote(repo, "origin");
+                    await gitClient.Fetch(repo, remote.Name);
+                    var changes = await gitClient.Compare(repo, pullRequest.Base.Sha, pullRequest.Head.Sha, detectRenames: true);
+                    return Observable.Return(changes);
+                }
             });
         }
 
@@ -231,9 +248,12 @@ namespace GitHub.Services
         {
             return Observable.Defer(() =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var result = GetLocalBranchesInternal(repository, repo, pullRequest).Select(x => new BranchModel(x, repository));
-                return result.ToObservable();
+                // TODO: Find out if IBranch depends on Repository
+                using (var repo = gitService.GetRepository(repository.LocalPath))
+                {
+                    var result = GetLocalBranchesInternal(repository, repo, pullRequest).Select(x => new BranchModel(x, repository));
+                    return result.ToObservable();
+                }
             });
         }
 
@@ -241,20 +261,22 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var branches = GetLocalBranchesInternal(repository, repo, pullRequest).Select(x => new BranchModel(x, repository));
-                var result = false;
-
-                foreach (var branch in branches)
+                using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
-                    if (!await IsBranchMarkedAsPullRequest(repo, branch.Name, pullRequest))
-                    {
-                        await MarkBranchAsPullRequest(repo, branch.Name, pullRequest);
-                        result = true;
-                    }
-                }
+                    var branches = GetLocalBranchesInternal(repository, repo, pullRequest).Select(x => new BranchModel(x, repository));
+                    var result = false;
 
-                return Observable.Return(result);
+                    foreach (var branch in branches)
+                    {
+                        if (!await IsBranchMarkedAsPullRequest(repo, branch.Name, pullRequest))
+                        {
+                            await MarkBranchAsPullRequest(repo, branch.Name, pullRequest);
+                            result = true;
+                        }
+                    }
+
+                    return Observable.Return(result);
+                }
             });
         }
 
@@ -272,36 +294,39 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var branchName = GetLocalBranchesInternal(repository, repo, pullRequest).FirstOrDefault();
-
-                Log.Assert(branchName != null, "PullRequestService.SwitchToBranch called but no local branch found");
-
-                if (branchName != null)
+                using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
-                    var remote = await gitClient.GetHttpRemote(repo, "origin");
-                    await gitClient.Fetch(repo, remote.Name);
+                    var branchName = GetLocalBranchesInternal(repository, repo, pullRequest).FirstOrDefault();
 
-                    var branch = repo.Branches[branchName];
+                    Log.Assert(branchName != null, "PullRequestService.SwitchToBranch called but no local branch found");
 
-                    if (branch == null)
+                    if (branchName != null)
                     {
-                        var trackedBranchName = $"refs/remotes/{remote.Name}/" + branchName;
-                        var trackedBranch = repo.Branches[trackedBranchName];
+                        var remote = await gitClient.GetHttpRemote(repo, "origin");
+                        await gitClient.Fetch(repo, remote.Name);
 
-                        if (trackedBranch != null)
+                        var branch = repo.Branches[branchName];
+
+                        if (branch == null)
                         {
-                            branch = repo.CreateBranch(branchName, trackedBranch.Tip);
-                            await gitClient.SetTrackingBranch(repo, branchName, trackedBranchName);
+                            var trackedBranchName = $"refs/remotes/{remote.Name}/" + branchName;
+                            var trackedBranch = repo.Branches[trackedBranchName];
+
+                            if (trackedBranch != null)
+                            {
+                                branch = repo.CreateBranch(branchName, trackedBranch.Tip);
+                                await gitClient.SetTrackingBranch(repo, branchName, trackedBranchName);
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException($"Could not find branch '{trackedBranchName}'.");
+                            }
                         }
-                        else
-                        {
-                            throw new InvalidOperationException($"Could not find branch '{trackedBranchName}'.");
-                        }
+
+                        await gitClient.Checkout(repo, branchName);
+                        await MarkBranchAsPullRequest(repo, branchName, pullRequest);
+
                     }
-
-                    await gitClient.Checkout(repo, branchName);
-                    await MarkBranchAsPullRequest(repo, branchName, pullRequest);
                 }
 
                 return Observable.Return(Unit.Default);
@@ -312,14 +337,16 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var configKey = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "branch.{0}.{1}",
-                    repo.Head.FriendlyName,
-                    SettingGHfVSPullRequest);
-                var value = await gitClient.GetConfig<string>(repo, configKey);
-                return Observable.Return(ParseGHfVSConfigKeyValue(value));
+                using (var repo = gitService.GetRepository(repository.LocalPath))
+                {
+                    var configKey = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "branch.{0}.{1}",
+                        repo.Head.FriendlyName,
+                        SettingGHfVSPullRequest);
+                    var value = await gitClient.GetConfig<string>(repo, configKey);
+                    return Observable.Return(ParseGHfVSConfigKeyValue(value));
+                }
             });
         }
 
@@ -332,34 +359,36 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var remote = await gitClient.GetHttpRemote(repo, "origin");
-                string sha;
-
-                if (head)
+                using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
-                    sha = pullRequest.Head.Sha;
-                }
-                else
-                {
-                    try
-                    {
-                        sha = await gitClient.GetPullRequestMergeBase(
-                            repo,
-                            pullRequest.Base.RepositoryCloneUrl,
-                            pullRequest.Base.Sha,
-                            pullRequest.Head.Sha,
-                            pullRequest.Base.Ref,
-                            pullRequest.Number);
-                    }
-                    catch (NotFoundException ex)
-                    {
-                        throw new NotFoundException($"The Pull Request file failed to load. Please check your network connection and click refresh to try again. If this issue persists, please let us know at support@github.com", ex);
-                    }
-                }
+                    var remote = await gitClient.GetHttpRemote(repo, "origin");
+                    string sha;
 
-                var file = await ExtractToTempFile(repo, pullRequest.Number, sha, fileName, encoding);
-                return Observable.Return(file);
+                    if (head)
+                    {
+                        sha = pullRequest.Head.Sha;
+                    }
+                    else
+                    {
+                        try
+                        {
+                            sha = await gitClient.GetPullRequestMergeBase(
+                                repo,
+                                pullRequest.Base.RepositoryCloneUrl,
+                                pullRequest.Base.Sha,
+                                pullRequest.Head.Sha,
+                                pullRequest.Base.Ref,
+                                pullRequest.Number);
+                        }
+                        catch (NotFoundException ex)
+                        {
+                            throw new NotFoundException($"The Pull Request file failed to load. Please check your network connection and click refresh to try again. If this issue persists, please let us know at support@github.com", ex);
+                        }
+                    }
+
+                    var file = await ExtractToTempFile(repo, pullRequest.Number, sha, fileName, encoding);
+                    return Observable.Return(file);
+                }
             });
         }
 
@@ -399,24 +428,26 @@ namespace GitHub.Services
         {
             return Observable.Defer(async () =>
             {
-                var repo = gitService.GetRepository(repository.LocalPath);
-                var usedRemotes = new HashSet<string>(
-                    repo.Branches
-                        .Where(x => !x.IsRemote && x.RemoteName != null)
-                        .Select(x => x.RemoteName));
-
-                foreach (var remote in repo.Network.Remotes)
+                using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
-                    var key = $"remote.{remote.Name}.{SettingCreatedByGHfVS}";
-                    var createdByUs = await gitClient.GetConfig<bool>(repo, key);
+                    var usedRemotes = new HashSet<string>(
+                        repo.Branches
+                            .Where(x => !x.IsRemote && x.RemoteName != null)
+                            .Select(x => x.RemoteName));
 
-                    if (createdByUs && !usedRemotes.Contains(remote.Name))
+                    foreach (var remote in repo.Network.Remotes)
                     {
-                        repo.Network.Remotes.Remove(remote.Name);
-                    }
-                }
+                        var key = $"remote.{remote.Name}.{SettingCreatedByGHfVS}";
+                        var createdByUs = await gitClient.GetConfig<bool>(repo, key);
 
-                return Observable.Return(Unit.Default);
+                        if (createdByUs && !usedRemotes.Contains(remote.Name))
+                        {
+                            repo.Network.Remotes.Remove(remote.Name);
+                        }
+                    }
+
+                    return Observable.Return(Unit.Default);
+                }
             });
         }
 
@@ -525,20 +556,23 @@ namespace GitHub.Services
             IBranch sourceBranch, IBranch targetBranch,
             string title, string body)
         {
-            var repo = await Task.Run(() => gitService.GetRepository(sourceRepository.LocalPath));
-            var remote = await gitClient.GetHttpRemote(repo, "origin");
-            await gitClient.Push(repo, sourceBranch.Name, remote.Name);
+            // TODO: Find out if IPullRequestModel depends on Repository
+            using (var repo = await Task.Run(() => gitService.GetRepository(sourceRepository.LocalPath)))
+            {
+                var remote = await gitClient.GetHttpRemote(repo, "origin");
+                await gitClient.Push(repo, sourceBranch.Name, remote.Name);
 
-            if (!repo.Branches[sourceBranch.Name].IsTracking)
-                await gitClient.SetTrackingBranch(repo, sourceBranch.Name, remote.Name);
+                if (!repo.Branches[sourceBranch.Name].IsTracking)
+                    await gitClient.SetTrackingBranch(repo, sourceBranch.Name, remote.Name);
 
-            // delay things a bit to avoid a race between pushing a new branch and creating a PR on it
-            if (!Splat.ModeDetector.Current.InUnitTestRunner().GetValueOrDefault())
-                await Task.Delay(TimeSpan.FromSeconds(5));
+                // delay things a bit to avoid a race between pushing a new branch and creating a PR on it
+                if (!Splat.ModeDetector.Current.InUnitTestRunner().GetValueOrDefault())
+                    await Task.Delay(TimeSpan.FromSeconds(5));
 
-            var ret = await modelService.CreatePullRequest(sourceRepository, targetRepository, sourceBranch, targetBranch, title, body);
-            await usageTracker.IncrementCounter(x => x.NumberOfUpstreamPullRequests);
-            return ret;
+                var ret = await modelService.CreatePullRequest(sourceRepository, targetRepository, sourceBranch, targetBranch, title, body);
+                await usageTracker.IncrementCounter(x => x.NumberOfUpstreamPullRequests);
+                return ret;
+            }
         }
 
         static string GetSafeBranchName(string name)

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -251,11 +251,11 @@ namespace GitHub.Services
         {
             return Observable.Defer(() =>
             {
-                // BranchModel doesn't keep a reference to repo
+                // BranchModel doesn't keep a reference to rep
                 using (var repo = gitService.GetRepository(repository.LocalPath))
                 {
                     var result = GetLocalBranchesInternal(repository, repo, pullRequest).Select(x => new BranchModel(x, repository));
-                    return result.ToObservable();
+                    return result.ToList().ToObservable();
                 }
             });
         }

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -387,8 +387,10 @@ namespace GitHub.ViewModels
                 CommentCount = pullRequest.Comments.Count + pullRequest.ReviewComments.Count;
                 Body = !string.IsNullOrWhiteSpace(pullRequest.Body) ? pullRequest.Body : Resources.NoDescriptionProvidedMarkdown;
 
-                var changes = await pullRequestsService.GetTreeChanges(LocalRepository, pullRequest);
-                ChangedFilesTree = (await CreateChangedFilesTree(pullRequest, changes)).Children.ToList();
+                using (var changes = await pullRequestsService.GetTreeChanges(LocalRepository, pullRequest))
+                {
+                    ChangedFilesTree = (await CreateChangedFilesTree(pullRequest, changes)).Children.ToList();
+                }
 
                 var localBranches = await pullRequestsService.GetLocalBranches(LocalRepository, pullRequest).ToList();
 

--- a/src/GitHub.Exports/Extensions/LocalRepositoryModelExtensions.cs
+++ b/src/GitHub.Exports/Extensions/LocalRepositoryModelExtensions.cs
@@ -10,8 +10,10 @@ namespace GitHub.Extensions
     {
         public static bool HasCommits(this ILocalRepositoryModel repository)
         {
-            var repo = GitService.GitServiceHelper.GetRepository(repository.LocalPath);
-            return repo?.Commits.Any() ?? false;
+            using (var repo = GitService.GitServiceHelper.GetRepository(repository.LocalPath))
+            {
+                return repo?.Commits.Any() ?? false;
+            }
         }
 
         public static bool MightContainSolution(this ILocalRepositoryModel repository)

--- a/src/GitHub.Exports/Models/LocalRepositoryModel.cs
+++ b/src/GitHub.Exports/Models/LocalRepositoryModel.cs
@@ -157,8 +157,10 @@ namespace GitHub.Models
         {
             get
             {
-                var repo = GitService.GitServiceHelper.GetRepository(LocalPath);
-                return repo?.Commits.FirstOrDefault()?.Sha ?? String.Empty;
+                using (var repo = GitService.GitServiceHelper.GetRepository(LocalPath))
+                {
+                    return repo?.Commits.FirstOrDefault()?.Sha ?? string.Empty;
+                }
             }
         }
 
@@ -169,8 +171,11 @@ namespace GitHub.Models
         {
             get
             {
-                var repo = GitService.GitServiceHelper.GetRepository(LocalPath);
-                return new BranchModel(repo?.Head, this);
+                // BranchModel doesn't keep a reference to Repository
+                using (var repo = GitService.GitServiceHelper.GetRepository(LocalPath))
+                {
+                    return new BranchModel(repo?.Head, this);
+                }
             }
         }
 

--- a/src/GitHub.Exports/Services/GitService.cs
+++ b/src/GitHub.Exports/Services/GitService.cs
@@ -38,7 +38,10 @@ namespace GitHub.Services
         /// <returns>Returns a <see cref="UriString"/> representing the uri of the remote normalized to a GitHub repository url or null if none found.</returns>
         public UriString GetUri(string path, string remote = "origin")
         {
-            return GetUri(GetRepository(path), remote);
+            using (var repo = GetRepository(path))
+            {
+                return GetUri(repo, remote);
+            }
         }
 
         /// <summary>
@@ -82,29 +85,30 @@ namespace GitHub.Services
         public Task<string> GetLatestPushedSha(string path)
         {
             Guard.ArgumentNotNull(path, nameof(path));
-            var repo = GetRepository(path);
-
-            if (repo == null)
-                return null;
-
-            if (repo.Head.IsTracking && repo.Head.Tip.Sha == repo.Head.TrackedBranch.Tip.Sha)
+            using (var repo = GetRepository(path))
             {
-                return Task.FromResult(repo.Head.Tip.Sha);
+                if (repo == null)
+                    return null;
+
+                if (repo.Head.IsTracking && repo.Head.Tip.Sha == repo.Head.TrackedBranch.Tip.Sha)
+                {
+                    return Task.FromResult(repo.Head.Tip.Sha);
+                }
+
+                return Task.Factory.StartNew(() =>
+                {
+                    var remoteHeads = repo.Refs.Where(r => r.IsRemoteTrackingBranch).ToList();
+
+                    foreach (var c in repo.Commits)
+                    {
+                        if (repo.Refs.ReachableFrom(remoteHeads, new[] { c }).Any())
+                        {
+                            return c.Sha;
+                        }
+                    }
+                    return null;
+                });
             }
-
-            return Task.Factory.StartNew(() =>
-             {
-                 var remoteHeads = repo.Refs.Where(r => r.IsRemoteTrackingBranch).ToList();
-
-                 foreach (var c in repo.Commits)
-                 {
-                     if (repo.Refs.ReachableFrom(remoteHeads, new[] { c }).Any())
-                     {
-                         return c.Sha;
-                     }
-                 }
-                 return null;
-             });
         }
     }
 }

--- a/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
@@ -116,7 +116,12 @@ namespace GitHub.Services
             if (repo != null)
                 ret = repo.RepositoryPath;
             if (ret == null)
-                ret = serviceProvider.GetSolution().GetRepositoryFromSolution()?.Info?.Path;
+            {
+                using (var repository = serviceProvider.GetSolution().GetRepositoryFromSolution())
+                {
+                    ret = repository?.Info?.Path;
+                }
+            }
             return ret ?? String.Empty;
         }
 

--- a/src/GitHub.VisualStudio/Menus/MenuBase.cs
+++ b/src/GitHub.VisualStudio/Menus/MenuBase.cs
@@ -39,7 +39,7 @@ namespace GitHub.VisualStudio
         protected ISimpleApiClientFactory ApiFactory => apiFactory.Value;
 
         protected MenuBase()
-        {}
+        { }
 
         protected MenuBase(IGitHubServiceProvider serviceProvider)
         {
@@ -55,8 +55,10 @@ namespace GitHub.VisualStudio
             {
                 if (!string.IsNullOrEmpty(path))
                 {
-                    var repo = ServiceProvider.TryGetService<IGitService>().GetRepository(path);
-                    return new LocalRepositoryModel(repo.Info.WorkingDirectory.TrimEnd('\\'));
+                    using (var repo = ServiceProvider.TryGetService<IGitService>().GetRepository(path))
+                    {
+                        return new LocalRepositoryModel(repo.Info.WorkingDirectory.TrimEnd('\\'));
+                    }
                 }
             }
             catch (Exception ex)

--- a/test/GitHub.InlineReviews.UnitTests/TestDoubles/FakeDiffService.cs
+++ b/test/GitHub.InlineReviews.UnitTests/TestDoubles/FakeDiffService.cs
@@ -54,7 +54,9 @@ namespace GitHub.InlineReviews.UnitTests.TestDoubles
         public void Dispose()
         {
             var path = repository.Info.WorkingDirectory;
-            repository.Dispose();
+
+            // NOTE: IDiffService doesn't own the Repository object
+            //repository.Dispose();
 
             // The .git folder has some files marked as readonly, meaning that a simple
             // Directory.Delete doesn't work here.

--- a/test/GitHub.InlineReviews.UnitTests/TestDoubles/FakeDiffService.cs
+++ b/test/GitHub.InlineReviews.UnitTests/TestDoubles/FakeDiffService.cs
@@ -55,9 +55,6 @@ namespace GitHub.InlineReviews.UnitTests.TestDoubles
         {
             var path = repository.Info.WorkingDirectory;
 
-            // NOTE: IDiffService doesn't own the Repository object
-            //repository.Dispose();
-
             // The .git folder has some files marked as readonly, meaning that a simple
             // Directory.Delete doesn't work here.
             DeleteDirectory(path);

--- a/test/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
+++ b/test/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
@@ -591,21 +591,23 @@ public class PullRequestServiceTests : TestBaseClass
             var localRepo = Substitute.For<ILocalRepositoryModel>();
             localRepo.CloneUrl.Returns(new UriString("https://foo.bar/owner/repo"));
 
-            var repo = gitService.GetRepository(localRepo.CloneUrl);
-            var remote = Substitute.For<Remote>();
-            var remoteCollection = Substitute.For<RemoteCollection>();
-            remoteCollection["fork"].Returns(remote);
-            repo.Network.Remotes.Returns(remoteCollection);
+            using (var repo = gitService.GetRepository(localRepo.CloneUrl))
+            {
+                var remote = Substitute.For<Remote>();
+                var remoteCollection = Substitute.For<RemoteCollection>();
+                remoteCollection["fork"].Returns(remote);
+                repo.Network.Remotes.Returns(remoteCollection);
 
-            var pr = Substitute.For<IPullRequestModel>();
-            pr.Number.Returns(5);
-            pr.Base.Returns(new GitReferenceModel("master", "owner:master", "123", "https://foo.bar/owner/repo.git"));
-            pr.Head.Returns(new GitReferenceModel("prbranch", "fork:prbranch", "123", "https://foo.bar/fork/repo.git"));
+                var pr = Substitute.For<IPullRequestModel>();
+                pr.Number.Returns(5);
+                pr.Base.Returns(new GitReferenceModel("master", "owner:master", "123", "https://foo.bar/owner/repo.git"));
+                pr.Head.Returns(new GitReferenceModel("prbranch", "fork:prbranch", "123", "https://foo.bar/fork/repo.git"));
 
-            await service.Checkout(localRepo, pr, "pr/5-fork-branch");
+                await service.Checkout(localRepo, pr, "pr/5-fork-branch");
 
-            gitClient.Received().SetRemote(Arg.Any<IRepository>(), "fork1", new Uri("https://foo.bar/fork/repo.git")).Forget();
-            gitClient.Received().SetConfig(Arg.Any<IRepository>(), "remote.fork1.created-by-ghfvs", "true").Forget();
+                gitClient.Received().SetRemote(Arg.Any<IRepository>(), "fork1", new Uri("https://foo.bar/fork/repo.git")).Forget();
+                gitClient.Received().SetConfig(Arg.Any<IRepository>(), "remote.fork1.created-by-ghfvs", "true").Forget();
+            }
         }
     }
 
@@ -745,35 +747,37 @@ public class PullRequestServiceTests : TestBaseClass
             var localRepo = Substitute.For<ILocalRepositoryModel>();
             localRepo.CloneUrl.Returns(new UriString("https://github.com/foo/bar"));
 
-            var repo = gitService.GetRepository(localRepo.CloneUrl);
-            var remote1 = Substitute.For<Remote>();
-            var remote2 = Substitute.For<Remote>();
-            var remote3 = Substitute.For<Remote>();
-            var remotes = new List<Remote> { remote1, remote2, remote3 };
-            var remoteCollection = Substitute.For<RemoteCollection>();
-            remote1.Name.Returns("remote1");
-            remote2.Name.Returns("remote2");
-            remote3.Name.Returns("remote3");
-            remoteCollection.GetEnumerator().Returns(_ => remotes.GetEnumerator());
-            repo.Network.Remotes.Returns(remoteCollection);
+            using (var repo = gitService.GetRepository(localRepo.CloneUrl))
+            {
+                var remote1 = Substitute.For<Remote>();
+                var remote2 = Substitute.For<Remote>();
+                var remote3 = Substitute.For<Remote>();
+                var remotes = new List<Remote> { remote1, remote2, remote3 };
+                var remoteCollection = Substitute.For<RemoteCollection>();
+                remote1.Name.Returns("remote1");
+                remote2.Name.Returns("remote2");
+                remote3.Name.Returns("remote3");
+                remoteCollection.GetEnumerator().Returns(_ => remotes.GetEnumerator());
+                repo.Network.Remotes.Returns(remoteCollection);
 
-            var branch1 = Substitute.For<LibGit2Sharp.Branch>();
-            var branch2 = Substitute.For<LibGit2Sharp.Branch>();
-            var branches = new List<LibGit2Sharp.Branch> { branch1, branch2 };
-            var branchCollection = Substitute.For<BranchCollection>();
-            branch1.RemoteName.Returns("remote1");
-            branch2.RemoteName.Returns("remote1");
-            branchCollection.GetEnumerator().Returns(_ => branches.GetEnumerator());
-            repo.Branches.Returns(branchCollection);
+                var branch1 = Substitute.For<LibGit2Sharp.Branch>();
+                var branch2 = Substitute.For<LibGit2Sharp.Branch>();
+                var branches = new List<LibGit2Sharp.Branch> { branch1, branch2 };
+                var branchCollection = Substitute.For<BranchCollection>();
+                branch1.RemoteName.Returns("remote1");
+                branch2.RemoteName.Returns("remote1");
+                branchCollection.GetEnumerator().Returns(_ => branches.GetEnumerator());
+                repo.Branches.Returns(branchCollection);
 
-            gitClient.GetConfig<bool>(Arg.Any<IRepository>(), "remote.remote1.created-by-ghfvs").Returns(Task.FromResult(true));
-            gitClient.GetConfig<bool>(Arg.Any<IRepository>(), "remote.remote2.created-by-ghfvs").Returns(Task.FromResult(true));
+                gitClient.GetConfig<bool>(Arg.Any<IRepository>(), "remote.remote1.created-by-ghfvs").Returns(Task.FromResult(true));
+                gitClient.GetConfig<bool>(Arg.Any<IRepository>(), "remote.remote2.created-by-ghfvs").Returns(Task.FromResult(true));
 
-            await service.RemoveUnusedRemotes(localRepo);
+                await service.RemoveUnusedRemotes(localRepo);
 
-            remoteCollection.DidNotReceive().Remove("remote1");
-            remoteCollection.Received().Remove("remote2");
-            remoteCollection.DidNotReceive().Remove("remote3");
+                remoteCollection.DidNotReceive().Remove("remote1");
+                remoteCollection.Received().Remove("remote2");
+                remoteCollection.DidNotReceive().Remove("remote3");
+            }
         }
     }
 


### PR DESCRIPTION
## The Bug

The following code can fail on the `repo.RetrieveStatus()` line with an `AccessViolationException`:

```c#
var repo = new Repository(path);
var status = repo.RetrieveStatus();
```

This is because `RetrieveStatus` creates a native pointer to the `Repository` object and but doesn't hold on to a managed reference. This allows the `Repository` object to be GCed before `RetrieveStatus` has finished with the native pointer.

- When does an object become available for garbage collection?https://blogs.msdn.microsoft.com/oldnewthing/20100810-00/?p=13193/

To vaoid random crashes, we need to be careful to keep a reference to `Repository` when calling its methods. The above code can be fixed like this:

```c#
var repo = new Repository(path);
var status = repo.RetrieveStatus();
GC.KeepAlive(repo);
```

Alternatively since the `Repository` object implements `IDisposable`, the following will keep a reference and dispose of it  afterwards:

```c#
using (var repo = new Repository(path))
{
    var status = repo.RetrieveStatus();
}
```

This PR wraps all temporary references to a `Repository` object in a `using` statement.

## Possible Gotchas

- This bug only shows up when the extension is compiled in `Release` configuration (in `Debug` configuration, references are held on to for longer and this bug doesn't occur).
- We need to make sure we don't return objects that keep references to disposed `Repository` objects. For example here, we need to make sure that `CommitMessage` doesn't cache a reference to the disposed `Repository` object:
https://github.com/github/VisualStudio/blob/7fb09a3282369eeb944b3b3b5d1b1c45c5d26c3f/src/GitHub.App/Services/PullRequestService.cs#L101

Fixes #1315
See also: https://github.com/libgit2/libgit2sharp/issues/1513