### PR TITLE
Update readme notice about how to approach installer issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
 
 ## Notices
 
-### VS 2017 v15.3 users, please read
+### If you are having issues with the installer, please read
 
-If you need to downgrade or uninstall the extension, **do not use** ***Revert*** in Visual Studio 2017 15.3. Instead, manually uninstall the extension with the steps listed in https://github.com/github/VisualStudio/issues/1206#issuecomment-326558902
-
-If you have a corrupted extension cache, steps for fixing it are in https://github.com/github/VisualStudio/issues/1206#issuecomment-326053090
-
-The Visual Studio 2017 15.3 installer [has a bug](https://github.com/github/VisualStudio/issues/1206) that causes a corruption of the installed extensions data when you revert an installation of the extension (see also [this MS issue](https://developercommunity.visualstudio.com/content/problem/102178/error-installing-github-extension.html)). Until VS 2017 15.4 comes out, **do not use Revert in** ***Extensions and Updates***.
+If you need to upgrade, downgrade, or uninstall the extension, refer to this issue: https://github.com/github/VisualStudio/issues/1394 which details common problems and solutions when using the installer.
 
 ### The location of the submodules has changed as of 31-01-2017
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### If you are having issues with the installer, please read
 
-If you need to upgrade, downgrade, or uninstall the extension, refer to this issue: https://github.com/github/VisualStudio/issues/1394 which details common problems and solutions when using the installer.
+If you need to upgrade, downgrade, or uninstall the extension, and are having problems doing so, refer to this issue: https://github.com/github/VisualStudio/issues/1394 which details common problems and solutions when using the installer.
 
 ### The location of the submodules has changed as of 31-01-2017
 


### PR DESCRIPTION
Modify notice to users about how to approach installer issues, and link to the master installer issue.

Also removed the part about reverting in 15.3 as that's no longer relevant and VS is currently on version 15.5