### PR TITLE
Fix running using tests from command line

### DIFF
--- a/scripts/Run-NUnit.ps1
+++ b/scripts/Run-NUnit.ps1
@@ -40,7 +40,14 @@ $xml = Join-Path $rootDirectory "nunit-$Project.xml"
         exit -1
     }
 
-    Run-Process -Fatal $TimeoutDuration $consoleRunner $dll,"--where ""cat != Timings""","--result=$xml;format=AppVeyor"
+    $args = @()
+    if ($AppVeyor) {
+        $args = $dll, "--where", "cat!=Timings", "--result=$xml;format=AppVeyor"
+    } else {
+        $args = $dll, "--where", "cat!=Timings", "--result=$xml"
+    }
+
+    Run-Process -Fatal $TimeoutDuration $consoleRunner $args
     if (!$?) {
         Die 1 "$Project tests failed"
     }

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -30,7 +30,7 @@ if ($Trace) {
     Set-PSDebug -Trace 1
 }
 
-$env:PATH = "$$PSScriptRoot;$env:PATH"
+$env:PATH = "$PSScriptRoot;$env:PATH"
 
 $exitcode = 0
 

--- a/test.cmd
+++ b/test.cmd
@@ -1,8 +1,2 @@
-@rem Tests currently only work on `Release` build.
-@if "%config%" == "" set config=Release
-
-call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
-
-msbuild GitHubVS.sln /p:Configuration=%Config%
-VSTest.Console.exe src\UnitTests\bin\%Config%\UnitTests.dll /TestAdapterPath:"."
-VSTest.Console.exe src\TrackingCollectionTests\bin\%Config%\TrackingCollectionTests.dll /TestAdapterPath:"."
+@if "%1" == "" echo Please specify Debug or Release && EXIT /B
+powershell -ExecutionPolicy Unrestricted scripts\test.ps1 -Config:%1


### PR DESCRIPTION
This PR fixes a few little issues when running tests from command line

- Tests were failing because path wasn't being set correctly
- Don't send results to AppVeyer when not running in CI
- Make `test.cmd` execute tests using `scripts\test.ps1`

### To test

- From cmd shell
```
build Release
test Release
```

- From PoweShell
```
.\scripts\build.ps1
.\scripts\test.ps1
```
