### PR TITLE
Fix Diff Display for Moved Files.

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -61,7 +61,7 @@ This requires that errors be propagated from the viewmodel to the view and from 
             var repositoriesDir = new PullRequestDirectoryNode("Repositories");
             var itrackingBranch = new PullRequestFileNode(repoPath, @"GitHub\Models\ITrackingBranch.cs", "abc", PullRequestFileStatus.Modified, null);
             var oldBranchModel = new PullRequestFileNode(repoPath, @"GitHub\Models\OldBranchModel.cs", "abc", PullRequestFileStatus.Removed, null);
-            var concurrentRepositoryConnection = new PullRequestFileNode(repoPath, @"GitHub\Repositories\ConcurrentRepositoryConnection.cs", "abc", PullRequestFileStatus.Added, "add");
+            var concurrentRepositoryConnection = new PullRequestFileNode(repoPath, @"GitHub\Repositories\ConcurrentRepositoryConnection.cs", "abc", PullRequestFileStatus.Added, null);
 
             repositoriesDir.Files.Add(concurrentRepositoryConnection);
             modelsDir.Directories.Add(repositoriesDir);

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
@@ -470,6 +470,12 @@ namespace GitHub.ViewModels.GitHubPane
         {
             var relativePath = Path.Combine(file.DirectoryPath, file.FileName);
             var encoding = pullRequestsService.GetEncoding(LocalRepository, relativePath);
+
+            if (!head && file.OldPath != null)
+            {
+                relativePath = file.OldPath;
+            }
+
             return pullRequestsService.ExtractFile(LocalRepository, model, relativePath, head, encoding).ToTask();
         }
 
@@ -527,7 +533,7 @@ namespace GitHub.ViewModels.GitHubPane
                     changedFile.FileName,
                     changedFile.Sha,
                     changedFile.Status,
-                    GetStatusDisplay(changedFile, changes));
+                    GetOldFileName(changedFile, changes));
 
                 var file = await Session.GetFile(changedFile.FileName);
                 var fileCommentCount = file?.WhenAnyValue(x => x.InlineCommentThreads)
@@ -573,28 +579,15 @@ namespace GitHub.ViewModels.GitHubPane
             }
         }
 
-        string GetStatusDisplay(IPullRequestFileModel file, TreeChanges changes)
+        string GetOldFileName(IPullRequestFileModel file, TreeChanges changes)
         {
-            switch (file.Status)
+            if (file.Status == PullRequestFileStatus.Renamed)
             {
-                case PullRequestFileStatus.Added:
-                    return Resources.AddedFileStatus;
-                case PullRequestFileStatus.Renamed:
-                    var fileName = file.FileName.Replace("/", "\\");
-                    var change = changes?.Renamed.FirstOrDefault(x => x.Path == fileName);
-
-                    if (change != null)
-                    {
-                        return Path.GetDirectoryName(change.OldPath) == Path.GetDirectoryName(change.Path) ?
-                            Path.GetFileName(change.OldPath) : change.OldPath;
-                    }
-                    else
-                    {
-                        return Resources.RenamedFileStatus;
-                    }
-                default:
-                    return null;
+                var fileName = file.FileName.Replace("/", "\\");
+                return changes?.Renamed.FirstOrDefault(x => x.Path == fileName)?.OldPath;
             }
+
+            return null;
         }
 
         IObservable<Unit> DoCheckout(object unused)

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestFileNode.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestFileNode.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using GitHub.App;
 using GitHub.Extensions;
 using GitHub.Models;
 using ReactiveUI;
@@ -21,12 +22,16 @@ namespace GitHub.ViewModels.GitHubPane
         /// <param name="sha">The SHA of the file.</param>
         /// <param name="status">The way the file was changed.</param>
         /// <param name="statusDisplay">The string to display in the [message] box next to the filename.</param>
+        /// <param name="oldPath">
+        /// The old path of a moved/renamed file, relative to the repository. Should be null if the
+        /// file was not moved/renamed.
+        /// </param>
         public PullRequestFileNode(
             string repositoryPath,
             string path,
             string sha,
             PullRequestFileStatus status,
-            string statusDisplay)
+            string oldPath)
         {
             Guard.ArgumentNotEmptyString(repositoryPath, nameof(repositoryPath));
             Guard.ArgumentNotEmptyString(path, nameof(path));
@@ -34,10 +39,26 @@ namespace GitHub.ViewModels.GitHubPane
 
             FileName = Path.GetFileName(path);
             DirectoryPath = Path.GetDirectoryName(path);
-            DisplayPath = Path.Combine(Path.GetFileName(repositoryPath), DirectoryPath);
             Sha = sha;
             Status = status;
-            StatusDisplay = statusDisplay;
+            OldPath = oldPath;
+
+            if (status == PullRequestFileStatus.Added)
+            {
+                StatusDisplay = Resources.AddedFileStatus;
+            }
+            else if (status == PullRequestFileStatus.Renamed)
+            {
+                if (oldPath != null)
+                {
+                    StatusDisplay = Path.GetDirectoryName(oldPath) == Path.GetDirectoryName(path) ?
+                            Path.GetFileName(oldPath) : oldPath;
+                }
+                else
+                {
+                    StatusDisplay = Resources.RenamedFileStatus;
+                }
+            }
         }
 
         /// <summary>
@@ -51,9 +72,9 @@ namespace GitHub.ViewModels.GitHubPane
         public string DirectoryPath { get; }
 
         /// <summary>
-        /// Gets the path to display in the "Path" column of the changed files list.
+        /// Gets the old path of a moved/renamed file, relative to the root of the repository.
         /// </summary>
-        public string DisplayPath { get; }
+        public string OldPath { get; }
 
         /// <summary>
         /// Gets the SHA of the file.

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestFileNode.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestFileNode.cs
@@ -10,9 +10,9 @@ namespace GitHub.ViewModels.GitHubPane
         string FileName { get; }
 
         /// <summary>
-        /// Gets the path to display in the "Path" column of the changed files list.
+        /// Gets the old path of a moved/renamed file, relative to the root of the repository.
         /// </summary>
-        string DisplayPath { get; }
+        string OldPath { get; }
 
         /// <summary>
         /// Gets the SHA of the file.

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml.cs
@@ -123,12 +123,12 @@ namespace GitHub.VisualStudio.Views.GitHubPane
         {
             try
             {
-                var relativePath = System.IO.Path.Combine(file.DirectoryPath, file.FileName);
+                var rightPath = System.IO.Path.Combine(file.DirectoryPath, file.FileName);
+                var leftPath = file.OldPath ?? rightPath;
                 var rightFile = workingDirectory ? ViewModel.GetLocalFilePath(file) : await ViewModel.ExtractFile(file, true);
                 var leftFile = await ViewModel.ExtractFile(file, false);
-                var fullPath = System.IO.Path.Combine(ViewModel.LocalRepository.LocalPath, relativePath);
-                var leftLabel = $"{relativePath};{ViewModel.TargetBranchDisplayName}";
-                var rightLabel = workingDirectory ? relativePath : $"{relativePath};PR {ViewModel.Model.Number}";
+                var leftLabel = $"{leftPath};{ViewModel.TargetBranchDisplayName}";
+                var rightLabel = workingDirectory ? rightPath : $"{rightPath};PR {ViewModel.Model.Number}";
                 var caption = $"Diff - {file.FileName}";
                 var options = __VSDIFFSERVICEOPTIONS.VSDIFFOPT_DetectBinaryFiles |
                     __VSDIFFSERVICEOPTIONS.VSDIFFOPT_LeftFileIsTemporary;
@@ -161,11 +161,11 @@ namespace GitHub.VisualStudio.Views.GitHubPane
                 var diffViewer = ((IVsDifferenceCodeWindow)docView).DifferenceViewer;
 
                 var session = ViewModel.Session;
-                AddBufferTag(diffViewer.LeftView.TextBuffer, session, relativePath, DiffSide.Left);
+                AddBufferTag(diffViewer.LeftView.TextBuffer, session, leftPath, DiffSide.Left);
 
                 if (!workingDirectory)
                 {
-                    AddBufferTag(diffViewer.RightView.TextBuffer, session, relativePath, DiffSide.Right);
+                    AddBufferTag(diffViewer.RightView.TextBuffer, session, rightPath, DiffSide.Right);
                 }
 
                 if (workingDirectory)


### PR DESCRIPTION
- Store the old path in `PullRequestFileNode`
- Use this path in `ExtractFile` for moved files

Fixes #1365 
Fixes #1383