### PR TITLE
Fix calculating machine fingerprint.

### DIFF
--- a/src/GitHub.Api/ApiClientConfiguration.cs
+++ b/src/GitHub.Api/ApiClientConfiguration.cs
@@ -61,10 +61,10 @@ namespace GitHub.Api
             {
                 // adapted from http://stackoverflow.com/a/1561067
                 var fastedValidNetworkInterface = NetworkInterface.GetAllNetworkInterfaces()
-                    .OrderBy(nic => nic.Speed)
+                    .OrderByDescending(nic => nic.Speed)
                     .Where(nic => nic.OperationalStatus == OperationalStatus.Up)
                     .Select(nic => nic.GetPhysicalAddress().ToString())
-                    .FirstOrDefault(address => address.Length > 12);
+                    .FirstOrDefault(address => address.Length >= 12);
 
                 return fastedValidNetworkInterface ?? GetMachineNameSafe();
             }

--- a/src/GitHub.Api/ApiClientConfiguration.cs
+++ b/src/GitHub.Api/ApiClientConfiguration.cs
@@ -49,7 +49,10 @@ namespace GitHub.Api
         {
             get
             {
-                return GetSha256Hash(Info.ApplicationInfo.ApplicationDescription + ":" + GetMachineIdentifier());
+                return GetSha256Hash(
+                    Info.ApplicationInfo.ApplicationDescription + ":" +
+                    GetMachineIdentifier() + ":" +
+                    GetMachineNameSafe());
             }
         }
 

--- a/src/GitHub.Api/ApiClientConfiguration.cs
+++ b/src/GitHub.Api/ApiClientConfiguration.cs
@@ -63,13 +63,13 @@ namespace GitHub.Api
             try
             {
                 // adapted from http://stackoverflow.com/a/1561067
-                var fastedValidNetworkInterface = NetworkInterface.GetAllNetworkInterfaces()
+                var fastestValidNetworkInterface = NetworkInterface.GetAllNetworkInterfaces()
                     .OrderByDescending(nic => nic.Speed)
                     .Where(nic => nic.OperationalStatus == OperationalStatus.Up)
                     .Select(nic => nic.GetPhysicalAddress().ToString())
                     .FirstOrDefault(address => address.Length >= 12);
 
-                return fastedValidNetworkInterface ?? GetMachineNameSafe();
+                return fastestValidNetworkInterface ?? GetMachineNameSafe();
             }
             catch (Exception)
             {


### PR DESCRIPTION
Our logic for calculating the machine identifier for the OAuth fingerprint was flaky, meaning that the same fingerprint was easily created on different machines. Try fixing it by:

- Starting from the fastest NIC (`OrderByDescending` instead of `OrderBy`) and check for length of `>= 12` instead of `> 12`. This results in a better machine identifier on my machine at least.
- Always including the machine name in the `MachineFingerprint`.

FIxes #1234 