### PR TITLE
Fix PullRequestDetailView in designer.

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -315,7 +315,7 @@
                                                     Tag="{Binding DataContext, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type ui:SectionControl}}}">
                                             <ui:OcticonImage Icon="file_code" Margin="0,0,0,2">
                                                 <ui:OcticonImage.Style>
-                                                    <Style TargetType="ui:OcticonImage" BasedOn="{StaticResource OcticonImage}">
+                                                    <Style TargetType="ui:OcticonImage" BasedOn="{StaticResource {x:Type ui:OcticonImage}}">
                                                         <Style.Triggers>
                                                             <MultiDataTrigger>
                                                                 <MultiDataTrigger.Conditions>


### PR DESCRIPTION
`PullRequestDetailView` was not displaying in the Visual Studio designer - it was showing an error related to `OcticonImage`.

 Not sure why this works when the previous didn't, but seems to fix it.