### PR TITLE
Make sure our assemblies are lazily loaded

### DIFF
--- a/src/GitHub.Api/LoginManager.cs
+++ b/src/GitHub.Api/LoginManager.cs
@@ -14,7 +14,7 @@ namespace GitHub.Api
     {
         readonly string[] scopes = { "user", "repo", "gist", "write:public_key" };
         readonly IKeychain keychain;
-        readonly ITwoFactorChallengeHandler twoFactorChallengeHandler;
+        readonly Lazy<ITwoFactorChallengeHandler> twoFactorChallengeHandler;
         readonly string clientId;
         readonly string clientSecret;
         readonly string authorizationNote;
@@ -31,7 +31,7 @@ namespace GitHub.Api
         /// <param name="fingerprint">The machine fingerprint.</param>
         public LoginManager(
             IKeychain keychain,
-            ITwoFactorChallengeHandler twoFactorChallengeHandler,
+            Lazy<ITwoFactorChallengeHandler> twoFactorChallengeHandler,
             string clientId,
             string clientSecret,
             string authorizationNote = null,
@@ -194,7 +194,7 @@ namespace GitHub.Api
         {
             for (;;)
             {
-                var challengeResult = await twoFactorChallengeHandler.HandleTwoFactorException(exception);
+                var challengeResult = await twoFactorChallengeHandler.Value.HandleTwoFactorException(exception);
 
                 if (challengeResult == null)
                 {
@@ -218,7 +218,7 @@ namespace GitHub.Api
                     }
                     catch (Exception e)
                     {
-                        await twoFactorChallengeHandler.ChallengeFailed(e);
+                        await twoFactorChallengeHandler.Value.ChallengeFailed(e);
                         await keychain.Delete(hostAddress).ConfigureAwait(false);
                         throw;
                     }

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -32,8 +32,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
         readonly IPackageSettings packageSettings;
         readonly IVSServices vsServices;
         readonly int sectionIndex;
-        readonly IDialogService dialogService;
-        readonly IRepositoryCloneService cloneService;
         readonly ILocalRepositories localRepositories;
 
         bool isCloning;
@@ -100,8 +98,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             IConnectionManager manager,
             IPackageSettings packageSettings,
             IVSServices vsServices,
-            IRepositoryCloneService cloneService,
-            IDialogService dialogService,
             ILocalRepositories localRepositories,
             int index)
             : base(serviceProvider, apiFactory, holder, manager)
@@ -111,8 +107,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             Guard.ArgumentNotNull(manager, nameof(manager));
             Guard.ArgumentNotNull(packageSettings, nameof(packageSettings));
             Guard.ArgumentNotNull(vsServices, nameof(vsServices));
-            Guard.ArgumentNotNull(cloneService, nameof(cloneService));
-            Guard.ArgumentNotNull(dialogService, nameof(dialogService));
             Guard.ArgumentNotNull(localRepositories, nameof(localRepositories));
 
             Title = "GitHub";
@@ -123,8 +117,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
             this.packageSettings = packageSettings;
             this.vsServices = vsServices;
-            this.cloneService = cloneService;
-            this.dialogService = dialogService;
             this.localRepositories = localRepositories;
 
             Clone = CreateAsyncCommandHack(DoClone);
@@ -136,6 +128,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
         async Task DoClone()
         {
+            var dialogService = ServiceProvider.GetService<IDialogService>();
             var result = await dialogService.ShowCloneDialog(SectionConnection);
 
             if (result != null)
@@ -143,6 +136,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                 try
                 {
                     ServiceProvider.GitServiceProvider = TEServiceProvider;
+                    var cloneService = ServiceProvider.GetService<IRepositoryCloneService>();
                     await cloneService.CloneRepository(
                         result.Repository.CloneUrl,
                         result.Repository.Name,
@@ -381,6 +375,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
         public void DoCreate()
         {
+            var dialogService = ServiceProvider.GetService<IDialogService>();
             dialogService.ShowCreateRepositoryDialog(SectionConnection);
         }
 
@@ -391,6 +386,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
         public void Login()
         {
+            var dialogService = ServiceProvider.GetService<IDialogService>();
             dialogService.ShowLoginDialog();
         }
 

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection0.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection0.cs
@@ -20,10 +20,8 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             IConnectionManager manager,
             IPackageSettings settings,
             IVSServices vsServices,
-            IRepositoryCloneService cloneService,
-            IDialogService dialogService,
             ILocalRepositories localRepositories)
-            : base(serviceProvider, apiFactory, holder, manager, settings, vsServices, cloneService, dialogService, localRepositories, 0)
+            : base(serviceProvider, apiFactory, holder, manager, settings, vsServices, localRepositories, 0)
         {
         }
     }

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection1.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection1.cs
@@ -20,10 +20,8 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             IConnectionManager manager,
             IPackageSettings settings,
             IVSServices vsServices,
-            IRepositoryCloneService cloneService,
-            IDialogService dialogService,
             ILocalRepositories localRepositories)
-            : base(serviceProvider, apiFactory, holder, manager, settings, vsServices, cloneService, dialogService, localRepositories, 1)
+            : base(serviceProvider, apiFactory, holder, manager, settings, vsServices, localRepositories, 1)
         {
         }
     }

--- a/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
+++ b/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
@@ -1,22 +1,19 @@
 ﻿using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Windows.Input;
+using GitHub.Api;
+using GitHub.Extensions;
+using GitHub.Info;
+using GitHub.Primitives;
+using GitHub.Services;
+using GitHub.Settings;
 using GitHub.UI;
 using GitHub.VisualStudio.Base;
 using GitHub.VisualStudio.Helpers;
+using GitHub.VisualStudio.UI;
 using GitHub.VisualStudio.UI.Views;
 using Microsoft.TeamFoundation.Controls;
-using GitHub.Services;
-using GitHub.Api;
-using GitHub.Primitives;
-using System.Threading.Tasks;
-using System.Diagnostics;
-using GitHub.Extensions;
-using System.Windows.Input;
-using ReactiveUI;
-using GitHub.VisualStudio.UI;
-using GitHub.Settings;
-using System.Windows.Threading;
-using GitHub.Info;
 
 namespace GitHub.VisualStudio.TeamExplorer.Home
 {
@@ -51,8 +48,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             this.settings = settings;
             this.usageTracker = usageTracker;
 
-            var openOnGitHub = ReactiveCommand.Create();
-            openOnGitHub.Subscribe(_ => DoOpenOnGitHub());
+            var openOnGitHub = new RelayCommand(_ => DoOpenOnGitHub());
             OpenOnGitHub = openOnGitHub;
         }
 

--- a/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
+++ b/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
@@ -32,7 +32,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
         readonly ITeamExplorerServices teamExplorerServices;
         readonly IPackageSettings settings;
         readonly IUsageTracker usageTracker;
-        readonly IDialogService dialogService;
 
         [ImportingConstructor]
         public GitHubHomeSection(IGitHubServiceProvider serviceProvider,
@@ -41,8 +40,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             IVisualStudioBrowser visualStudioBrowser,
             ITeamExplorerServices teamExplorerServices,
             IPackageSettings settings,
-            IUsageTracker usageTracker,
-            IDialogService dialogService)
+            IUsageTracker usageTracker)
             : base(serviceProvider, apiFactory, holder)
         {
             Title = "GitHub";
@@ -52,7 +50,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             this.teamExplorerServices = teamExplorerServices;
             this.settings = settings;
             this.usageTracker = usageTracker;
-            this.dialogService = dialogService;
 
             var openOnGitHub = ReactiveCommand.Create();
             openOnGitHub.Subscribe(_ => DoOpenOnGitHub());
@@ -118,6 +115,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
 
         public void Login()
         {
+            var dialogService = ServiceProvider.GetService<IDialogService>();
             dialogService.ShowLoginDialog();
         }
 

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -211,11 +212,10 @@ namespace GitHub.VisualStudio
             {
                 var serviceProvider = await GetServiceAsync(typeof(IGitHubServiceProvider)) as IGitHubServiceProvider;
                 var keychain = serviceProvider.GetService<IKeychain>();
-                var twoFaHandler = serviceProvider.GetService<ITwoFactorChallengeHandler>();
 
                 return new LoginManager(
                     keychain,
-                    twoFaHandler,
+                    new Lazy<ITwoFactorChallengeHandler>(() => serviceProvider.GetService<ITwoFactorChallengeHandler>()),
                     ApiClientConfiguration.ClientId,
                     ApiClientConfiguration.ClientSecret,
                     ApiClientConfiguration.AuthorizationNote,

--- a/src/GitHub.VisualStudio/Services/GitHubServiceProvider.cs
+++ b/src/GitHub.VisualStudio/Services/GitHubServiceProvider.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Reactive.Disposables;
 using GitHub.Logging;
 using GitHub.Models;
 using GitHub.Exports;
@@ -89,11 +88,11 @@ namespace GitHub.VisualStudio
         }
 
         static readonly ILogger log = LogManager.ForContext<GitHubServiceProvider>();
-        CompositeDisposable disposables = new CompositeDisposable();
         readonly IServiceProviderPackage asyncServiceProvider;
         readonly IServiceProvider syncServiceProvider;
         readonly Dictionary<string, OwnedComposablePart> tempParts;
         readonly Version currentVersion;
+        List<IDisposable> disposables = new List<IDisposable>();
         bool initialized = false;
 
         public ExportProvider ExportProvider { get; private set; }
@@ -290,7 +289,13 @@ namespace GitHub.VisualStudio
                 if (disposed) return;
 
                 if (disposables != null)
-                    disposables.Dispose();
+                {
+                    foreach (var disposable in disposables)
+                    {
+                        disposable.Dispose();
+                    }
+                }
+
                 disposables = null;
                 if (tempContainer != null)
                     tempContainer.Dispose();

--- a/test/UnitTests/GitHub.Api/LoginManagerTests.cs
+++ b/test/UnitTests/GitHub.Api/LoginManagerTests.cs
@@ -22,7 +22,7 @@ public class LoginManagerTests
                 .Returns(new ApplicationAuthorization("123abc"));
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
+           var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
 
             var target = new LoginManager(keychain, tfa, "id", "secret");
             await target.Login(host, client, "foo", "bar");
@@ -40,7 +40,7 @@ public class LoginManagerTests
             client.User.Current().Returns(user);
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
+            var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
 
             var target = new LoginManager(keychain, tfa, "id", "secret");
             var result = await target.Login(host, client, "foo", "bar");
@@ -63,7 +63,7 @@ public class LoginManagerTests
             client.User.Current().Returns(user);
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
+            var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
 
             var target = new LoginManager(keychain, tfa, "id", "secret");
             var result = await target.Login(host, client, "foo", "bar");
@@ -85,8 +85,8 @@ public class LoginManagerTests
                 .Returns(new ApplicationAuthorization("123abc"));
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
-            tfa.HandleTwoFactorException(exception).Returns(new TwoFactorChallengeResult("123456"));
+            var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
+            tfa.Value.HandleTwoFactorException(exception).Returns(new TwoFactorChallengeResult("123456"));
 
             var target = new LoginManager(keychain, tfa, "id", "secret");
             await target.Login(host, client, "foo", "bar");
@@ -112,8 +112,8 @@ public class LoginManagerTests
                 .Returns(new ApplicationAuthorization("123abc"));
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
-            tfa.HandleTwoFactorException(exception).Returns(
+            var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
+            tfa.Value.HandleTwoFactorException(exception).Returns(
                 new TwoFactorChallengeResult("111111"),
                 new TwoFactorChallengeResult("123456"));
 
@@ -147,8 +147,8 @@ public class LoginManagerTests
                 .Returns<ApplicationAuthorization>(_ => { throw loginAttemptsException; });
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
-            tfa.HandleTwoFactorException(twoFaException).Returns(
+            var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
+            tfa.Value.HandleTwoFactorException(twoFaException).Returns(
                 new TwoFactorChallengeResult("111111"),
                 new TwoFactorChallengeResult("123456"));
 
@@ -160,7 +160,7 @@ public class LoginManagerTests
                 "secret",
                 Arg.Any<NewAuthorization>(),
                 "111111");
-            tfa.Received(1).ChallengeFailed(loginAttemptsException);
+            tfa.Value.Received(1).ChallengeFailed(loginAttemptsException);
         }
 
         [Fact]
@@ -177,8 +177,8 @@ public class LoginManagerTests
             client.User.Current().Returns(user);
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
-            tfa.HandleTwoFactorException(exception).Returns(
+            var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
+            tfa.Value.HandleTwoFactorException(exception).Returns(
                 TwoFactorChallengeResult.RequestResendCode,
                 new TwoFactorChallengeResult("123456"));
 
@@ -202,7 +202,7 @@ public class LoginManagerTests
             client.User.Current().Returns(user);
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
+            var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
 
             var target = new LoginManager(keychain, tfa, "id", "secret");
             await target.Login(enterprise, client, "foo", "bar");
@@ -220,7 +220,7 @@ public class LoginManagerTests
                 .Returns<ApplicationAuthorization>(_ => { throw new AuthorizationException(); });
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
+            var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
 
             var target = new LoginManager(keychain, tfa, "id", "secret");
             await Assert.ThrowsAsync<AuthorizationException>(async () => await target.Login(enterprise, client, "foo", "bar"));
@@ -238,7 +238,7 @@ public class LoginManagerTests
                 .Returns<ApplicationAuthorization>(_ => { throw new InvalidOperationException(); });
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
+            var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
 
             var target = new LoginManager(keychain, tfa, "id", "secret");
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await target.Login(host, client, "foo", "bar"));
@@ -260,8 +260,8 @@ public class LoginManagerTests
             client.User.Current().Returns(user);
 
             var keychain = Substitute.For<IKeychain>();
-            var tfa = Substitute.For<ITwoFactorChallengeHandler>();
-            tfa.HandleTwoFactorException(exception).Returns(new TwoFactorChallengeResult("123456"));
+            var tfa = new Lazy<ITwoFactorChallengeHandler>(() => Substitute.For<ITwoFactorChallengeHandler>());
+            tfa.Value.HandleTwoFactorException(exception).Returns(new TwoFactorChallengeResult("123456"));
 
             var target = new LoginManager(keychain, tfa, "id", "secret");
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await target.Login(host, client, "foo", "bar"));


### PR DESCRIPTION
This fixes our lazy loading of assemblies. Previously all assemblies were loaded on VS startup (with Team Explorer and GitHub pane not shown):

![image](https://user-images.githubusercontent.com/1775141/33951743-1af643de-e030-11e7-8dd7-08614358eb4c.png)

Following this PR the list now looks like:

![image](https://user-images.githubusercontent.com/1775141/33944551-d4a1cdf8-e01c-11e7-9f8a-c9fdff563878.png)

Note that this only fixes things to the state they were before. ReactiveUI is still used by `GitHubConnectSection` which in VS2017 is the default view in team explorer, meaning that RxUI gets loaded as soon as Team Explorer loads in VS2017. We should fix this, but it's a different PR I think.

Fixes #1387 