### PR TITLE
Avoid possible NRE in DiffService.

### DIFF
--- a/src/GitHub.Exports/Models/DiffUtilities.cs
+++ b/src/GitHub.Exports/Models/DiffUtilities.cs
@@ -13,6 +13,8 @@ namespace GitHub.Models
 
         public static IEnumerable<DiffChunk> ParseFragment(string diff)
         {
+            Guard.ArgumentNotNull(diff, nameof(diff));
+
             var reader = new LineReader(diff);
             string line;
             DiffChunk chunk = null;

--- a/src/GitHub.InlineReviews/Services/DiffService.cs
+++ b/src/GitHub.InlineReviews/Services/DiffService.cs
@@ -32,7 +32,15 @@ namespace GitHub.InlineReviews.Services
             string path)
         {
             var patch = await gitClient.Compare(repo, baseSha, headSha, path);
-            return DiffUtilities.ParseFragment(patch).ToList();
+
+            if (patch != null)
+            {
+                return DiffUtilities.ParseFragment(patch).ToList();
+            }
+            else
+            {
+                return new DiffChunk[0];
+            }
         }
 
         /// <inheritdoc/>
@@ -44,7 +52,15 @@ namespace GitHub.InlineReviews.Services
             byte[] contents)
         {
             var changes = await gitClient.CompareWith(repo, baseSha, headSha, path, contents);
-            return DiffUtilities.ParseFragment(changes.Patch).ToList();
+
+            if (changes?.Patch != null)
+            {
+                return DiffUtilities.ParseFragment(changes.Patch).ToList();
+            }
+            else
+            {
+                return new DiffChunk[0];
+            }
         }
     }
 }


### PR DESCRIPTION
`GitClient.Compare` and `GitClient.CompareWith` can return null if one of the requested commits can't be found. Don't try to pass this null to `ParseFragment` . Also add a null guard to `ParseFragment` to make this clearer.

Fixes #1240