### PR TITLE
Make deleted file visible on Dark theme.

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -317,9 +317,13 @@
                                                 <ui:OcticonImage.Style>
                                                     <Style TargetType="ui:OcticonImage" BasedOn="{StaticResource OcticonImage}">
                                                         <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding Status}" Value="Removed">
+                                                            <MultiDataTrigger>
+                                                                <MultiDataTrigger.Conditions>
+                                                                    <Condition Binding="{Binding Status}" Value="Removed"/>
+                                                                    <Condition Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type TreeViewItem}}, Path=IsSelected}" Value="False"/>
+                                                                </MultiDataTrigger.Conditions>
                                                                 <Setter Property="Foreground" Value="{DynamicResource GitHubDeletedFileIconBrush}"/>
-                                                            </DataTrigger>
+                                                            </MultiDataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
                                                 </ui:OcticonImage.Style>
@@ -329,9 +333,15 @@
                                                     <Style TargetType="TextBlock">
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding Status}" Value="Removed">
-                                                                <Setter Property="Foreground" Value="{DynamicResource GitHubDeletedFileBrush}"/>
                                                                 <Setter Property="TextDecorations" Value="Strikethrough"/>
                                                             </DataTrigger>
+                                                            <MultiDataTrigger>
+                                                                <MultiDataTrigger.Conditions>
+                                                                    <Condition Binding="{Binding Status}" Value="Removed"/>
+                                                                    <Condition Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type TreeViewItem}}, Path=IsSelected}" Value="False"/>
+                                                                </MultiDataTrigger.Conditions>
+                                                                <Setter Property="Foreground" Value="{DynamicResource GitHubDeletedFileBrush}"/>
+                                                            </MultiDataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
                                                 </TextBlock.Style>


### PR DESCRIPTION
Only change the color of a deleted file's icon and text foreground to a subdued gray when the item is not selected, otherwise it becomes unreadable in the Dark theme.

Before:

![image](https://user-images.githubusercontent.com/310137/33321861-7255f5b0-d447-11e7-85b2-b04674c72629.png)

After:

![image](https://user-images.githubusercontent.com/1775141/33882395-3f9caf3c-df38-11e7-94c4-81a0e3a57ee3.png)

Fixes #1349