### PR TITLE
Lightweight fix for PR detail view not refreshing

### DIFF
--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -76,25 +76,12 @@ namespace GitHub.ViewModels
         {
             this.vsGitExt = vsGitExt;
 
-            AutoDispose.DisposePrevious(this);
             vsGitExt.ActiveRepositoriesChanged += Refresh;
         }
 
         public void Dispose()
         {
             vsGitExt.ActiveRepositoriesChanged -= Refresh;
-        }
-
-        // HACK: This is a workaround for models not being automatically disposed.
-        static class AutoDispose
-        {
-            static IDisposable previous;
-
-            internal static void DisposePrevious(IDisposable disposable)
-            {
-                previous?.Dispose();
-                previous = disposable;
-            }
         }
 
         /// <summary>

--- a/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestDetailViewModel.cs
@@ -26,7 +26,7 @@ namespace GitHub.ViewModels
     /// </summary>
     [ExportViewModel(ViewType = UIViewType.PRDetail)]
     [PartCreationPolicy(CreationPolicy.NonShared)]
-    public class PullRequestDetailViewModel : PanePageViewModelBase, IPullRequestDetailViewModel, IDisposable
+    public sealed class PullRequestDetailViewModel : PanePageViewModelBase, IPullRequestDetailViewModel, IDisposable
     {
         static readonly ILogger log = LogManager.ForContext<PullRequestDetailViewModel>();
 
@@ -86,7 +86,7 @@ namespace GitHub.ViewModels
         }
 
         // HACK: This is a workaround for models not being automatically disposed.
-        class AutoDispose
+        static class AutoDispose
         {
             static IDisposable previous;
 


### PR DESCRIPTION
This PR listens to the `IVSGitExt` service for `ActiveRepositoriesChanged` events and refreshes the model.

I considered extending `ITeamExplorerServiceHolder`, but this code is already quite confusing and I didn't want to complicate it further.

At the moment there is no obvious way to dispose of view models. ~~As a workaround, this code assumes there is only one active `PullRequestDetailViewModel` object and automatically disposes of any previous instances.~~

I spoke with @grokys about how this might be handled in future. A future implementation of the `GitHub` pane might dispose of view models, making the `AutoDispose` workaround redundant.

Fixes #1345.