### PR TITLE
Fix Sign in link in several docs .md files

### DIFF
--- a/docs/contributing/creating-an-empty-repository-from-visual-studio.md
+++ b/docs/contributing/creating-an-empty-repository-from-visual-studio.md
@@ -1,6 +1,6 @@
 # Creating an empty repository from Visual Studio
 
-1. [Sign in](authenticating-to-github) to GitHub.
+1. [Sign in](../getting-started/authenticating-to-github.md) to GitHub.
 
 2. Open **Team Explorer** by clicking on its tab next to *Solution Explorer*, or via the *View* menu.
 

--- a/docs/contributing/creating-gists.md
+++ b/docs/contributing/creating-gists.md
@@ -2,7 +2,7 @@
 
 GitHub for Visual Studio enables easy creation of gists directly from the Visual Studio Editor.
 
-1. [Sign in](authenticating-to-github) to GitHub.
+1. [Sign in](../getting-started/authenticating-to-github.md) to GitHub.
 
 2. Open a file in the Visual Studio text editor.
 

--- a/docs/contributing/viewing-the-pull-requests-for-a-repository.md
+++ b/docs/contributing/viewing-the-pull-requests-for-a-repository.md
@@ -2,7 +2,7 @@
 
 GitHub for Visual Studio exposes the pull requests for the current repository and lets you create new pull requests and review pull requests from other contributors.
 
-1. [Sign in](authenticating-to-github) to GitHub.
+1. [Sign in](../getting-started/authenticating-to-github.md) to GitHub.
 2. Open a solution in a GitHub repository.
 3. Open **Team Explorer** and click the **Pull Requests** button to open the **GitHub** pane.
 ![Pull Requests button in the Team Explorer pane](images/pull-requests-button2.png)


### PR DESCRIPTION
- Sign in links are broken in three different files because the linked file does not exist in the same directory.
- The fix was to utilize relative path to get to the right file.

Eissa