### PR TITLE
Relax the GitHub pane URL regex.

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
@@ -402,8 +402,8 @@ namespace GitHub.ViewModels.GitHubPane
 
         static Regex CreateRoute(string route)
         {
-            // Build RegEx from route (:foo to named group (?<foo>[a-z0-9]+)).
-            var routeFormat = new Regex("(:([a-z]+))\\b").Replace(route, "(?<$2>[a-z0-9]+)");
+            // Build RegEx from route (:foo to named group (?<foo>[\w_.-]+)).
+            var routeFormat = new Regex("(:([a-z]+))\\b").Replace(route, @"(?<$2>[\w_.-]+)");
             return new Regex(routeFormat, RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
         }
     }


### PR DESCRIPTION
Fix the GitHub pane URL regex that was causing #1376.

Although the actual regex for validating GitHub usernames and repository names are more complex than this, we're not actually _validating_ them, we just want to be able to parse them. The new regex, `[\w_.-]+` should encompass all valid usernames and repo names I think.

Fixes #1376