### PR TITLE
Fix build/install to match README.md

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,2 @@
-powershell -ExecutionPolicy Unrestricted scripts\build.ps1 %1
+@if "%1" == "" echo Please specify Debug or Release && EXIT /B
+powershell -ExecutionPolicy Unrestricted scripts\build.ps1 -Package:$true -Config:%1

--- a/install.cmd
+++ b/install.cmd
@@ -1,4 +1,3 @@
-@set Configuration=%1
-@if "%Configuration%" == "" echo Please specify Debug or Release
-tools\VsixUtil\vsixutil /install "build\%Configuration%\GitHub.VisualStudio.vsix"
-@echo Installed %Configuration% build of GitHub for Visual Studio
+@if "%1" == "" echo Please specify Debug or Release && EXIT /B
+tools\VsixUtil\vsixutil /install "build\%1\GitHub.VisualStudio.vsix"
+@echo Installed %1 build of GitHub for Visual Studio


### PR DESCRIPTION
The `build.cmd` and `install.cmd` files have been fixed to match the `README.md`:
https://github.com/github/visualstudio#build-flavors

(they both should accept Debug or Release)