### PR TITLE
Fix Switching Between Fork and Parent PRs

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
@@ -88,6 +88,10 @@ namespace GitHub.ViewModels.GitHubPane
                 .Where(x => PullRequests != null)
                 .Subscribe(f => UpdateFilter(SelectedState, SelectedAssignee, SelectedAuthor, f));
 
+            this.WhenAnyValue(x => x.SelectedRepository)
+                .Skip(1)
+                .Subscribe(_ => ResetAndLoad());
+
             OpenPullRequest = ReactiveCommand.Create();
             OpenPullRequest.Subscribe(DoOpenPullRequest);
             CreatePullRequest = ReactiveCommand.Create();
@@ -117,9 +121,9 @@ namespace GitHub.ViewModels.GitHubPane
                     new[] { remoteRepository.Parent, remoteRepository } :
                     new[] { remoteRepository };
                 SelectedState = States.FirstOrDefault(x => x.Name == listSettings.SelectedState) ?? States[0];
+
+                // Setting SelectedRepository will cause a Load().
                 SelectedRepository = Repositories[0];
-                WebUrl = repository.CloneUrl?.ToRepositoryUrl().Append("pulls");
-                await Load();
             }
             finally
             {
@@ -321,6 +325,7 @@ namespace GitHub.ViewModels.GitHubPane
 
         void ResetAndLoad()
         {
+            WebUrl = SelectedRepository.CloneUrl?.ToRepositoryUrl().Append("pulls");
             CreatePullRequests();
             UpdateFilter(SelectedState, SelectedAssignee, SelectedAuthor, SearchQuery);
             Load().Forget();


### PR DESCRIPTION
#1367 accidentially removed the code to refresh the PR list when switching between fork and parent PRs. Also update the `WebUrl` when this happens to fix #1218.

Fixes #1380
Fixes #1218