### PR TITLE
Add lifecycle management for GitHub Pane pages

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
@@ -46,6 +46,7 @@ namespace GitHub.ViewModels.GitHubPane
         readonly ReactiveCommand<Unit> refresh;
         readonly ReactiveCommand<Unit> showPullRequests;
         readonly ReactiveCommand<object> openInBrowser;
+        bool initialized;
         IViewModel content;
         ILocalRepositoryModel localRepository;
         string searchQuery;
@@ -343,10 +344,13 @@ namespace GitHub.ViewModels.GitHubPane
 
         async Task UpdateContent(ILocalRepositoryModel repository)
         {
+            if (initialized && Equals(repository, LocalRepository)) return;
+
+            initialized = true;
             LocalRepository = repository;
             Connection = null;
-
             Content = null;
+            navigator.Clear();
 
             if (repository == null)
             {
@@ -372,7 +376,6 @@ namespace GitHub.ViewModels.GitHubPane
 
                 if (Connection != null)
                 {
-                    navigator.Clear();
                     Content = navigator;
                     await ShowDefaultPage();
                 }

--- a/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
@@ -200,7 +200,7 @@ namespace GitHub.ViewModels.GitHubPane
         public async Task InitializeAsync(IServiceProvider paneServiceProvider)
         {
             await UpdateContent(teServiceHolder.ActiveRepo);
-            teServiceHolder.Subscribe(this, x => UpdateContent(x).Forget());
+            teServiceHolder.Subscribe(this, x => UpdateContentIfRepositoryChanged(x).Forget());
             connectionManager.Connections.CollectionChanged += (_, __) => UpdateContent(LocalRepository).Forget();
 
             BindNavigatorCommand(paneServiceProvider, PkgCmdIDList.pullRequestCommand, showPullRequests);
@@ -344,8 +344,6 @@ namespace GitHub.ViewModels.GitHubPane
 
         async Task UpdateContent(ILocalRepositoryModel repository)
         {
-            if (initialized && Equals(repository, LocalRepository)) return;
-
             initialized = true;
             LocalRepository = repository;
             Connection = null;
@@ -387,6 +385,14 @@ namespace GitHub.ViewModels.GitHubPane
             else
             {
                 Content = notAGitHubRepository;
+            }
+        }
+
+        async Task UpdateContentIfRepositoryChanged(ILocalRepositoryModel repository)
+        {
+            if (!initialized || !Equals(repository, LocalRepository))
+            {
+                await UpdateContent(repository);
             }
         }
 

--- a/src/GitHub.App/ViewModels/GitHubPane/NavigationViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/NavigationViewModel.cs
@@ -119,7 +119,7 @@ namespace GitHub.ViewModels.GitHubPane
              
         void BeforeItemAdded(IPanePageViewModel page)
         {
-            if (page.CloseRequested != null && !history.Contains(page))
+            if (!history.Contains(page))
             {
                 page.CloseRequested.Subscribe(_ => RemoveAll(page));
             }

--- a/src/GitHub.App/ViewModels/GitHubPane/PanePageViewModelBase.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PanePageViewModelBase.cs
@@ -12,7 +12,8 @@ namespace GitHub.ViewModels.GitHubPane
     public abstract class PanePageViewModelBase : ViewModelBase, IPanePageViewModel, IDisposable
     {
         static readonly Uri paneUri = new Uri("github://pane");
-        Subject<Uri> navigate = new Subject<Uri>();
+        readonly Subject<Uri> navigate = new Subject<Uri>();
+        readonly Subject<Unit> close = new Subject<Unit>();
         Exception error;
         bool isBusy;
         bool isLoading;
@@ -59,7 +60,7 @@ namespace GitHub.ViewModels.GitHubPane
         }
 
         /// <inheritdoc/>
-        public virtual IObservable<Unit> CloseRequested { get; }
+        public IObservable<Unit> CloseRequested => close;
 
         /// <inheritdoc/>
         public IObservable<Uri> NavigationRequested => navigate;
@@ -85,6 +86,11 @@ namespace GitHub.ViewModels.GitHubPane
         public virtual Task Refresh() => Task.CompletedTask;
 
         /// <summary>
+        /// Sends a request to close the page.
+        /// </summary>
+        protected void Close() => close.OnNext(Unit.Default);
+
+        /// <summary>
         /// Sends a request to navigate to a new page.
         /// </summary>
         /// <param name="uri">
@@ -96,8 +102,8 @@ namespace GitHub.ViewModels.GitHubPane
         {
             if (disposing)
             {
-                navigate?.Dispose();
-                navigate = null;
+                close.Dispose();
+                navigate.Dispose();
             }
         }
     }

--- a/src/GitHub.App/ViewModels/GitHubPane/PanePageViewModelBase.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PanePageViewModelBase.cs
@@ -65,6 +65,16 @@ namespace GitHub.ViewModels.GitHubPane
         public IObservable<Uri> NavigationRequested => navigate;
 
         /// <inheritdoc/>
+        public virtual void Activated()
+        {
+        }
+
+        /// <inheritdoc/>
+        public virtual void Deactivated()
+        {
+        }
+
+        /// <inheritdoc/>
         public void Dispose()
         {
             Dispose(true);

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestCreationViewModel.cs
@@ -95,6 +95,7 @@ namespace GitHub.ViewModels.GitHubPane
             });
 
             Cancel = ReactiveCommand.Create();
+            Cancel.Subscribe(_ => Close());
 
             isExecuting = CreatePullRequest.IsExecuting.ToProperty(this, x => x.IsExecuting);
 
@@ -298,7 +299,5 @@ namespace GitHub.ViewModels.GitHubPane
             get { return branchValidator; }
             set { this.RaiseAndSetIfChanged(ref branchValidator, value); }
         }
-
-        public override IObservable<Unit> CloseRequested => Cancel.SelectUnit();
     }
 }

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
@@ -46,6 +47,8 @@ namespace GitHub.ViewModels.GitHubPane
         bool isCheckedOut;
         bool isFromFork;
         bool isInCheckout;
+        bool active;
+        bool refreshOnActivate;
         Uri webUrl;
 
         /// <summary>
@@ -483,6 +486,21 @@ namespace GitHub.ViewModels.GitHubPane
         }
 
         /// <inheritdoc/>
+        public override void Activated()
+        {
+            active = true;
+
+            if (refreshOnActivate)
+            {
+                Refresh().Forget();
+                refreshOnActivate = false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Deactivated() => active = false;
+
+        /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
@@ -493,7 +511,17 @@ namespace GitHub.ViewModels.GitHubPane
             }
         }
 
-        void ActiveRepositoriesChanged() => Refresh().Forget();
+        void ActiveRepositoriesChanged()
+        {
+            if (active)
+            {
+                Refresh().Forget();
+            }
+            else
+            {
+                refreshOnActivate = true;
+            }
+        }
 
         void SubscribeOperationError(ReactiveCommand<Unit> command)
         {

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
@@ -193,12 +193,15 @@ namespace GitHub.ViewModels.GitHubPane
                 filterTextIsString = hasText && !filterTextIsNumber;
             }
 
-            pullRequests.Filter = (pullRequest, index, list) =>
-                (!state.IsOpen.HasValue || state.IsOpen == pullRequest.IsOpen) &&
-                (ass == null || ass.Equals(pullRequest.Assignee)) &&
-                (aut == null || aut.Equals(pullRequest.Author)) &&
-                (filterTextIsNumber == false || pullRequest.Number == filterPullRequestNumber) && 
-                (filterTextIsString == false || pullRequest.Title.ToUpperInvariant().Contains(filText.ToUpperInvariant()));
+            if (!pullRequests.Disposed)
+            {
+                pullRequests.Filter = (pullRequest, index, list) =>
+                    (!state.IsOpen.HasValue || state.IsOpen == pullRequest.IsOpen) &&
+                    (ass == null || ass.Equals(pullRequest.Assignee)) &&
+                    (aut == null || aut.Equals(pullRequest.Author)) &&
+                    (filterTextIsNumber == false || pullRequest.Number == filterPullRequestNumber) &&
+                    (filterTextIsString == false || pullRequest.Title.ToUpperInvariant().Contains(filText.ToUpperInvariant()));
+            }
         }
 
         string searchQuery;

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/INavigationViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/INavigationViewModel.cs
@@ -58,14 +58,6 @@ namespace GitHub.ViewModels
         void NavigateTo(IPanePageViewModel page);
 
         /// <summary>
-        /// Registers a resource for disposal when all instances of a page are removed from the
-        /// history.
-        /// </summary>
-        /// <param name="page">The page.</param>
-        /// <param name="dispose">The resource to dispose.</param>
-        void RegisterDispose(IPanePageViewModel page, IDisposable dispose);
-
-        /// <summary>
         /// Removes all instances of a page from the history.
         /// </summary>
         /// <param name="page">The page to remove.</param>

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPanePageViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPanePageViewModel.cs
@@ -7,7 +7,7 @@ namespace GitHub.ViewModels.GitHubPane
     /// <summary>
     /// A view model that represents a page in the GitHub pane.
     /// </summary>
-    public interface IPanePageViewModel : IViewModel
+    public interface IPanePageViewModel : IViewModel, IDisposable
     {
         /// <summary>
         /// Gets an exception representing an error state to display.
@@ -47,6 +47,16 @@ namespace GitHub.ViewModels.GitHubPane
         /// pane.
         /// </summary>
         IObservable<Uri> NavigationRequested { get; }
+
+        /// <summary>
+        /// Called when the page becomes the current page in the GitHub pane.
+        /// </summary>
+        void Activated();
+
+        /// <summary>
+        /// Called when the page stops being the current page in the GitHub pane.
+        /// </summary>
+        void Deactivated();
 
         /// <summary>
         /// Refreshes the view model.

--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/NavigationViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/NavigationViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using GitHub.ViewModels.GitHubPane;
 using NSubstitute;
@@ -412,7 +413,7 @@ public class NavigationViewModelTests
     static IPanePageViewModel CreatePage()
     {
         var result = Substitute.For<IPanePageViewModel>();
-        result.CloseRequested.Returns((IObservable<Unit>)null);
+        result.CloseRequested.Returns(Observable.Never<Unit>());
         return result;
     }
 }


### PR DESCRIPTION
This PR makes `IPanePageViewModel`s get disposed when they are removed from a `NavigationViewModel`'s history. It also adds `Activated` and `Deactivated` methods to `IPanePageViewModel` which are called when the page is moved to/away from in the navigator. `NavigationViewModel.RegisterDispose` has been removed as disposing of the view models should suffice.

It modifies `PullRequestDetailViewModel` to only refresh when the page is active. When not active, it simply sets a flag to refresh when the page is activated. This should prevent all pages in the GitHub pane history refreshing at once, which is an expensive operation.

Depends on #1346 
Fixes #1360