### PR TITLE
Simplify ViewViewModelFactory

### DIFF
--- a/src/GitHub.App/Factories/ViewViewModelFactory.cs
+++ b/src/GitHub.App/Factories/ViewViewModelFactory.cs
@@ -43,7 +43,7 @@ namespace GitHub.Factories
         /// <inheritdoc/>
         public FrameworkElement CreateView(Type viewModel)
         {
-            var f = Views.FirstOrDefault(x => x.Metadata.ViewModelType.Contains(viewModel));
+            var f = Views.FirstOrDefault(x => x.Metadata.ViewModelType.Contains(viewModel.FullName));
             return f?.CreateExport().Value;
         }
     }

--- a/src/GitHub.App/Factories/ViewViewModelFactory.cs
+++ b/src/GitHub.App/Factories/ViewViewModelFactory.cs
@@ -20,11 +20,9 @@ namespace GitHub.Factories
 
         [ImportingConstructor]
         public ViewViewModelFactory(
-            IGitHubServiceProvider serviceProvider,
-            ICompositionService cc)
+            IGitHubServiceProvider serviceProvider)
         {
             this.serviceProvider = serviceProvider;
-            cc.SatisfyImportsOnce(this);
         }
 
         [ImportMany(AllowRecomposition = true)]

--- a/src/GitHub.App/Factories/ViewViewModelFactory.cs
+++ b/src/GitHub.App/Factories/ViewViewModelFactory.cs
@@ -25,7 +25,7 @@ namespace GitHub.Factories
             this.serviceProvider = serviceProvider;
         }
 
-        [ImportMany(AllowRecomposition = true)]
+        [ImportMany]
         IEnumerable<ExportFactory<FrameworkElement, IViewModelMetadata>> Views { get; set; }
 
         /// <inheritdoc/>

--- a/src/GitHub.Exports/Exports/ExportMetadata.cs
+++ b/src/GitHub.Exports/Exports/ExportMetadata.cs
@@ -37,10 +37,10 @@ namespace GitHub.Exports
         public ExportViewForAttribute(Type viewModelType)
             : base(typeof(FrameworkElement))
         {
-            ViewModelType = viewModelType;
+            ViewModelType = viewModelType.FullName;
         }
 
-        public Type ViewModelType { get; }
+        public string ViewModelType { get; }
     }
 
     /// <summary>
@@ -69,7 +69,7 @@ namespace GitHub.Exports
     public interface IViewModelMetadata
     {
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
-        Type[] ViewModelType { get; }
+        string[] ViewModelType { get; }
     }
 
     /// <summary>

--- a/src/GitHub.Exports/Exports/ExportMetadata.cs
+++ b/src/GitHub.Exports/Exports/ExportMetadata.cs
@@ -32,6 +32,8 @@ namespace GitHub.Exports
     /// </summary>
     [MetadataAttribute]
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments",
+        Justification = "Store string rather than Type as metadata")]
     public sealed class ExportViewForAttribute : ExportAttribute
     {
         public ExportViewForAttribute(Type viewModelType)


### PR DESCRIPTION
This PR:

- Removes unnecessary call to `SatisfyImportsOnce`
- Removed unsupported setting of `AllowRecomposition`
- Stores `ViewModelType` as a `string` in metadata to avoid pre-loading assemblies

Storing the `ViewModelType` as a `string` mirrors the way `Export` metadata is stored. For example, the export: `Export(typeof(Foo.IBar))` will create a metadata property `ExportTypeIdentity` with the string "Foo.IBar".

Removing the dependency on `IGitHubServiceProvider` is more complicated and might be tackled in a separate PR, see: 
https://github.com/github/VisualStudio/pull/1370#discussion_r156337188

Fixes #1361 