### PR TITLE
Task-ize ConnectionManagerExtensions

### DIFF
--- a/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
@@ -14,7 +14,7 @@ namespace GitHub.Extensions
             IModelServiceFactory factory)
         {
             var connection = await cm.GetConnection(repository);
-            return connection != null ? await factory.CreateAsync(connection) : null;
+            return connection?.IsLoggedIn == true ? await factory.CreateAsync(connection) : null;
         }
     }
 }

--- a/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
@@ -1,66 +1,13 @@
 ﻿using System;
-using System.Linq;
-using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using GitHub.Factories;
 using GitHub.Models;
-using GitHub.Primitives;
 using GitHub.Services;
 
 namespace GitHub.Extensions
 {
     public static class ConnectionManagerExtensions
     {
-        public static IObservable<bool> IsLoggedIn(this IConnectionManager cm)
-        {
-            Guard.ArgumentNotNull(cm, nameof(cm));
-
-            return Observable.FromAsync(async () =>
-            {
-                var connections = await cm.GetLoadedConnections();
-                return connections.Any(x => x.ConnectionError == null);
-            });
-        }
-
-        public static IObservable<bool> IsLoggedIn(this IConnectionManager cm, HostAddress address)
-        {
-            Guard.ArgumentNotNull(cm, nameof(cm));
-            Guard.ArgumentNotNull(address, nameof(address));
-
-            return Observable.FromAsync(async () =>
-            {
-                var connections = await cm.GetLoadedConnections();
-                return connections.Any(x => x.HostAddress == address && x.ConnectionError == null);
-            });
-        }
-
-        public static IObservable<bool> IsLoggedIn(this IConnection connection)
-        {
-            Guard.ArgumentNotNull(connection, nameof(connection));
-
-            return Observable.Return(connection?.IsLoggedIn ?? false);
-        }
-
-        public static IObservable<IConnection> GetConnection(this IConnectionManager cm, HostAddress address)
-        {
-            Guard.ArgumentNotNull(cm, nameof(cm));
-            Guard.ArgumentNotNull(address, nameof(address));
-
-            return cm.GetLoadedConnections()
-                .ToObservable()
-                .Select(x => x.FirstOrDefault(y => y.HostAddress == address));
-        }
-
-        public static IObservable<IConnection> GetLoggedInConnections(this IConnectionManager cm)
-        {
-            Guard.ArgumentNotNull(cm, nameof(cm));
-
-            return cm.GetLoadedConnections()
-                .ToObservable()
-                .Select(x => x.FirstOrDefault(y => y.IsLoggedIn));
-        }
-
         public static async Task<IModelService> GetModelService(
             this IConnectionManager cm,
             ILocalRepositoryModel repository,
@@ -68,13 +15,6 @@ namespace GitHub.Extensions
         {
             var connection = await cm.LookupConnection(repository);
             return connection != null ? await factory.CreateAsync(connection) : null;
-        }
-
-        public static IObservable<IConnection> LookupConnection(this IConnectionManager cm, ILocalRepositoryModel repository)
-        {
-            return Observable.Return(repository?.CloneUrl != null
-                ? cm.Connections.FirstOrDefault(c => c.HostAddress.Equals(HostAddress.Create(repository.CloneUrl)))
-                : null);
         }
     }
 }

--- a/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
@@ -13,7 +13,7 @@ namespace GitHub.Extensions
             ILocalRepositoryModel repository,
             IModelServiceFactory factory)
         {
-            var connection = await cm.LookupConnection(repository);
+            var connection = await cm.GetConnection(repository);
             return connection != null ? await factory.CreateAsync(connection) : null;
         }
     }

--- a/src/GitHub.Exports/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports/Extensions/ConnectionManagerExtensions.cs
@@ -26,7 +26,7 @@ namespace GitHub.Extensions
             return connections.Any(x => x.HostAddress == address && x.ConnectionError == null);
         }
 
-        public static async Task<IConnection> GetLoggedInConnections(this IConnectionManager cm)
+        public static async Task<IConnection> GetFirstLoggedInConnection(this IConnectionManager cm)
         {
             Guard.ArgumentNotNull(cm, nameof(cm));
 
@@ -34,7 +34,7 @@ namespace GitHub.Extensions
             return connections.FirstOrDefault(x => x.IsLoggedIn);
         }
 
-        public static Task<IConnection> LookupConnection(this IConnectionManager cm, ILocalRepositoryModel repository)
+        public static Task<IConnection> GetConnection(this IConnectionManager cm, ILocalRepositoryModel repository)
         {
             if (repository?.CloneUrl != null)
             {

--- a/src/GitHub.Exports/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports/Extensions/ConnectionManagerExtensions.cs
@@ -34,7 +34,7 @@ namespace GitHub.Extensions
             return connections.FirstOrDefault(x => x.IsLoggedIn);
         }
 
-        public static Task<IConnection> GetConnection(this IConnectionManager cm, ILocalRepositoryModel repository)
+        public static Task<IConnection> GetConnection(this IConnectionManager cm, IRepositoryModel repository)
         {
             if (repository?.CloneUrl != null)
             {

--- a/src/GitHub.Exports/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports/Extensions/ConnectionManagerExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GitHub.Models;
+using GitHub.Primitives;
+using GitHub.Services;
+
+namespace GitHub.Extensions
+{
+    public static class ConnectionManagerExtensions
+    {
+        public static async Task<bool> IsLoggedIn(this IConnectionManager cm)
+        {
+            Guard.ArgumentNotNull(cm, nameof(cm));
+
+            var connections = await cm.GetLoadedConnections();
+            return connections.Any(x => x.ConnectionError == null);
+        }
+
+        public static async Task<bool> IsLoggedIn(this IConnectionManager cm, HostAddress address)
+        {
+            Guard.ArgumentNotNull(cm, nameof(cm));
+            Guard.ArgumentNotNull(address, nameof(address));
+
+            var connections = await cm.GetLoadedConnections();
+            return connections.Any(x => x.HostAddress == address && x.ConnectionError == null);
+        }
+
+        public static async Task<IConnection> GetLoggedInConnections(this IConnectionManager cm)
+        {
+            Guard.ArgumentNotNull(cm, nameof(cm));
+
+            var connections = await cm.GetLoadedConnections();
+            return connections.FirstOrDefault(x => x.IsLoggedIn);
+        }
+
+        public static Task<IConnection> LookupConnection(this IConnectionManager cm, ILocalRepositoryModel repository)
+        {
+            if (repository?.CloneUrl != null)
+            {
+                var hostAddress = HostAddress.Create(repository.CloneUrl);
+                return cm.GetConnection(hostAddress);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -140,6 +140,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Exports\ExportForProcess.cs" />
+    <Compile Include="Extensions\ConnectionManagerExtensions.cs" />
     <Compile Include="GitHubLogicException.cs" />
     <Compile Include="Models\CommitMessage.cs" />
     <Compile Include="Models\DiffChangeType.cs" />

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
@@ -951,9 +951,10 @@ Line 4";
         {
             var connection = Substitute.For<IConnection>();
             connection.HostAddress.Returns(HostAddress.Create("https://github.com"));
+            connection.IsLoggedIn.Returns(true);
 
             var result = Substitute.For<IConnectionManager>();
-            result.Connections.Returns(new ObservableCollectionEx<IConnection>(new[] { connection }));
+            result.GetConnection(connection.HostAddress).Returns(connection);
             return result;
         }
 


### PR DESCRIPTION
`ConnectionManagerExtensions` methods were returning `IObservables` but only returning a single value. Convert them to return `Task`s so they can be used in Team Explorer etc.

Also made the naming consistent and made sure we don't to try to create an `IModelService` for a non-logged-in connection.