### PR TITLE
Move GitHub.InlineReviews.UnitTests to nunit

### DIFF
--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -53,7 +53,7 @@ if (!$?) {
 }
 
 Write-Output "Running GitHub.InlineReviews.UnitTests..."
-Run-XUnit test GitHub.InlineReviews.UnitTests $TimeoutDuration $config -AppVeyor:$AppVeyor
+Run-NUnit test GitHub.InlineReviews.UnitTests $TimeoutDuration $config -AppVeyor:$AppVeyor
 if (!$?) {
     $exitcode = 4
 }

--- a/test/GitHub.InlineReviews.UnitTests/GitHub.InlineReviews.UnitTests.csproj
+++ b/test/GitHub.InlineReviews.UnitTests/GitHub.InlineReviews.UnitTests.csproj
@@ -64,6 +64,9 @@
       <HintPath>..\..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http, Version=4.1.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -114,10 +117,6 @@
     <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
       <Private>False</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>

--- a/test/GitHub.InlineReviews.UnitTests/GitHub.InlineReviews.UnitTests.csproj
+++ b/test/GitHub.InlineReviews.UnitTests/GitHub.InlineReviews.UnitTests.csproj
@@ -1,10 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props" Condition="Exists('..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" />
-  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
-  <Import Project="..\..\packages\LibGit2Sharp.NativeBinaries.1.0.164\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.164\build\LibGit2Sharp.NativeBinaries.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -112,21 +107,25 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.3.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.3.1\lib\netstandard1.1\xunit.core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.3.1.3858, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.3.1\lib\net452\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -195,21 +194,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\LibGit2Sharp.NativeBinaries.1.0.164\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\LibGit2Sharp.NativeBinaries.1.0.164\build\LibGit2Sharp.NativeBinaries.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.3.1\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.console.2.3.1\build\xunit.runner.console.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  <Import Project="..\..\packages\xunit.core.2.3.1\build\xunit.core.targets" Condition="Exists('..\..\packages\xunit.core.2.3.1\build\xunit.core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Linq;
 using GitHub.Models;
-using Xunit;
+using NUnit.Framework;
 
 namespace GitHub.InlineReviews.UnitTests.Models
 {
@@ -10,7 +10,7 @@ namespace GitHub.InlineReviews.UnitTests.Models
     {
         public class TheParseFragmentMethod
         {
-            [Fact]
+            [Test]
             public void EmptyDiff_NoDiffChunks()
             {
                 var chunks = DiffUtilities.ParseFragment("");
@@ -50,11 +50,11 @@ index b02decb..f7dadae 100644
                 var chunks = DiffUtilities.ParseFragment(header);
                 var chunk = chunks.First();
 
-                Assert.Equal(expectOldLineNumber, chunk.OldLineNumber);
-                Assert.Equal(expectNewLineNumber, chunk.NewLineNumber);
+                Assert.AreEqual(expectOldLineNumber, chunk.OldLineNumber);
+                Assert.AreEqual(expectNewLineNumber, chunk.NewLineNumber);
             }
 
-            [Fact]
+            [Test]
             public void HeaderOnlyNoNewLineAtEnd_NoLines()
             {
                 var header =
@@ -67,7 +67,7 @@ index b02decb..f7dadae 100644
                 Assert.Empty(chunk.Lines);
             }
 
-            [Fact]
+            [Test]
             public void NoNewLineNotAtEndOfChunk_CheckLineCount()
             {
                 var header =
@@ -78,10 +78,10 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(header).First();
 
-                Assert.Equal(2, chunk.Lines.Count());
+                Assert.AreEqual(2, chunk.Lines.Count());
             }
 
-            [Fact]
+            [Test]
             public void NoNewLineNotAtEndOfChunk_CheckDiffLineNumber()
             {
                 var header =
@@ -93,7 +93,7 @@ index b02decb..f7dadae 100644
                 var chunk = DiffUtilities.ParseFragment(header).First();
 
                 var line = chunk.Lines.Last();
-                Assert.Equal(3, line.DiffLineNumber);
+                Assert.AreEqual(3, line.DiffLineNumber);
             }
 
             [Theory]
@@ -108,8 +108,8 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(diff).First();
 
-                Assert.Equal(contentLine0, chunk.Lines[0].Content);
-                Assert.Equal(contentLine1, chunk.Lines[1].Content);
+                Assert.AreEqual(contentLine0, chunk.Lines[0].Content);
+                Assert.AreEqual(contentLine1, chunk.Lines[1].Content);
             }
 
             [Theory]
@@ -123,8 +123,8 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(diff).First();
 
-                Assert.Equal(lineNumber0, chunk.Lines[0].NewLineNumber);
-                Assert.Equal(lineNumber1, chunk.Lines[1].NewLineNumber);
+                Assert.AreEqual(lineNumber0, chunk.Lines[0].NewLineNumber);
+                Assert.AreEqual(lineNumber1, chunk.Lines[1].NewLineNumber);
             }
 
             [Theory]
@@ -138,11 +138,11 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(diff).First();
 
-                Assert.Equal(lineNumber0, chunk.Lines[0].OldLineNumber);
-                Assert.Equal(lineNumber1, chunk.Lines[1].OldLineNumber);
+                Assert.AreEqual(lineNumber0, chunk.Lines[0].OldLineNumber);
+                Assert.AreEqual(lineNumber1, chunk.Lines[1].OldLineNumber);
             }
 
-            [Fact]
+            [Test]
             public void FirstChunk_CheckDiffLineZeroBased()
             {
                 var expectDiffLine = 0;
@@ -150,7 +150,7 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(header).First();
 
-                Assert.Equal(expectDiffLine, chunk.DiffLine);
+                Assert.AreEqual(expectDiffLine, chunk.DiffLine);
             }
 
             [Theory]
@@ -161,8 +161,8 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(header).First();
 
-                Assert.Equal(oldLineNumber, chunk.OldLineNumber);
-                Assert.Equal(newLineNumber, chunk.NewLineNumber);
+                Assert.AreEqual(oldLineNumber, chunk.OldLineNumber);
+                Assert.AreEqual(newLineNumber, chunk.NewLineNumber);
             }
 
             [Theory]
@@ -176,8 +176,8 @@ index b02decb..f7dadae 100644
                 var chunk = DiffUtilities.ParseFragment(header).First();
                 var diffLine = chunk.Lines.First();
 
-                Assert.Equal(expectOldLineNumber, diffLine.OldLineNumber);
-                Assert.Equal(expectNewLineNumber, diffLine.NewLineNumber);
+                Assert.AreEqual(expectOldLineNumber, diffLine.OldLineNumber);
+                Assert.AreEqual(expectNewLineNumber, diffLine.NewLineNumber);
             }
 
             [Theory]
@@ -191,7 +191,7 @@ index b02decb..f7dadae 100644
                 var result = DiffUtilities.ParseFragment(fragment);
 
                 var firstLine = result.First().Lines.Skip(skip).First();
-                Assert.Equal(expectDiffLineNumber, firstLine.DiffLineNumber);
+                Assert.AreEqual(expectDiffLineNumber, firstLine.DiffLineNumber);
             }
 
             [Theory]
@@ -206,7 +206,7 @@ index b02decb..f7dadae 100644
 
                 var str = firstLine.ToString();
 
-                Assert.Equal(line, str);
+                Assert.AreEqual(line, str);
             }
 
             [Theory]
@@ -220,7 +220,7 @@ index b02decb..f7dadae 100644
                 var result = DiffUtilities.ParseFragment(fragment);
                 var firstLine = result.First().Lines.First();
 
-                Assert.Equal(line, firstLine.Content);
+                Assert.AreEqual(line, firstLine.Content);
             }
 
             [Theory]
@@ -234,7 +234,7 @@ index b02decb..f7dadae 100644
                 var result = DiffUtilities.ParseFragment(fragment);
 
                 var firstLine = result.First().Lines.First();
-                Assert.Equal(expectType, firstLine.Type);
+                Assert.AreEqual(expectType, firstLine.Type);
             }
 
             [Theory]
@@ -246,7 +246,7 @@ index b02decb..f7dadae 100644
                 var result = DiffUtilities.ParseFragment(fragment);
                 var e = Assert.Throws<InvalidDataException>(() => result.First());
 
-                Assert.Equal(expectMessage, e.Message);
+                Assert.AreEqual(expectMessage, e.Message);
             }
         }
 
@@ -286,10 +286,10 @@ index b02decb..f7dadae 100644
                 var line = DiffUtilities.Match(chunks1, targetLines);
 
                 var diffLineNumber = (line != null) ? line.DiffLineNumber : -1;
-                Assert.Equal(expectedDiffLineNumber, diffLineNumber);
+                Assert.AreEqual(expectedDiffLineNumber, diffLineNumber);
             }
 
-            [Fact]
+            [Test]
             public void MatchSameLine()
             {
                 var diff = "@@ -1 +1 @@\n 1";
@@ -301,10 +301,10 @@ index b02decb..f7dadae 100644
 
                 var line = DiffUtilities.Match(chunks1, targetLines);
 
-                Assert.Equal(expectLine, line);
+                Assert.AreEqual(expectLine, line);
             }
 
-            [Fact]
+            [Test]
             public void NoLineMatchesFromNoLines()
             {
                 var chunks = new DiffChunk[0];
@@ -334,15 +334,15 @@ index b02decb..f7dadae 100644
             public void ReadLines(string text, string[] expectLines)
             {
                 var lineReader = new DiffUtilities.LineReader(text);
-
+            
                 foreach (var expectLine in expectLines)
                 {
                     var line = lineReader.ReadLine();
-                    Assert.Equal(expectLine, line);
+                    Assert.AreEqual(expectLine, line);
                 }
             }
 
-            [Fact]
+            [Test]
             public void Constructor_NullText_ArgumentNullException()
             {
                 Assert.Throws<ArgumentNullException>(() => new DiffUtilities.LineReader(null));
@@ -358,10 +358,10 @@ index b02decb..f7dadae 100644
             {
                 var count = DiffUtilities.LineReader.CountCarriageReturns(text);
 
-                Assert.Equal(expectCount, count);
+                Assert.AreEqual(expectCount, count);
             }
 
-            [Fact]
+            [Test]
             public void CountCarriageReturns_NullText_ArgumentNullException()
             {
                 Assert.Throws<ArgumentNullException>(() => DiffUtilities.LineReader.CountCarriageReturns(null));

--- a/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
@@ -15,37 +15,36 @@ namespace GitHub.InlineReviews.UnitTests.Models
             {
                 var chunks = DiffUtilities.ParseFragment("");
 
-                Assert.Empty(chunks);
+				Assert.That(chunks, Is.Empty);
             }
 
-            [Theory]
-            [InlineData("@@ -1 +1 @@")]
-            [InlineData("@@ -1 +1,0 @@")]
-            [InlineData("@@ -1,0 +1 @@")]
-            [InlineData("@@ -1,0 +1,0 @@")]
-            [InlineData("@@ -1,0 +1,0 @@ THIS IS A COMMENT THAT WILL BE IGNORED")]
-            public void HeaderOnly_OneChunkNoLines(string header)
+            [TestCase("@@ -1 +1 @@")]
+			[TestCase("@@ -1 +1,0 @@")]
+			[TestCase("@@ -1,0 +1 @@")]
+			[TestCase("@@ -1,0 +1,0 @@")]
+			[TestCase("@@ -1,0 +1,0 @@ THIS IS A COMMENT THAT WILL BE IGNORED")]
+			public void HeaderOnly_OneChunkNoLines(string header)
             {
                 var chunks = DiffUtilities.ParseFragment(header);
 
-                Assert.Single(chunks);
-                var chunk = chunks.First();
-                Assert.Empty(chunk.Lines);
+				//Assert.Single(chunks);
+				var chunk = chunks.First();
+				Assert.That(chunk.Lines, Is.Empty);
             }
 
-            [Theory]
-            [InlineData("@@ -1 +2 @@", 1, 2)]
-            [InlineData("@@ -1 +2,0 @@", 1, 2)]
-            [InlineData("@@ -1,0 +2 @@", 1, 2)]
-            [InlineData("@@ -1,0 +2,0 @@", 1, 2)]
-            [InlineData("@@ -1,0 +2,0 @@ THIS IS A COMMENT THAT WILL BE IGNORED", 1, 2)]
-            [InlineData(
+			[TestCase("@@ -1 +2 @@", 1, 2)]
+			[TestCase("@@ -1 +2,0 @@", 1, 2)]
+			[TestCase("@@ -1,0 +2 @@", 1, 2)]
+			[TestCase("@@ -1,0 +2,0 @@", 1, 2)]
+			[TestCase("@@ -1,0 +2,0 @@ THIS IS A COMMENT THAT WILL BE IGNORED", 1, 2)]
+            [TestCase(
 @"diff --git a/src/Foo.cs b/src/Foo.cs
 index b02decb..f7dadae 100644
 --- a/src/Foo.cs
 +++ b/src/Foo.cs
-@@ -1 +2 @@", 1, 2)] // Extra header info when using `Diff.Compare<Patch>`.
-            public void HeaderOnly_OldAndNewLineNumbers(string header, int expectOldLineNumber, int expectNewLineNumber)
+@@ -1 +2 @@", 1, 2)]
+
+			public void HeaderOnly_OldAndNewLineNumbers(string header, int expectOldLineNumber, int expectNewLineNumber)
             {
                 var chunks = DiffUtilities.ParseFragment(header);
                 var chunk = chunks.First();
@@ -64,7 +63,7 @@ index b02decb..f7dadae 100644
                 var chunks = DiffUtilities.ParseFragment(header);
 
                 var chunk = chunks.First();
-                Assert.Empty(chunk.Lines);
+				Assert.That(chunk.Lines, Is.Empty);
             }
 
             [Test]
@@ -96,12 +95,11 @@ index b02decb..f7dadae 100644
                 Assert.AreEqual(3, line.DiffLineNumber);
             }
 
-            [Theory]
-            [InlineData("+foo\n+bar\n", "+foo", "+bar")]
-            [InlineData("+fo\ro\n+bar\n", "+fo\ro", "+bar")]
-            [InlineData("+foo\r\r\n+bar\n", "+foo\r", "+bar")]
-            [InlineData("+\\r\n+\r\n", "+\\r", "+")]
-            public void FirstChunk_CheckLineContent(string diffLines, string contentLine0, string contentLine1)
+			[TestCase("+foo\n+bar\n", "+foo", "+bar")]
+			[TestCase("+fo\ro\n+bar\n", "+fo\ro", "+bar")]
+			[TestCase("+foo\r\r\n+bar\n", "+foo\r", "+bar")]
+			[TestCase("+\\r\n+\r\n", "+\\r", "+")]
+			public void FirstChunk_CheckLineContent(string diffLines, string contentLine0, string contentLine1)
             {
                 var header = "@@ -1 +1 @@";
                 var diff = header + "\n" + diffLines;
@@ -112,11 +110,10 @@ index b02decb..f7dadae 100644
                 Assert.AreEqual(contentLine1, chunk.Lines[1].Content);
             }
 
-            [Theory]
-            [InlineData("+foo\n+bar\n", 1, 2)]
-            [InlineData("+fo\ro\n+bar\n", 1, 3)]
-            [InlineData("+foo\r\r\n+bar\n", 1, 3)]
-            public void FirstChunk_CheckNewLineNumber(string diffLines, int lineNumber0, int lineNumber1)
+			[TestCase("+foo\n+bar\n", 1, 2)]
+			[TestCase("+fo\ro\n+bar\n", 1, 3)]
+			[TestCase("+foo\r\r\n+bar\n", 1, 3)]
+			public void FirstChunk_CheckNewLineNumber(string diffLines, int lineNumber0, int lineNumber1)
             {
                 var header = "@@ -1 +1 @@";
                 var diff = header + "\n" + diffLines;
@@ -127,11 +124,10 @@ index b02decb..f7dadae 100644
                 Assert.AreEqual(lineNumber1, chunk.Lines[1].NewLineNumber);
             }
 
-            [Theory]
-            [InlineData("-foo\n-bar\n", 1, 2)]
-            [InlineData("-fo\ro\n-bar\n", 1, 3)]
-            [InlineData("-foo\r\r\n-bar\n", 1, 3)]
-            public void FirstChunk_CheckOldLineNumber(string diffLines, int lineNumber0, int lineNumber1)
+			[TestCase("-foo\n-bar\n", 1, 2)]
+			[TestCase("-fo\ro\n-bar\n", 1, 3)]
+			[TestCase("-foo\r\r\n-bar\n", 1, 3)]
+			public void FirstChunk_CheckOldLineNumber(string diffLines, int lineNumber0, int lineNumber1)
             {
                 var header = "@@ -1 +1 @@";
                 var diff = header + "\n" + diffLines;
@@ -153,9 +149,8 @@ index b02decb..f7dadae 100644
                 Assert.AreEqual(expectDiffLine, chunk.DiffLine);
             }
 
-            [Theory]
-            [InlineData(1, 2)]
-            public void FirstChunk_CheckLineNumbers(int oldLineNumber, int newLineNumber)
+			[TestCase(1, 2)]
+			public void FirstChunk_CheckLineNumbers(int oldLineNumber, int newLineNumber)
             {
                 var header = $"@@ -{oldLineNumber} +{newLineNumber} @@";
 
@@ -165,11 +160,10 @@ index b02decb..f7dadae 100644
                 Assert.AreEqual(newLineNumber, chunk.NewLineNumber);
             }
 
-            [Theory]
-            [InlineData(1, 2, " 1", 1, 2)]
-            [InlineData(1, 2, "+1", -1, 2)]
-            [InlineData(1, 2, "-1", 1, -1)]
-            public void FirstLine_CheckLineNumbers(int oldLineNumber, int newLineNumber, string line, int expectOldLineNumber, int expectNewLineNumber)
+			[TestCase(1, 2, " 1", 1, 2)]
+			[TestCase(1, 2, "+1", -1, 2)]
+			[TestCase(1, 2, "-1", 1, -1)]
+			public void FirstLine_CheckLineNumbers(int oldLineNumber, int newLineNumber, string line, int expectOldLineNumber, int expectNewLineNumber)
             {
                 var header = $"@@ -{oldLineNumber} +{newLineNumber} @@\n{line}";
 
@@ -180,11 +174,10 @@ index b02decb..f7dadae 100644
                 Assert.AreEqual(expectNewLineNumber, diffLine.NewLineNumber);
             }
 
-            [Theory]
-            [InlineData(" 1", 0, 1)]
-            [InlineData(" 1\n 2", 1, 2)]
-            [InlineData(" 1\n 2\n 3", 2, 3)]
-            public void SkipNLines_CheckDiffLineNumber(string lines, int skip, int expectDiffLineNumber)
+			[TestCase(" 1", 0, 1)]
+			[TestCase(" 1\n 2", 1, 2)]
+			[TestCase(" 1\n 2\n 3", 2, 3)]
+			public void SkipNLines_CheckDiffLineNumber(string lines, int skip, int expectDiffLineNumber)
             {
                 var fragment = $"@@ -1 +1 @@\n{lines}";
 
@@ -194,11 +187,10 @@ index b02decb..f7dadae 100644
                 Assert.AreEqual(expectDiffLineNumber, firstLine.DiffLineNumber);
             }
 
-            [Theory]
-            [InlineData(" FIRST")]
-            [InlineData("+FIRST")]
-            [InlineData("-FIRST")]
-            public void FirstLine_CheckToString(string line)
+			[TestCase(" FIRST")]
+			[TestCase("+FIRST")]
+			[TestCase("-FIRST")]
+			public void FirstLine_CheckToString(string line)
             {
                 var fragment = $"@@ -1 +1 @@\n{line}";
                 var result = DiffUtilities.ParseFragment(fragment);
@@ -209,11 +201,10 @@ index b02decb..f7dadae 100644
                 Assert.AreEqual(line, str);
             }
 
-            [Theory]
-            [InlineData(" FIRST")]
-            [InlineData("+FIRST")]
-            [InlineData("-FIRST")]
-            public void FirstLine_CheckContent(string line)
+			[TestCase(" FIRST")]
+			[TestCase("+FIRST")]
+			[TestCase("-FIRST")]
+			public void FirstLine_CheckContent(string line)
             {
                 var fragment = $"@@ -1,4 +1,4 @@\n{line}";
 
@@ -223,11 +214,10 @@ index b02decb..f7dadae 100644
                 Assert.AreEqual(line, firstLine.Content);
             }
 
-            [Theory]
-            [InlineData(" FIRST", DiffChangeType.None)]
-            [InlineData("+FIRST", DiffChangeType.Add)]
-            [InlineData("-FIRST", DiffChangeType.Delete)]
-            public void FirstLine_CheckDiffChangeTypes(string line, DiffChangeType expectType)
+			[TestCase(" FIRST", DiffChangeType.None)]
+			[TestCase("+FIRST", DiffChangeType.Add)]
+			[TestCase("-FIRST", DiffChangeType.Delete)]
+			public void FirstLine_CheckDiffChangeTypes(string line, DiffChangeType expectType)
             {
                 var fragment = $"@@ -1 +1 @@\n{line}";
 
@@ -237,9 +227,8 @@ index b02decb..f7dadae 100644
                 Assert.AreEqual(expectType, firstLine.Type);
             }
 
-            [Theory]
-            [InlineData("?FIRST", "Invalid diff line change char: '?'.")]
-            public void InvalidDiffLineChangeChar(string line, string expectMessage)
+			[TestCase("?FIRST", "Invalid diff line change char: '?'.")]
+			public void InvalidDiffLineChangeChar(string line, string expectMessage)
             {
                 var fragment = $"@@ -1,4 +1,4 @@\n{line}";
 
@@ -255,25 +244,24 @@ index b02decb..f7dadae 100644
             /// <param name="diffLines">Target diff chunk with header (with '.' as line separator)</param>
             /// <param name="matchLines">Diff lines to match (with '.' as line separator)</param>
             /// <param name="expectedDiffLineNumber">The DiffLineNumber that the last line of matchLines falls on</param>
-            [Theory]
-            [InlineData(" 1", " 1", 1)]
-            [InlineData(" 1. 2", " 2", 2)]
-            [InlineData(" 1. 1", " 1", 2)] // match the later line
-            [InlineData("+x", "-x", -1)]
-            [InlineData("", " x", -1)]
-            [InlineData(" x", "", -1)]
+            [TestCase(" 1", " 1", 1)]
+            [TestCase(" 1. 2", " 2", 2)]
+            [TestCase(" 1. 1", " 1", 2)] // match the later line
+            [TestCase("+x", "-x", -1)]
+            [TestCase("", " x", -1)]
+            [TestCase(" x", "", -1)]
 
-            [InlineData(" 1. 2.", " 1. 2.", 2)] // matched full context
-            [InlineData(" 1. 2.", " 3. 2.", -1)] // didn't match full context
-            [InlineData(" 2.", " 1. 2.", 1)] // match if we run out of context lines
+            [TestCase(" 1. 2.", " 1. 2.", 2)] // matched full context
+            [TestCase(" 1. 2.", " 3. 2.", -1)] // didn't match full context
+            [TestCase(" 2.", " 1. 2.", 1)] // match if we run out of context lines
 
             // Tests for https://github.com/github/VisualStudio/issues/1149
             // Matching algorithm got confused when there was a partial match.
-            [InlineData("+a.+x.+x.", "+a.+x.", 2)]
-            [InlineData("+a.+x.+x.", "+a.+x.+x.", 3)]
-            [InlineData("+a.+x.+x.+b.+x.+x.", "+a.+x.", 2)]
-            [InlineData("+a.+x.+x.+b.+x.+x.", "+b.+x.", 5)]
-            [InlineData("+a.+b.+x", "+a.+x.", -1)] // backtrack when there is a failed match
+            [TestCase("+a.+x.+x.", "+a.+x.", 2)]
+            [TestCase("+a.+x.+x.", "+a.+x.+x.", 3)]
+            [TestCase("+a.+x.+x.+b.+x.+x.", "+a.+x.", 2)]
+            [TestCase("+a.+x.+x.+b.+x.+x.", "+b.+x.", 5)]
+            [TestCase("+a.+b.+x", "+a.+x.", -1)] // backtrack when there is a failed match
             public void MatchLine(string diffLines, string matchLines, int expectedDiffLineNumber /* -1 for no match */)
             {
                 var header = "@@ -1 +1 @@";
@@ -318,19 +306,18 @@ index b02decb..f7dadae 100644
 
         public class TheLineReaderClass
         {
-            [Theory]
-            [InlineData("", new[] { "", null })]
-            [InlineData("\n", new[] { "", null })]
-            [InlineData("\r\n", new[] { "", null })]
-            [InlineData("1", new[] { "1", null })]
-            [InlineData("1\n2\n", new[] { "1", "2", null })]
-            [InlineData("1\n2", new[] { "1", "2", null })]
-            [InlineData("1\r\n2\n", new[] { "1", "2", null })]
-            [InlineData("1\r\n2", new[] { "1", "2", null })]
-            [InlineData("\r", new[] { "\r", null })]
-            [InlineData("\r\r", new[] { "\r\r", null })]
-            [InlineData("\r\r\n", new[] { "\r", null })]
-            [InlineData("\r_\n", new[] { "\r_", null })]
+            [TestCase("", new[] { "", null })]
+            [TestCase("\n", new[] { "", null })]
+            [TestCase("\r\n", new[] { "", null })]
+            [TestCase("1", new[] { "1", null })]
+            [TestCase("1\n2\n", new[] { "1", "2", null })]
+            [TestCase("1\n2", new[] { "1", "2", null })]
+            [TestCase("1\r\n2\n", new[] { "1", "2", null })]
+            [TestCase("1\r\n2", new[] { "1", "2", null })]
+            [TestCase("\r", new[] { "\r", null })]
+            [TestCase("\r\r", new[] { "\r\r", null })]
+            [TestCase("\r\r\n", new[] { "\r", null })]
+            [TestCase("\r_\n", new[] { "\r_", null })]
             public void ReadLines(string text, string[] expectLines)
             {
                 var lineReader = new DiffUtilities.LineReader(text);
@@ -348,12 +335,11 @@ index b02decb..f7dadae 100644
                 Assert.Throws<ArgumentNullException>(() => new DiffUtilities.LineReader(null));
             }
 
-            [Theory]
-            [InlineData("", 0)]
-            [InlineData("\r", 1)]
-            [InlineData("\r\n", 1)]
-            [InlineData("\r\r", 2)]
-            [InlineData("\r-\r", 2)]
+            [TestCase("", 0)]
+            [TestCase("\r", 1)]
+            [TestCase("\r\n", 1)]
+            [TestCase("\r\r", 2)]
+            [TestCase("\r-\r", 2)]
             public void CountCarriageReturns(string text, int expectCount)
             {
                 var count = DiffUtilities.LineReader.CountCarriageReturns(text);

--- a/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
@@ -27,7 +27,7 @@ namespace GitHub.InlineReviews.UnitTests.Models
             {
                 var chunks = DiffUtilities.ParseFragment(header);
 
-				//Assert.Single(chunks);
+                Assert.That(chunks, Has.One.Items);
 				var chunk = chunks.First();
 				Assert.That(chunk.Lines, Is.Empty);
             }

--- a/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Models/DiffUtilitiesTests.cs
@@ -49,8 +49,8 @@ index b02decb..f7dadae 100644
                 var chunks = DiffUtilities.ParseFragment(header);
                 var chunk = chunks.First();
 
-                Assert.AreEqual(expectOldLineNumber, chunk.OldLineNumber);
-                Assert.AreEqual(expectNewLineNumber, chunk.NewLineNumber);
+                Assert.That(expectOldLineNumber, Is.EqualTo(chunk.OldLineNumber));
+                Assert.That(expectNewLineNumber, Is.EqualTo(chunk.NewLineNumber));
             }
 
             [Test]
@@ -77,7 +77,7 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(header).First();
 
-                Assert.AreEqual(2, chunk.Lines.Count());
+                Assert.That(2, Is.EqualTo(chunk.Lines.Count()));
             }
 
             [Test]
@@ -92,7 +92,7 @@ index b02decb..f7dadae 100644
                 var chunk = DiffUtilities.ParseFragment(header).First();
 
                 var line = chunk.Lines.Last();
-                Assert.AreEqual(3, line.DiffLineNumber);
+                Assert.That(3, Is.EqualTo(line.DiffLineNumber));
             }
 
 			[TestCase("+foo\n+bar\n", "+foo", "+bar")]
@@ -106,8 +106,8 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(diff).First();
 
-                Assert.AreEqual(contentLine0, chunk.Lines[0].Content);
-                Assert.AreEqual(contentLine1, chunk.Lines[1].Content);
+                Assert.That(contentLine0, Is.EqualTo(chunk.Lines[0].Content));
+                Assert.That(contentLine1, Is.EqualTo(chunk.Lines[1].Content));
             }
 
 			[TestCase("+foo\n+bar\n", 1, 2)]
@@ -120,8 +120,8 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(diff).First();
 
-                Assert.AreEqual(lineNumber0, chunk.Lines[0].NewLineNumber);
-                Assert.AreEqual(lineNumber1, chunk.Lines[1].NewLineNumber);
+                Assert.That(lineNumber0, Is.EqualTo(chunk.Lines[0].NewLineNumber));
+                Assert.That(lineNumber1, Is.EqualTo(chunk.Lines[1].NewLineNumber));
             }
 
 			[TestCase("-foo\n-bar\n", 1, 2)]
@@ -134,8 +134,8 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(diff).First();
 
-                Assert.AreEqual(lineNumber0, chunk.Lines[0].OldLineNumber);
-                Assert.AreEqual(lineNumber1, chunk.Lines[1].OldLineNumber);
+                Assert.That(lineNumber0, Is.EqualTo(chunk.Lines[0].OldLineNumber));
+                Assert.That(lineNumber1, Is.EqualTo(chunk.Lines[1].OldLineNumber));
             }
 
             [Test]
@@ -146,7 +146,7 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(header).First();
 
-                Assert.AreEqual(expectDiffLine, chunk.DiffLine);
+                Assert.That(expectDiffLine, Is.EqualTo(chunk.DiffLine));
             }
 
 			[TestCase(1, 2)]
@@ -156,8 +156,8 @@ index b02decb..f7dadae 100644
 
                 var chunk = DiffUtilities.ParseFragment(header).First();
 
-                Assert.AreEqual(oldLineNumber, chunk.OldLineNumber);
-                Assert.AreEqual(newLineNumber, chunk.NewLineNumber);
+                Assert.That(oldLineNumber, Is.EqualTo(chunk.OldLineNumber));
+                Assert.That(newLineNumber, Is.EqualTo(chunk.NewLineNumber));
             }
 
 			[TestCase(1, 2, " 1", 1, 2)]
@@ -170,8 +170,8 @@ index b02decb..f7dadae 100644
                 var chunk = DiffUtilities.ParseFragment(header).First();
                 var diffLine = chunk.Lines.First();
 
-                Assert.AreEqual(expectOldLineNumber, diffLine.OldLineNumber);
-                Assert.AreEqual(expectNewLineNumber, diffLine.NewLineNumber);
+                Assert.That(expectOldLineNumber, Is.EqualTo(diffLine.OldLineNumber));
+                Assert.That(expectNewLineNumber, Is.EqualTo(diffLine.NewLineNumber));
             }
 
 			[TestCase(" 1", 0, 1)]
@@ -184,7 +184,7 @@ index b02decb..f7dadae 100644
                 var result = DiffUtilities.ParseFragment(fragment);
 
                 var firstLine = result.First().Lines.Skip(skip).First();
-                Assert.AreEqual(expectDiffLineNumber, firstLine.DiffLineNumber);
+                Assert.That(expectDiffLineNumber, Is.EqualTo(firstLine.DiffLineNumber));
             }
 
 			[TestCase(" FIRST")]
@@ -198,7 +198,7 @@ index b02decb..f7dadae 100644
 
                 var str = firstLine.ToString();
 
-                Assert.AreEqual(line, str);
+                Assert.That(line, Is.EqualTo(str));
             }
 
 			[TestCase(" FIRST")]
@@ -211,7 +211,7 @@ index b02decb..f7dadae 100644
                 var result = DiffUtilities.ParseFragment(fragment);
                 var firstLine = result.First().Lines.First();
 
-                Assert.AreEqual(line, firstLine.Content);
+                Assert.That(line, Is.EqualTo(firstLine.Content));
             }
 
 			[TestCase(" FIRST", DiffChangeType.None)]
@@ -224,7 +224,7 @@ index b02decb..f7dadae 100644
                 var result = DiffUtilities.ParseFragment(fragment);
 
                 var firstLine = result.First().Lines.First();
-                Assert.AreEqual(expectType, firstLine.Type);
+                Assert.That(expectType, Is.EqualTo(firstLine.Type));
             }
 
 			[TestCase("?FIRST", "Invalid diff line change char: '?'.")]
@@ -235,7 +235,7 @@ index b02decb..f7dadae 100644
                 var result = DiffUtilities.ParseFragment(fragment);
                 var e = Assert.Throws<InvalidDataException>(() => result.First());
 
-                Assert.AreEqual(expectMessage, e.Message);
+                Assert.That(expectMessage, Is.EqualTo(e.Message));
             }
         }
 
@@ -274,7 +274,7 @@ index b02decb..f7dadae 100644
                 var line = DiffUtilities.Match(chunks1, targetLines);
 
                 var diffLineNumber = (line != null) ? line.DiffLineNumber : -1;
-                Assert.AreEqual(expectedDiffLineNumber, diffLineNumber);
+                Assert.That(expectedDiffLineNumber, Is.EqualTo(diffLineNumber));
             }
 
             [Test]
@@ -289,7 +289,7 @@ index b02decb..f7dadae 100644
 
                 var line = DiffUtilities.Match(chunks1, targetLines);
 
-                Assert.AreEqual(expectLine, line);
+                Assert.That(expectLine, Is.EqualTo(line));
             }
 
             [Test]
@@ -300,7 +300,7 @@ index b02decb..f7dadae 100644
 
                 var line = DiffUtilities.Match(chunks, lines);
 
-                Assert.Null(line);
+                Assert.That(line, Is.Null);
             }
         }
 
@@ -325,7 +325,7 @@ index b02decb..f7dadae 100644
                 foreach (var expectLine in expectLines)
                 {
                     var line = lineReader.ReadLine();
-                    Assert.AreEqual(expectLine, line);
+                    Assert.That(expectLine, Is.EqualTo(line));
                 }
             }
 
@@ -344,7 +344,7 @@ index b02decb..f7dadae 100644
             {
                 var count = DiffUtilities.LineReader.CountCarriageReturns(text);
 
-                Assert.AreEqual(expectCount, count);
+                Assert.That(expectCount, Is.EqualTo(count));
             }
 
             [Test]

--- a/test/GitHub.InlineReviews.UnitTests/Services/DiffServiceTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/DiffServiceTests.cs
@@ -20,38 +20,38 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 var target = new DiffService(Substitute.For<IGitClient>());
                 var result = DiffUtilities.ParseFragment(Resources.pr_960_diff).ToList();
 
-                Assert.AreEqual(4, result.Count);
+                Assert.That(4, Is.EqualTo(result.Count));
 
-                Assert.AreEqual(11, result[0].OldLineNumber);
-                Assert.AreEqual(11, result[0].NewLineNumber);
-                Assert.AreEqual(24, result[0].Lines.Count);
+                Assert.That(11, Is.EqualTo(result[0].OldLineNumber));
+                Assert.That(11, Is.EqualTo(result[0].NewLineNumber));
+                Assert.That(24, Is.EqualTo(result[0].Lines.Count));
 
-                Assert.AreEqual(61, result[1].OldLineNumber);
-                Assert.AreEqual(61, result[1].NewLineNumber);
-                Assert.AreEqual(21, result[1].Lines.Count);
+                Assert.That(61, Is.EqualTo(result[1].OldLineNumber));
+                Assert.That(61, Is.EqualTo(result[1].NewLineNumber));
+                Assert.That(21, Is.EqualTo(result[1].Lines.Count));
 
-                Assert.AreEqual(244, result[2].OldLineNumber);
-                Assert.AreEqual(247, result[2].NewLineNumber);
-                Assert.AreEqual(15, result[2].Lines.Count);
+                Assert.That(244, Is.EqualTo(result[2].OldLineNumber));
+                Assert.That(247, Is.EqualTo(result[2].NewLineNumber));
+                Assert.That(15, Is.EqualTo(result[2].Lines.Count));
 
-                Assert.AreEqual(268, result[3].OldLineNumber);
-                Assert.AreEqual(264, result[3].NewLineNumber);
-                Assert.AreEqual(15, result[3].Lines.Count);
+                Assert.That(268, Is.EqualTo(result[3].OldLineNumber));
+                Assert.That(264, Is.EqualTo(result[3].NewLineNumber));
+                Assert.That(15, Is.EqualTo(result[3].Lines.Count));
 
                 // -    public class UsageTracker : IUsageTracker
-                Assert.AreEqual(17, result[0].Lines[7].OldLineNumber);
-                Assert.AreEqual(-1, result[0].Lines[7].NewLineNumber);
-                Assert.AreEqual(8, result[0].Lines[7].DiffLineNumber);
+                Assert.That(17, Is.EqualTo(result[0].Lines[7].OldLineNumber));
+                Assert.That(-1, Is.EqualTo(result[0].Lines[7].NewLineNumber));
+                Assert.That(8, Is.EqualTo(result[0].Lines[7].DiffLineNumber));
 
                 // +    public sealed class UsageTracker : IUsageTracker, IDisposable
-                Assert.AreEqual(-1, result[0].Lines[8].OldLineNumber);
-                Assert.AreEqual(18, result[0].Lines[8].NewLineNumber);
-                Assert.AreEqual(9, result[0].Lines[8].DiffLineNumber);
+                Assert.That(-1, Is.EqualTo(result[0].Lines[8].OldLineNumber));
+                Assert.That(18, Is.EqualTo(result[0].Lines[8].NewLineNumber));
+                Assert.That(9, Is.EqualTo(result[0].Lines[8].DiffLineNumber));
 
                 //      IConnectionManager connectionManager;
-                Assert.AreEqual(26, result[0].Lines[17].OldLineNumber);
-                Assert.AreEqual(25, result[0].Lines[17].NewLineNumber);
-                Assert.AreEqual(18, result[0].Lines[17].DiffLineNumber);
+                Assert.That(26, Is.EqualTo(result[0].Lines[17].OldLineNumber));
+                Assert.That(25, Is.EqualTo(result[0].Lines[17].NewLineNumber));
+                Assert.That(18, Is.EqualTo(result[0].Lines[17].DiffLineNumber));
             }
         }
     }

--- a/test/GitHub.InlineReviews.UnitTests/Services/DiffServiceTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/DiffServiceTests.cs
@@ -6,7 +6,7 @@ using GitHub.InlineReviews.UnitTests.Properties;
 using GitHub.Services;
 using GitHub.Models;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 
 namespace GitHub.InlineReviews.UnitTests.Services
 {
@@ -14,44 +14,44 @@ namespace GitHub.InlineReviews.UnitTests.Services
     {
         public class TheParseFragmentMethod
         {
-            [Fact]
+            [Test]
             public void ShouldParsePr960()
             {
                 var target = new DiffService(Substitute.For<IGitClient>());
                 var result = DiffUtilities.ParseFragment(Resources.pr_960_diff).ToList();
 
-                Assert.Equal(4, result.Count);
+                Assert.AreEqual(4, result.Count);
 
-                Assert.Equal(11, result[0].OldLineNumber);
-                Assert.Equal(11, result[0].NewLineNumber);
-                Assert.Equal(24, result[0].Lines.Count);
+                Assert.AreEqual(11, result[0].OldLineNumber);
+                Assert.AreEqual(11, result[0].NewLineNumber);
+                Assert.AreEqual(24, result[0].Lines.Count);
 
-                Assert.Equal(61, result[1].OldLineNumber);
-                Assert.Equal(61, result[1].NewLineNumber);
-                Assert.Equal(21, result[1].Lines.Count);
+                Assert.AreEqual(61, result[1].OldLineNumber);
+                Assert.AreEqual(61, result[1].NewLineNumber);
+                Assert.AreEqual(21, result[1].Lines.Count);
 
-                Assert.Equal(244, result[2].OldLineNumber);
-                Assert.Equal(247, result[2].NewLineNumber);
-                Assert.Equal(15, result[2].Lines.Count);
+                Assert.AreEqual(244, result[2].OldLineNumber);
+                Assert.AreEqual(247, result[2].NewLineNumber);
+                Assert.AreEqual(15, result[2].Lines.Count);
 
-                Assert.Equal(268, result[3].OldLineNumber);
-                Assert.Equal(264, result[3].NewLineNumber);
-                Assert.Equal(15, result[3].Lines.Count);
+                Assert.AreEqual(268, result[3].OldLineNumber);
+                Assert.AreEqual(264, result[3].NewLineNumber);
+                Assert.AreEqual(15, result[3].Lines.Count);
 
                 // -    public class UsageTracker : IUsageTracker
-                Assert.Equal(17, result[0].Lines[7].OldLineNumber);
-                Assert.Equal(-1, result[0].Lines[7].NewLineNumber);
-                Assert.Equal(8, result[0].Lines[7].DiffLineNumber);
+                Assert.AreEqual(17, result[0].Lines[7].OldLineNumber);
+                Assert.AreEqual(-1, result[0].Lines[7].NewLineNumber);
+                Assert.AreEqual(8, result[0].Lines[7].DiffLineNumber);
 
                 // +    public sealed class UsageTracker : IUsageTracker, IDisposable
-                Assert.Equal(-1, result[0].Lines[8].OldLineNumber);
-                Assert.Equal(18, result[0].Lines[8].NewLineNumber);
-                Assert.Equal(9, result[0].Lines[8].DiffLineNumber);
+                Assert.AreEqual(-1, result[0].Lines[8].OldLineNumber);
+                Assert.AreEqual(18, result[0].Lines[8].NewLineNumber);
+                Assert.AreEqual(9, result[0].Lines[8].DiffLineNumber);
 
                 //      IConnectionManager connectionManager;
-                Assert.Equal(26, result[0].Lines[17].OldLineNumber);
-                Assert.Equal(25, result[0].Lines[17].NewLineNumber);
-                Assert.Equal(18, result[0].Lines[17].DiffLineNumber);
+                Assert.AreEqual(26, result[0].Lines[17].OldLineNumber);
+                Assert.AreEqual(25, result[0].Lines[17].NewLineNumber);
+                Assert.AreEqual(18, result[0].Lines[17].DiffLineNumber);
             }
         }
     }

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
@@ -17,7 +17,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 using System.Reactive.Disposables;
 
 namespace GitHub.InlineReviews.UnitTests.Services
@@ -35,7 +35,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
         public class TheConstructor : PullRequestSessionManagerTests
         {
-            [Fact]
+            [Test]
             public void ReadsPullRequestFromCorrectFork()
             {
                 var service = CreatePullRequestService();
@@ -59,7 +59,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
         public class TheCurrentSessionProperty : PullRequestSessionManagerTests
         {
-            [Fact]
+            [Test]
             public void CreatesSessionForCurrentBranch()
             {
                 var target = new PullRequestSessionManager(
@@ -73,7 +73,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 Assert.True(target.CurrentSession.IsCheckedOut);
             }
 
-            [Fact]
+            [Test]
             public void CurrentSessionIsNullIfNoPullRequestForCurrentBranch()
             {
                 var service = CreatePullRequestService();
@@ -89,7 +89,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 Assert.Null(target.CurrentSession);
             }
 
-            [Fact]
+            [Test]
             public void CurrentSessionChangesWhenBranchChanges()
             {
                 var service = CreatePullRequestService();
@@ -106,10 +106,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 service.GetPullRequestForCurrentBranch(null).ReturnsForAnyArgs(Observable.Return(Tuple.Create("foo", 22)));
                 teService.NotifyActiveRepoChanged();
 
-                Assert.NotSame(session, target.CurrentSession);
+                Assert.That(session, Is.Not.SameAs(target.CurrentSession));
             }
 
-            [Fact]
+            [Test]
             public void CurrentSessionChangesWhenRepoChanged()
             {
                 var teService = new FakeTeamExplorerServiceHolder(CreateRepositoryModel());
@@ -124,10 +124,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
                 teService.ActiveRepo = CreateRepositoryModel("https://github.com/owner/other");
 
-                Assert.NotSame(session, target.CurrentSession);
+                Assert.That(session, Is.Not.SameAs(target.CurrentSession));
             }
 
-            [Fact]
+            [Test]
             public void RepoChangedDoesntCreateNewSessionIfNotNecessary()
             {
                 var teService = new FakeTeamExplorerServiceHolder(CreateRepositoryModel());
@@ -142,10 +142,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
                 teService.NotifyActiveRepoChanged();
 
-                Assert.Same(session, target.CurrentSession);
+                Assert.That(session, Is.SameAs(target.CurrentSession));
             }
 
-            [Fact]
+            [Test]
             public void RepoChangedHandlesNullRepository()
             {
                 var teService = new FakeTeamExplorerServiceHolder(CreateRepositoryModel());
@@ -161,7 +161,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 Assert.Null(target.CurrentSession);
             }
 
-            [Fact]
+            [Test]
             public void CreatesSessionWithCorrectRepositoryOwner()
             {
                 var target = new PullRequestSessionManager(
@@ -171,7 +171,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     CreateModelServiceFactory(),
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
 
-                Assert.Equal("this-owner", target.CurrentSession.RepositoryOwner);
+                Assert.AreEqual("this-owner", target.CurrentSession.RepositoryOwner);
             }
         }
 
@@ -179,7 +179,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
         {
             const string FilePath = "test.cs";
 
-            [Fact]
+            [Test]
             public async Task BaseShaIsSet()
             {
                 var textView = CreateTextView();
@@ -192,10 +192,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                 var file = await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.Same("BASESHA", file.BaseSha);
+                Assert.That("BASESHA", Is.SameAs(file.BaseSha));
             }
 
-            [Fact]
+            [Test]
             public async Task CommitShaIsSet()
             {
                 var textView = CreateTextView();
@@ -208,10 +208,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                 var file = await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.Same("TIPSHA", file.CommitSha);
+                Assert.That("TIPSHA", Is.SameAs(file.CommitSha));
             }
 
-            [Fact]
+            [Test]
             public async Task CommitShaIsNullIfModified()
             {
                 var textView = CreateTextView();
@@ -227,7 +227,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 Assert.Null(file.CommitSha);
             }
 
-            [Fact]
+            [Test]
             public async Task DiffIsSet()
             {
                 var textView = CreateTextView();
@@ -252,10 +252,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                 var file = await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.Same(diff, file.Diff);
+                Assert.That(diff, Is.SameAs(file.Diff));
             }
 
-            [Fact]
+            [Test]
             public async Task InlineCommentThreadsIsSet()
             {
                 var textView = CreateTextView();
@@ -277,10 +277,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
                 var file = await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.Same(threads, file.InlineCommentThreads);
+                Assert.That(threads, Is.SameAs(file.InlineCommentThreads));
             }
 
-            [Fact]
+            [Test]
             public async Task CreatesTrackingPointsForThreads()
             {
                 var textView = CreateTextView();
@@ -306,10 +306,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
                 var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.Equal(2, file.TrackingPoints.Count);
+                Assert.AreEqual(2, file.TrackingPoints.Count);
             }
 
-            [Fact]
+            [Test]
             public async Task MovingToNoRepositoryShouldNullOutProperties()
             {
                 var textView = CreateTextView();
@@ -347,7 +347,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 Assert.Null(file.TrackingPoints);
             }
 
-            [Fact]
+            [Test]
             public async Task ModifyingBufferMarksThreadsAsStaleAndSignalsRebuild()
             {
                 var textView = CreateTextView();
@@ -391,7 +391,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 file.Rebuild.Received().OnNext(Arg.Any<ITextSnapshot>());
             }
 
-            [Fact]
+            [Test]
             public async Task RebuildSignalUpdatesCommitSha()
             {
                 var textView = CreateTextView();
@@ -412,7 +412,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                 var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.Same("TIPSHA", file.CommitSha);
+                Assert.That("TIPSHA", Is.SameAs(file.CommitSha));
 
                 sessionService.IsUnmodifiedAndPushed(null, null, null).ReturnsForAnyArgs(false);
                 file.Rebuild.OnNext(textView.TextBuffer.CurrentSnapshot);
@@ -420,7 +420,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 Assert.Null(file.CommitSha);
             }
 
-            [Fact]
+            [Test]
             public async Task ClosingTextViewDisposesFile()
             {
                 var textView = CreateTextView();
@@ -442,7 +442,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 Assert.True(compositeDisposable.IsDisposed);
             }
 
-            [Fact]
+            [Test]
             public async Task InlineCommentThreadsAreLoadedFromCurrentSession()
             {
                 var baseContents = @"Line 1
@@ -477,12 +477,12 @@ Line 4";
                         new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                     var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                    Assert.Equal(1, file.InlineCommentThreads.Count);
-                    Assert.Equal(2, file.InlineCommentThreads[0].LineNumber);
+                    Assert.AreEqual(1, file.InlineCommentThreads.Count);
+                    Assert.AreEqual(2, file.InlineCommentThreads[0].LineNumber);
                 }
             }
 
-            [Fact]
+            [Test]
             public async Task UpdatesInlineCommentThreadsFromEditorContent()
             {
                 var baseContents = @"Line 1
@@ -523,17 +523,17 @@ Line 4";
                         new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                     var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                    Assert.Equal(1, file.InlineCommentThreads.Count);
-                    Assert.Equal(2, file.InlineCommentThreads[0].LineNumber);
+                    Assert.AreEqual(1, file.InlineCommentThreads.Count);
+                    Assert.AreEqual(2, file.InlineCommentThreads[0].LineNumber);
 
                     textView.TextSnapshot.GetText().Returns(editorContents);
                     SignalTextChanged(textView.TextBuffer);
 
                     var linesChanged = await file.LinesChanged.Take(1);
 
-                    Assert.Equal(1, file.InlineCommentThreads.Count);
-                    Assert.Equal(4, file.InlineCommentThreads[0].LineNumber);
-                    Assert.Equal(
+                    Assert.AreEqual(1, file.InlineCommentThreads.Count);
+                    Assert.AreEqual(4, file.InlineCommentThreads[0].LineNumber);
+                    Assert.AreEqual(
                         new[]
                         {
                             Tuple.Create(2, DiffSide.Right),
@@ -543,7 +543,7 @@ Line 4";
                 }
             }
 
-            [Fact]
+            [Test]
             public async Task UpdatesReviewCommentWithNewBody()
             {
                 var baseContents = @"Line 1
@@ -583,7 +583,7 @@ Line 4";
                         new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                     var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                    Assert.Equal("Original Comment", file.InlineCommentThreads[0].Comments[0].Body);
+                    Assert.AreEqual("Original Comment", file.InlineCommentThreads[0].Comments[0].Body);
 
                     pullRequest = CreatePullRequestModel(
                         CurrentBranchPullRequestNumber,
@@ -593,11 +593,11 @@ Line 4";
 
                     await file.LinesChanged.Take(1);
 
-                    Assert.Equal("Updated Comment", file.InlineCommentThreads[0].Comments[0].Body);
+                    Assert.AreEqual("Updated Comment", file.InlineCommentThreads[0].Comments[0].Body);
                 }
             }
 
-            [Fact]
+            [Test]
             public async Task AddsNewReviewCommentToThread()
             {
                 var baseContents = @"Line 1
@@ -638,7 +638,7 @@ Line 4";
                         new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                     var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                    Assert.Equal(1, file.InlineCommentThreads[0].Comments.Count);
+                    Assert.AreEqual(1, file.InlineCommentThreads[0].Comments.Count);
 
                     pullRequest = CreatePullRequestModel(
                         CurrentBranchPullRequestNumber,
@@ -649,13 +649,13 @@ Line 4";
 
                     var linesChanged = await file.LinesChanged.Take(1);
 
-                    Assert.Equal(2, file.InlineCommentThreads[0].Comments.Count);
-                    Assert.Equal("Comment1", file.InlineCommentThreads[0].Comments[0].Body);
-                    Assert.Equal("Comment2", file.InlineCommentThreads[0].Comments[1].Body);
+                    Assert.AreEqual(2, file.InlineCommentThreads[0].Comments.Count);
+                    Assert.AreEqual("Comment1", file.InlineCommentThreads[0].Comments[0].Body);
+                    Assert.AreEqual("Comment2", file.InlineCommentThreads[0].Comments[1].Body);
                 }
             }
 
-            [Fact]
+            [Test]
             public async Task CommitShaIsUpdatedOnTextChange()
             {
                 var textView = CreateTextView();
@@ -669,7 +669,7 @@ Line 4";
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                 var file = await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.Equal("TIPSHA", file.CommitSha);
+                Assert.AreEqual("TIPSHA", file.CommitSha);
 
                 sessionService.IsUnmodifiedAndPushed(null, null, null).ReturnsForAnyArgs(false);
                 SignalTextChanged(textView.TextBuffer);
@@ -677,7 +677,7 @@ Line 4";
                 Assert.Null(file.CommitSha);
             }
 
-            [Fact]
+            [Test]
             public async Task UpdatingCurrentSessionPullRequestTriggersLinesChanged()
             {
                 var textView = CreateTextView();
@@ -799,7 +799,7 @@ Line 4";
 
         public class TheGetSessionMethod : PullRequestSessionManagerTests
         {
-            [Fact]
+            [Test]
             public async Task GetSessionReturnsAndUpdatesCurrentSessionIfNumbersMatch()
             {
                 var target = new PullRequestSessionManager(
@@ -812,11 +812,11 @@ Line 4";
                 var newModel = CreatePullRequestModel(CurrentBranchPullRequestNumber);
                 var result = await target.GetSession(newModel);
 
-                Assert.Same(target.CurrentSession, result);
-                Assert.Same(target.CurrentSession.PullRequest, newModel);
+                Assert.That(target.CurrentSession, Is.SameAs(result));
+                ///Assert.That(target.CurrentSession, Is.SameAs(newModel));
             }
 
-            [Fact]
+            [Test]
             public async Task GetSessionReturnsNewSessionForPullRequestWithDifferentNumber()
             {
                 var target = new PullRequestSessionManager(
@@ -829,12 +829,12 @@ Line 4";
                 var newModel = CreatePullRequestModel(NotCurrentBranchPullRequestNumber);
                 var result = await target.GetSession(newModel);
 
-                Assert.NotSame(target.CurrentSession, result);
-                Assert.Same(result.PullRequest, newModel);
+                Assert.That(target.CurrentSession, Is.Not.SameAs(result));
+                Assert.That(result.PullRequest, Is.SameAs(newModel));
                 Assert.False(result.IsCheckedOut);
             }
 
-            [Fact]
+            [Test]
             public async Task GetSessionReturnsNewSessionForPullRequestWithDifferentBaseOwner()
             {
                 var target = new PullRequestSessionManager(
@@ -847,12 +847,12 @@ Line 4";
                 var newModel = CreatePullRequestModel(CurrentBranchPullRequestNumber, "https://github.com/fork/repo");
                 var result = await target.GetSession(newModel);
 
-                Assert.NotSame(target.CurrentSession, result);
-                Assert.Same(result.PullRequest, newModel);
+                Assert.That(target.CurrentSession, Is.Not.SameAs(result));
+                Assert.That(result.PullRequest, Is.SameAs(newModel));
                 Assert.False(result.IsCheckedOut);
             }
 
-            [Fact]
+            [Test]
             public async Task GetSessionReturnsSameSessionEachTime()
             {
                 var target = new PullRequestSessionManager(
@@ -866,10 +866,10 @@ Line 4";
                 var result1 = await target.GetSession(newModel);
                 var result2 = await target.GetSession(newModel);
 
-                Assert.Same(result1, result2);
+                Assert.That(result1, Is.SameAs(result2));
             }
 
-            [Fact]
+            [Test]
             public async Task SessionCanBeCollected()
             {
                 WeakReference<IPullRequestSession> weakSession = null;
@@ -900,7 +900,7 @@ Line 4";
                 Assert.Null(result);
             }
 
-            [Fact]
+            [Test]
             public async Task GetSessionUpdatesCurrentSessionIfCurrentBranchIsPullRequestButWasNotMarked()
             {
                 var service = CreatePullRequestService();
@@ -923,7 +923,7 @@ Line 4";
 
                 var session = await target.GetSession(model);
 
-                Assert.Same(session, target.CurrentSession);
+                Assert.That(session, Is.SameAs(target.CurrentSession));
             }
         }
 

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
@@ -813,7 +813,7 @@ Line 4";
                 var result = await target.GetSession(newModel);
 
                 Assert.That(target.CurrentSession, Is.SameAs(result));
-                ///Assert.That(target.CurrentSession, Is.SameAs(newModel));
+                Assert.That(result.PullRequest, Is.SameAs(newModel));
             }
 
             [Test]

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
@@ -69,8 +69,8 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     CreateModelServiceFactory(),
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
 
-                Assert.NotNull(target.CurrentSession);
-                Assert.True(target.CurrentSession.IsCheckedOut);
+                Assert.That(target.CurrentSession, Is.Not.Null);
+                Assert.That(target.CurrentSession.IsCheckedOut, Is.True);
             }
 
             [Test]
@@ -86,7 +86,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     CreateModelServiceFactory(),
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
 
-                Assert.Null(target.CurrentSession);
+                Assert.That(target.CurrentSession, Is.Null);
             }
 
             [Test]
@@ -158,7 +158,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
                 teService.ActiveRepo = null;
 
-                Assert.Null(target.CurrentSession);
+                Assert.That(target.CurrentSession, Is.Null);
             }
 
             [Test]
@@ -171,7 +171,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     CreateModelServiceFactory(),
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
 
-                Assert.AreEqual("this-owner", target.CurrentSession.RepositoryOwner);
+                Assert.That("this-owner", Is.EqualTo(target.CurrentSession.RepositoryOwner));
             }
         }
 
@@ -224,7 +224,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                 var file = await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.Null(file.CommitSha);
+                Assert.That(file.CommitSha, Is.Null);
             }
 
             [Test]
@@ -306,7 +306,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
                 var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.AreEqual(2, file.TrackingPoints.Count);
+                Assert.That(2, Is.EqualTo(file.TrackingPoints.Count));
             }
 
             [Test]
@@ -332,19 +332,19 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
                 var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.NotNull(file.BaseSha);
-                Assert.NotNull(file.CommitSha);
-                Assert.NotNull(file.Diff);
-                Assert.NotNull(file.InlineCommentThreads);
-                Assert.NotNull(file.TrackingPoints);
+                Assert.That(file.BaseSha, Is.Not.Null);
+                Assert.That(file.CommitSha, Is.Not.Null);
+                Assert.That(file.Diff, Is.Not.Null);
+                Assert.That(file.InlineCommentThreads, Is.Not.Null);
+                Assert.That(file.TrackingPoints, Is.Not.Null);
 
                 teHolder.ActiveRepo = null;
 
-                Assert.Null(file.BaseSha);
-                Assert.Null(file.CommitSha);
-                Assert.Null(file.Diff);
-                Assert.Null(file.InlineCommentThreads);
-                Assert.Null(file.TrackingPoints);
+                Assert.That(file.BaseSha, Is.Null);
+                Assert.That(file.CommitSha, Is.Null);
+                Assert.That(file.Diff, Is.Null);
+                Assert.That(file.InlineCommentThreads, Is.Null);
+                Assert.That(file.TrackingPoints, Is.Null);
             }
 
             [Test]
@@ -387,7 +387,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 threads[0].Received().IsStale = true;
                 threads[1].DidNotReceive().IsStale = true;
 
-                Assert.True(linesChangedReceived);
+                Assert.That(linesChangedReceived, Is.True);
                 file.Rebuild.Received().OnNext(Arg.Any<ITextSnapshot>());
             }
 
@@ -417,7 +417,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 sessionService.IsUnmodifiedAndPushed(null, null, null).ReturnsForAnyArgs(false);
                 file.Rebuild.OnNext(textView.TextBuffer.CurrentSnapshot);
 
-                Assert.Null(file.CommitSha);
+                Assert.That(file.CommitSha, Is.Null);
             }
 
             [Test]
@@ -434,12 +434,12 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
                 var compositeDisposable = file.ToDispose as CompositeDisposable;
-                Assert.NotNull(compositeDisposable);
-                Assert.False(compositeDisposable.IsDisposed);
+                Assert.That(compositeDisposable, Is.Not.Null);
+                Assert.That(compositeDisposable.IsDisposed, Is.False);
 
                 textView.Closed += Raise.Event();
 
-                Assert.True(compositeDisposable.IsDisposed);
+                Assert.That(compositeDisposable.IsDisposed, Is.True);
             }
 
             [Test]
@@ -477,8 +477,8 @@ Line 4";
                         new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                     var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                    Assert.AreEqual(1, file.InlineCommentThreads.Count);
-                    Assert.AreEqual(2, file.InlineCommentThreads[0].LineNumber);
+                    Assert.That(1, Is.EqualTo(file.InlineCommentThreads.Count));
+                    Assert.That(2, Is.EqualTo(file.InlineCommentThreads[0].LineNumber));
                 }
             }
 
@@ -523,23 +523,23 @@ Line 4";
                         new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                     var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                    Assert.AreEqual(1, file.InlineCommentThreads.Count);
-                    Assert.AreEqual(2, file.InlineCommentThreads[0].LineNumber);
+                    Assert.That(1, Is.EqualTo(file.InlineCommentThreads.Count));
+                    Assert.That(2, Is.EqualTo(file.InlineCommentThreads[0].LineNumber));
 
                     textView.TextSnapshot.GetText().Returns(editorContents);
                     SignalTextChanged(textView.TextBuffer);
 
                     var linesChanged = await file.LinesChanged.Take(1);
 
-                    Assert.AreEqual(1, file.InlineCommentThreads.Count);
-                    Assert.AreEqual(4, file.InlineCommentThreads[0].LineNumber);
-                    Assert.AreEqual(
+                    Assert.That(1, Is.EqualTo(file.InlineCommentThreads.Count));
+                    Assert.That(4, Is.EqualTo(file.InlineCommentThreads[0].LineNumber));
+                    Assert.That(
                         new[]
                         {
                             Tuple.Create(2, DiffSide.Right),
                             Tuple.Create(4, DiffSide.Right),
                         },
-                        linesChanged.ToArray());
+                        Is.EqualTo(linesChanged.ToArray()));
                 }
             }
 
@@ -583,7 +583,7 @@ Line 4";
                         new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                     var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                    Assert.AreEqual("Original Comment", file.InlineCommentThreads[0].Comments[0].Body);
+                    Assert.That("Original Comment", Is.EqualTo(file.InlineCommentThreads[0].Comments[0].Body));
 
                     pullRequest = CreatePullRequestModel(
                         CurrentBranchPullRequestNumber,
@@ -593,7 +593,7 @@ Line 4";
 
                     await file.LinesChanged.Take(1);
 
-                    Assert.AreEqual("Updated Comment", file.InlineCommentThreads[0].Comments[0].Body);
+                    Assert.That("Updated Comment", Is.EqualTo(file.InlineCommentThreads[0].Comments[0].Body));
                 }
             }
 
@@ -638,7 +638,7 @@ Line 4";
                         new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                     var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                    Assert.AreEqual(1, file.InlineCommentThreads[0].Comments.Count);
+                    Assert.That(1, Is.EqualTo(file.InlineCommentThreads[0].Comments.Count));
 
                     pullRequest = CreatePullRequestModel(
                         CurrentBranchPullRequestNumber,
@@ -649,9 +649,9 @@ Line 4";
 
                     var linesChanged = await file.LinesChanged.Take(1);
 
-                    Assert.AreEqual(2, file.InlineCommentThreads[0].Comments.Count);
-                    Assert.AreEqual("Comment1", file.InlineCommentThreads[0].Comments[0].Body);
-                    Assert.AreEqual("Comment2", file.InlineCommentThreads[0].Comments[1].Body);
+                    Assert.That(2, Is.EqualTo(file.InlineCommentThreads[0].Comments.Count));
+                    Assert.That("Comment1", Is.EqualTo(file.InlineCommentThreads[0].Comments[0].Body));
+                    Assert.That("Comment2", Is.EqualTo(file.InlineCommentThreads[0].Comments[1].Body));
                 }
             }
 
@@ -669,12 +669,12 @@ Line 4";
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
                 var file = await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
 
-                Assert.AreEqual("TIPSHA", file.CommitSha);
+                Assert.That("TIPSHA", Is.EqualTo(file.CommitSha));
 
                 sessionService.IsUnmodifiedAndPushed(null, null, null).ReturnsForAnyArgs(false);
                 SignalTextChanged(textView.TextBuffer);
 
-                Assert.Null(file.CommitSha);
+                Assert.That(file.CommitSha, Is.Null);
             }
 
             [Test]
@@ -705,7 +705,7 @@ Line 4";
                 // LinesChanged should be raised even if the IPullRequestModel is the same.
                 await target.CurrentSession.Update(target.CurrentSession.PullRequest);
 
-                Assert.True(raised);
+                Assert.That(raised, Is.True);
             }
 
             static IPullRequestReviewCommentModel CreateComment(
@@ -831,7 +831,7 @@ Line 4";
 
                 Assert.That(target.CurrentSession, Is.Not.SameAs(result));
                 Assert.That(result.PullRequest, Is.SameAs(newModel));
-                Assert.False(result.IsCheckedOut);
+                Assert.That(result.IsCheckedOut, Is.False);
             }
 
             [Test]
@@ -849,7 +849,7 @@ Line 4";
 
                 Assert.That(target.CurrentSession, Is.Not.SameAs(result));
                 Assert.That(result.PullRequest, Is.SameAs(newModel));
-                Assert.False(result.IsCheckedOut);
+                Assert.That(result.IsCheckedOut, Is.False);
             }
 
             [Test]
@@ -886,7 +886,7 @@ Line 4";
                     var newModel = CreatePullRequestModel(NotCurrentBranchPullRequestNumber);
                     var session = await target.GetSession(newModel);
 
-                    Assert.NotNull(session);
+                    Assert.That(session, Is.Not.Null);
 
                     weakSession = new WeakReference<IPullRequestSession>(session);
                 };
@@ -897,7 +897,7 @@ Line 4";
                 IPullRequestSession result;
                 weakSession.TryGetTarget(out result);
 
-                Assert.Null(result);
+                Assert.That(result, Is.Null);
             }
 
             [Test]
@@ -914,7 +914,7 @@ Line 4";
                     CreateModelServiceFactory(),
                     new FakeTeamExplorerServiceHolder(CreateRepositoryModel()));
 
-                Assert.Null(target.CurrentSession);
+                Assert.That(target.CurrentSession, Is.Null);
 
                 var model = CreatePullRequestModel(CurrentBranchPullRequestNumber);
 

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionServiceTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionServiceTests.cs
@@ -49,7 +49,7 @@ Line 4";
                         diff);
 
                     var thread = result.Single();
-                    Assert.AreEqual(2, thread.LineNumber);
+                    Assert.That(2, Is.EqualTo(thread.LineNumber));
                 }
             }
 
@@ -85,7 +85,7 @@ Line 4";
                         diff);
 
                     var thread = result.Single();
-                    Assert.AreEqual(4, thread.LineNumber);
+                    Assert.That(4, Is.EqualTo(thread.LineNumber));
                 }
             }
 
@@ -124,8 +124,8 @@ Line 4";
                         FilePath,
                         diff);
 
-                    Assert.AreEqual(2, result.Count);
-                    Assert.AreEqual(-1, result[1].LineNumber);
+                    Assert.That(2, Is.EqualTo(result.Count));
+                    Assert.That(-1, Is.EqualTo(result[1].LineNumber));
                 }
             }
 
@@ -164,7 +164,7 @@ Line 4";
                         diff);
 
                     var thread = result.First();
-                    Assert.AreEqual(4, thread.LineNumber);
+                    Assert.That(4, Is.EqualTo(thread.LineNumber));
                 }
             }
         }
@@ -205,19 +205,19 @@ Line 4";
                         FilePath,
                         diff);
 
-                    Assert.AreEqual(2, threads[0].LineNumber);
+                    Assert.That(2, Is.EqualTo(threads[0].LineNumber));
 
                     diff = await diffService.Diff(FilePath, newHeadContents);
                     var changedLines = target.UpdateCommentThreads(threads, diff);
 
-                    Assert.AreEqual(3, threads[0].LineNumber);
-                    Assert.AreEqual(
+                    Assert.That(3, Is.EqualTo(threads[0].LineNumber));
+                    Assert.That(
                         new[] 
                         {
                             Tuple.Create(2, DiffSide.Right),
                             Tuple.Create(3, DiffSide.Right)
-                        }, 
-                        changedLines.ToArray());
+                        },
+                        Is.EqualTo(changedLines.ToArray()));
                 }
             }
 
@@ -253,8 +253,8 @@ Line 4";
                     threads[0].IsStale = true;
                     var changedLines = target.UpdateCommentThreads(threads, diff);
 
-                    Assert.False(threads[0].IsStale);
-                    Assert.AreEqual(new[] { Tuple.Create(2, DiffSide.Right) }, changedLines.ToArray());
+                    Assert.That(threads[0].IsStale, Is.False);
+                    Assert.That(new[] { Tuple.Create(2, DiffSide.Right) }, Is.EqualTo(changedLines.ToArray()));
                 }
             }
         }

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionServiceTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionServiceTests.cs
@@ -7,7 +7,7 @@ using GitHub.InlineReviews.UnitTests.TestDoubles;
 using GitHub.Models;
 using GitHub.Services;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 
 namespace GitHub.InlineReviews.UnitTests.Services
 {
@@ -19,7 +19,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
         public class TheBuildCommentThreadsMethod
         {
-            [Fact]
+            [Test]
             public async Task MatchesReviewCommentOnOriginalLine()
             {
                 var baseContents = @"Line 1
@@ -49,11 +49,11 @@ Line 4";
                         diff);
 
                     var thread = result.Single();
-                    Assert.Equal(2, thread.LineNumber);
+                    Assert.AreEqual(2, thread.LineNumber);
                 }
             }
 
-            [Fact]
+            [Test]
             public async Task MatchesReviewCommentOnDifferentLine()
             {
                 var baseContents = @"Line 1
@@ -85,11 +85,11 @@ Line 4";
                         diff);
 
                     var thread = result.Single();
-                    Assert.Equal(4, thread.LineNumber);
+                    Assert.AreEqual(4, thread.LineNumber);
                 }
             }
 
-            [Fact]
+            [Test]
             public async Task ReturnsLineNumberMinus1ForNonMatchingComment()
             {
                 var baseContents = @"Line 1
@@ -124,12 +124,12 @@ Line 4";
                         FilePath,
                         diff);
 
-                    Assert.Equal(2, result.Count);
-                    Assert.Equal(-1, result[1].LineNumber);
+                    Assert.AreEqual(2, result.Count);
+                    Assert.AreEqual(-1, result[1].LineNumber);
                 }
             }
 
-            [Fact]
+            [Test]
             public async Task HandlesDifferingPathSeparators()
             {
                 var winFilePath = @"foo\test.cs";
@@ -164,14 +164,14 @@ Line 4";
                         diff);
 
                     var thread = result.First();
-                    Assert.Equal(4, thread.LineNumber);
+                    Assert.AreEqual(4, thread.LineNumber);
                 }
             }
         }
 
         public class TheUpdateCommentThreadsMethod
         {
-            [Fact]
+            [Test]
             public async Task UpdatesWithNewLineNumber()
             {
                 var baseContents = @"Line 1
@@ -205,13 +205,13 @@ Line 4";
                         FilePath,
                         diff);
 
-                    Assert.Equal(2, threads[0].LineNumber);
+                    Assert.AreEqual(2, threads[0].LineNumber);
 
                     diff = await diffService.Diff(FilePath, newHeadContents);
                     var changedLines = target.UpdateCommentThreads(threads, diff);
 
-                    Assert.Equal(3, threads[0].LineNumber);
-                    Assert.Equal(
+                    Assert.AreEqual(3, threads[0].LineNumber);
+                    Assert.AreEqual(
                         new[] 
                         {
                             Tuple.Create(2, DiffSide.Right),
@@ -221,7 +221,7 @@ Line 4";
                 }
             }
 
-            [Fact]
+            [Test]
             public async Task UnmarksStaleThreads()
             {
                 var baseContents = @"Line 1
@@ -254,7 +254,7 @@ Line 4";
                     var changedLines = target.UpdateCommentThreads(threads, diff);
 
                     Assert.False(threads[0].IsStale);
-                    Assert.Equal(new[] { Tuple.Create(2, DiffSide.Right) }, changedLines.ToArray());
+                    Assert.AreEqual(new[] { Tuple.Create(2, DiffSide.Right) }, changedLines.ToArray());
                 }
             }
         }

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
@@ -114,7 +114,7 @@ Line 4";
 
                     var file = await target.GetFile(FilePath);
                     var thread = file.InlineCommentThreads.First();
-                    Assert.AreEqual(2, thread.LineNumber);
+                    Assert.That(2, Is.EqualTo(thread.LineNumber));
                 }
             }
         }
@@ -241,12 +241,12 @@ Line 4";
 
                     var file = await target.GetFile(FilePath);
 
-                    Assert.AreEqual(1, file.InlineCommentThreads[0].Comments.Count);
+                    Assert.That(1, Is.EqualTo(file.InlineCommentThreads[0].Comments.Count));
 
                     pullRequest = CreatePullRequest(comment1, comment2);
                     await target.Update(pullRequest);
 
-                    Assert.AreEqual(2, file.InlineCommentThreads[0].Comments.Count);
+                    Assert.That(2, Is.EqualTo(file.InlineCommentThreads[0].Comments.Count));
                 }
             }
 

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
@@ -12,7 +12,7 @@ using GitHub.Primitives;
 using GitHub.Services;
 using LibGit2Sharp;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 
 namespace GitHub.InlineReviews.UnitTests.Services
 {
@@ -24,7 +24,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
         public class TheGetFileMethod
         {
-            [Fact]
+            [Test]
             public async Task BaseShaIsSet()
             {
                 var target = new PullRequestSession(
@@ -36,10 +36,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     true);
                 var file = await target.GetFile(FilePath);
 
-                Assert.Same("BASE_SHA", file.BaseSha);
+                Assert.That("BASE_SHA", Is.SameAs(file.BaseSha));
             }
 
-            [Fact]
+            [Test]
             public async Task CommitShaIsSet()
             {
                 var target = new PullRequestSession(
@@ -51,10 +51,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     true);
                 var file = await target.GetFile(FilePath);
 
-                Assert.Same("HEAD_SHA", file.CommitSha);
+                Assert.That("HEAD_SHA", Is.SameAs(file.CommitSha));
             }
 
-            [Fact]
+            [Test]
             public async Task DiffShaIsSet()
             {
                 var diff = new List<DiffChunk>();
@@ -75,10 +75,10 @@ namespace GitHub.InlineReviews.UnitTests.Services
                     true);
                 var file = await target.GetFile(FilePath);
 
-                Assert.Same(diff, file.Diff);
+                Assert.That(diff, Is.SameAs(file.Diff));
             }
 
-            [Fact]
+            [Test]
             public async Task InlineCommentThreadsIsSet()
             {
                 var baseContents = @"Line 1
@@ -114,14 +114,14 @@ Line 4";
 
                     var file = await target.GetFile(FilePath);
                     var thread = file.InlineCommentThreads.First();
-                    Assert.Equal(2, thread.LineNumber);
+                    Assert.AreEqual(2, thread.LineNumber);
                 }
             }
         }
 
         public class ThePostReviewCommentMethod
         {
-            [Fact]
+            [Test]
             public async Task PostsToCorrectFork()
             {
                 var service = Substitute.For<IPullRequestSessionService>();
@@ -140,7 +140,7 @@ Line 4";
                     1);
             }
 
-            [Fact]
+            [Test]
             public async Task PostsReplyToCorrectFork()
             {
                 var service = Substitute.For<IPullRequestSessionService>();
@@ -180,7 +180,7 @@ Line 4";
 
         public class TheUpdateMethod
         {
-            [Fact]
+            [Test]
             public async Task UpdatesThePullRequestModel()
             {
                 var target = new PullRequestSession(
@@ -197,10 +197,10 @@ Line 4";
                 // PullRequestModel overrides Equals such that two PRs with the same number are
                 // considered equal. This was causing the PullRequest not to be updated on refresh.
                 // Test that this works correctly!
-                Assert.Same(newPullRequest, target.PullRequest);
+                Assert.That(newPullRequest, Is.SameAs(target.PullRequest));
             }
 
-            [Fact]
+            [Test]
             public async Task AddsNewReviewCommentToThread()
             {
                 var baseContents = @"Line 1
@@ -241,16 +241,16 @@ Line 4";
 
                     var file = await target.GetFile(FilePath);
 
-                    Assert.Equal(1, file.InlineCommentThreads[0].Comments.Count);
+                    Assert.AreEqual(1, file.InlineCommentThreads[0].Comments.Count);
 
                     pullRequest = CreatePullRequest(comment1, comment2);
                     await target.Update(pullRequest);
 
-                    Assert.Equal(2, file.InlineCommentThreads[0].Comments.Count);
+                    Assert.AreEqual(2, file.InlineCommentThreads[0].Comments.Count);
                 }
             }
 
-            [Fact]
+            [Test]
             public async Task DoesntThrowIfGetFileCalledDuringUpdate()
             {
                 var comment = CreateComment(@"@@ -1,4 +1,4 @@

--- a/test/GitHub.InlineReviews.UnitTests/Tags/InlineCommentTaggerTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Tags/InlineCommentTaggerTests.cs
@@ -44,7 +44,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                /**Assert.Single(result);**/
+                //Assert.Single(result);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
             }
 
@@ -61,7 +61,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                /**Assert.Single(result);**/
+                //Assert.Single(result);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
             }
 
@@ -111,7 +111,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                /**Assert.Single(result);**/
+                //Assert.Single(result);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
             }
 
@@ -221,7 +221,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                /**Assert.Single(result);**/
+                //Assert.Single(result);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
             }
 
@@ -238,7 +238,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                /**Assert.Single(result);**/
+                //Assert.Single(result);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
             }
 

--- a/test/GitHub.InlineReviews.UnitTests/Tags/InlineCommentTaggerTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Tags/InlineCommentTaggerTests.cs
@@ -10,7 +10,7 @@ using GitHub.Services;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using NSubstitute;
-using Xunit;
+using NUnit.Framework;
 
 namespace GitHub.InlineReviews.UnitTests.Tags
 {
@@ -18,7 +18,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
     {
         public class WithTextBufferInfo
         {
-            [Fact]
+            [Test]
             public void FirstPassShouldReturnEmptyTags()
             {
                 var target = new InlineCommentTagger(
@@ -28,10 +28,10 @@ namespace GitHub.InlineReviews.UnitTests.Tags
 
                 var result = target.GetTags(CreateSpan(10));
 
-                Assert.Empty(result);
+                Assert.That(result, Is.Empty);
             }
 
-            [Fact]
+            [Test]
             public void ShouldReturnShowCommentTagForRhs()
             {
                 var target = new InlineCommentTagger(
@@ -44,11 +44,11 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                Assert.Single(result);
-                Assert.IsType<ShowInlineCommentTag>(result[0].Tag);
+                /**Assert.Single(result);**/
+                Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
             }
 
-            [Fact]
+            [Test]
             public void ShouldReturnAddNewCommentTagForAddedLineOnRhs()
             {
                 var target = new InlineCommentTagger(
@@ -61,11 +61,11 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                Assert.Single(result);
-                Assert.IsType<AddInlineCommentTag>(result[0].Tag);
+                /**Assert.Single(result);**/
+                Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
             }
 
-            [Fact]
+            [Test]
             public void ShouldNotReturnAddNewCommentTagForDeletedLineOnRhs()
             {
                 var target = new InlineCommentTagger(
@@ -78,10 +78,10 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                Assert.Empty(result);
+                Assert.That(result, Is.Empty);
             }
 
-            [Fact]
+            [Test]
             public void ShouldReturnShowCommentTagForLhs()
             {
                 var target = new InlineCommentTagger(
@@ -94,11 +94,11 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                Assert.Single(result);
-                Assert.IsType<ShowInlineCommentTag>(result[0].Tag);
+                /**Assert.Single(result);**/
+                Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
             }
 
-            [Fact]
+            [Test]
             public void ShouldReturnAddCommentTagForLhs()
             {
                 var target = new InlineCommentTagger(
@@ -111,11 +111,11 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                Assert.Single(result);
-                Assert.IsType<AddInlineCommentTag>(result[0].Tag);
+                /**Assert.Single(result);**/
+                Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
             }
 
-            [Fact]
+            [Test]
             public void ShouldRaiseTagsChangedOnFileLinesChanged()
             {
                 var file = CreateSessionFile();
@@ -196,7 +196,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
 
         public class WithoutTextBufferInfo
         {
-            [Fact]
+            [Test]
             public void FirstPassShouldReturnEmptyTags()
             {
                 var target = new InlineCommentTagger(
@@ -205,11 +205,10 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                     CreateSessionManager());
 
                 var result = target.GetTags(CreateSpan(10));
-
-                Assert.Empty(result);
+                Assert.That(result, Is.Empty);
             }
 
-            [Fact]
+            [Test]
             public void ShouldReturnShowCommentTag()
             {
                 var target = new InlineCommentTagger(
@@ -222,11 +221,11 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                Assert.Single(result);
-                Assert.IsType<ShowInlineCommentTag>(result[0].Tag);
+                /**Assert.Single(result);**/
+                Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
             }
 
-            [Fact]
+            [Test]
             public void ShouldReturnAddNewCommentTagForAddedLine()
             {
                 var target = new InlineCommentTagger(
@@ -239,11 +238,11 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                Assert.Single(result);
-                Assert.IsType<AddInlineCommentTag>(result[0].Tag);
+                /**Assert.Single(result);**/
+                Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
             }
 
-            [Fact]
+            [Test]
             public void ShouldNotReturnAddNewCommentTagForDeletedLineOnRhs()
             {
                 var target = new InlineCommentTagger(
@@ -255,11 +254,10 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var span = CreateSpan(13);
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
-
-                Assert.Empty(result);
+                 Assert.That(result, Is.Empty);
             }
 
-            [Fact]
+            [Test]
             public void ShouldRaiseTagsChangedOnFileLinesChanged()
             {
                 var file = CreateSessionFile();
@@ -283,7 +281,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 Assert.True(raised);
             }
 
-            [Fact]
+            [Test]
             public void ShouldNotRaiseTagsChangedOnLeftHandSideLinesChanged()
             {
                 var file = CreateSessionFile();

--- a/test/GitHub.InlineReviews.UnitTests/Tags/InlineCommentTaggerTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Tags/InlineCommentTaggerTests.cs
@@ -45,7 +45,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var result = target.GetTags(span).ToList();
 
                 Assert.That(result, Has.One.Items);
-                Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
+                Assert.That(result[0].Tag, Is.InstanceOf<ShowInlineCommentTag>());
             }
 
             [Test]
@@ -62,7 +62,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var result = target.GetTags(span).ToList();
 
                 Assert.That(result, Has.One.Items);
-                Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
+                Assert.That(result[0].Tag, Is.InstanceOf<AddInlineCommentTag>());
             }
 
             [Test]
@@ -95,7 +95,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var result = target.GetTags(span).ToList();
 
                 Assert.That(result, Has.One.Items);
-                Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
+                Assert.That(result[0].Tag, Is.InstanceOf<ShowInlineCommentTag>());
             }
 
             [Test]
@@ -112,7 +112,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var result = target.GetTags(span).ToList();
 
                 Assert.That(result, Has.One.Items);
-                Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
+                Assert.That(result[0].Tag, Is.InstanceOf<AddInlineCommentTag>());
             }
 
             [Test]
@@ -222,7 +222,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var result = target.GetTags(span).ToList();
 
                 Assert.That(result, Has.One.Items);
-                Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
+                Assert.That(result[0].Tag, Is.InstanceOf<ShowInlineCommentTag>());
             }
 
             [Test]
@@ -239,7 +239,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var result = target.GetTags(span).ToList();
 
                 Assert.That(result, Has.One.Items);
-                Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
+                Assert.That(result[0].Tag, Is.InstanceOf<AddInlineCommentTag>());
             }
 
             [Test]

--- a/test/GitHub.InlineReviews.UnitTests/Tags/InlineCommentTaggerTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Tags/InlineCommentTaggerTests.cs
@@ -44,7 +44,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                //Assert.Single(result);
+                Assert.That(result, Has.One.Items);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
             }
 
@@ -61,7 +61,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                //Assert.Single(result);
+                Assert.That(result, Has.One.Items);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
             }
 
@@ -94,7 +94,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                /**Assert.Single(result);**/
+                Assert.That(result, Has.One.Items);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
             }
 
@@ -111,7 +111,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                //Assert.Single(result);
+                Assert.That(result, Has.One.Items);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
             }
 
@@ -221,7 +221,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                //Assert.Single(result);
+                Assert.That(result, Has.One.Items);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(ShowInlineCommentTag)));
             }
 
@@ -238,7 +238,7 @@ namespace GitHub.InlineReviews.UnitTests.Tags
                 var firstPass = target.GetTags(span);
                 var result = target.GetTags(span).ToList();
 
-                //Assert.Single(result);
+                Assert.That(result, Has.One.Items);
                 Assert.That(result[0].Tag, Is.InstanceOf(typeof(AddInlineCommentTag)));
             }
 

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentPeekViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentPeekViewModelTests.cs
@@ -101,7 +101,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             await target.Thread.Comments[0].CommitEdit.ExecuteAsyncTask(null);
 
-            Assert.That(target.Thread, Is.InstanceOf(typeof(NewInlineCommentThreadViewModel)));
+            Assert.That(target.Thread, Is.InstanceOf(typeof(InlineCommentThreadViewModel)));
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             await target.Initialize();
 
-            Assert.That(target.Thread, Is.InstanceOf(typeof(NewInlineCommentThreadViewModel)));
+            Assert.That(target.Thread, Is.InstanceOf(typeof(InlineCommentThreadViewModel)));
             Assert.AreEqual(2, target.Thread.Comments.Count);
 
             var file = await sessionManager.GetLiveFile(

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentPeekViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentPeekViewModelTests.cs
@@ -44,10 +44,10 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             // There should be an existing comment and a reply placeholder.
             Assert.That(target.Thread, Is.InstanceOf(typeof(InlineCommentThreadViewModel)));
-            Assert.AreEqual(2, target.Thread.Comments.Count);
-            Assert.AreEqual("Existing comment", target.Thread.Comments[0].Body);
-            Assert.AreEqual(string.Empty, target.Thread.Comments[1].Body);
-            Assert.AreEqual(CommentEditState.Placeholder, target.Thread.Comments[1].EditState);
+            Assert.That(2, Is.EqualTo(target.Thread.Comments.Count));
+            Assert.That("Existing comment", Is.EqualTo(target.Thread.Comments[0].Body));
+            Assert.That(string.Empty, Is.EqualTo(target.Thread.Comments[1].Body));
+            Assert.That(CommentEditState.Placeholder, Is.EqualTo(target.Thread.Comments[1].EditState));
         }
 
         [Test]
@@ -64,8 +64,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             await target.Initialize();
 
             Assert.That(target.Thread, Is.InstanceOf(typeof(NewInlineCommentThreadViewModel)));
-            Assert.AreEqual(string.Empty, target.Thread.Comments[0].Body);
-            Assert.AreEqual(CommentEditState.Editing, target.Thread.Comments[0].EditState);
+            Assert.That(string.Empty, Is.EqualTo(target.Thread.Comments[0].Body));
+            Assert.That(CommentEditState.Editing, Is.EqualTo(target.Thread.Comments[0].EditState));
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             await target.Initialize();
 
             Assert.That(target.Thread, Is.InstanceOf(typeof(InlineCommentThreadViewModel)));
-            Assert.AreEqual(2, target.Thread.Comments.Count);
+            Assert.That(2, Is.EqualTo(target.Thread.Comments.Count));
 
             var file = await sessionManager.GetLiveFile(
                 RelativePath,
@@ -127,7 +127,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 peekSession.TextView.TextBuffer);
             AddCommentToExistingThread(file);
 
-            Assert.AreEqual(3, target.Thread.Comments.Count);
+            Assert.That(3, Is.EqualTo(target.Thread.Comments.Count));
         }
 
         [Test]
@@ -144,7 +144,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             await target.Initialize();
 
-            Assert.AreEqual(2, target.Thread.Comments.Count);
+            Assert.That(2, Is.EqualTo(target.Thread.Comments.Count));
 
             var placeholder = target.Thread.Comments.Last();
             placeholder.BeginEdit.Execute(null);
@@ -157,9 +157,9 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             AddCommentToExistingThread(file);
 
             placeholder = target.Thread.Comments.Last();
-            Assert.AreEqual(3, target.Thread.Comments.Count);
-            Assert.AreEqual(CommentEditState.Editing, placeholder.EditState);
-            Assert.AreEqual("Comment being edited", placeholder.Body);
+            Assert.That(3, Is.EqualTo(target.Thread.Comments.Count));
+            Assert.That(CommentEditState.Editing, Is.EqualTo(placeholder.EditState));
+            Assert.That("Comment being edited", Is.EqualTo(placeholder.Body));
         }
 
         [Test]
@@ -176,7 +176,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             await target.Initialize();
 
-            Assert.AreEqual(2, target.Thread.Comments.Count);
+            Assert.That(2, Is.EqualTo(target.Thread.Comments.Count));
 
             sessionManager.CurrentSession.PostReviewComment(null, 0)
                 .ReturnsForAnyArgs(async x =>
@@ -195,8 +195,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             placeholder.CommitEdit.Execute(null);
 
             placeholder = target.Thread.Comments.Last();
-            Assert.AreEqual(CommentEditState.Placeholder, placeholder.EditState);
-            Assert.AreEqual(string.Empty, placeholder.Body);
+            Assert.That(CommentEditState.Placeholder, Is.EqualTo(placeholder.EditState));
+            Assert.That(string.Empty, Is.EqualTo(placeholder.Body));
         }
 
         void AddCommentToExistingThread(IPullRequestSessionFile file)

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentPeekViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentPeekViewModelTests.cs
@@ -20,7 +20,7 @@ using Microsoft.VisualStudio.Utilities;
 using NSubstitute;
 using Octokit;
 using ReactiveUI;
-using Xunit;
+using NUnit.Framework;
 
 namespace GitHub.InlineReviews.UnitTests.ViewModels
 {
@@ -29,7 +29,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
         const string FullPath = "c:\\repo\\test.cs";
         const string RelativePath = "test.cs";
 
-        [Fact]
+        [Test]
         public async Task ThreadIsCreatedForExistingComments()
         {
             // There is an existing comment thread at line 10.
@@ -43,14 +43,14 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             await target.Initialize();
 
             // There should be an existing comment and a reply placeholder.
-            Assert.IsType<InlineCommentThreadViewModel>(target.Thread);
-            Assert.Equal(2, target.Thread.Comments.Count);
-            Assert.Equal("Existing comment", target.Thread.Comments[0].Body);
-            Assert.Equal(string.Empty, target.Thread.Comments[1].Body);
-            Assert.Equal(CommentEditState.Placeholder, target.Thread.Comments[1].EditState);
+            Assert.That(target.Thread, Is.InstanceOf(typeof(InlineCommentThreadViewModel)));
+            Assert.AreEqual(2, target.Thread.Comments.Count);
+            Assert.AreEqual("Existing comment", target.Thread.Comments[0].Body);
+            Assert.AreEqual(string.Empty, target.Thread.Comments[1].Body);
+            Assert.AreEqual(CommentEditState.Placeholder, target.Thread.Comments[1].EditState);
         }
 
-        [Fact]
+        [Test]
         public async Task ThreadIsCreatedForNewComment()
         {
             // There is no existing comment thread at line 9, but there is a + diff entry.
@@ -63,12 +63,12 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             await target.Initialize();
 
-            Assert.IsType<NewInlineCommentThreadViewModel>(target.Thread);
-            Assert.Equal(string.Empty, target.Thread.Comments[0].Body);
-            Assert.Equal(CommentEditState.Editing, target.Thread.Comments[0].EditState);
+            Assert.That(target.Thread, Is.InstanceOf(typeof(NewInlineCommentThreadViewModel)));
+            Assert.AreEqual(string.Empty, target.Thread.Comments[0].Body);
+            Assert.AreEqual(CommentEditState.Editing, target.Thread.Comments[0].EditState);
         }
 
-        [Fact]
+        [Test]
         public async Task SwitchesFromNewThreadToExistingThreadWhenCommentPosted()
         {
             var sessionManager = CreateSessionManager();
@@ -81,7 +81,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 Substitute.For<IPreviousInlineCommentCommand>());
 
             await target.Initialize();
-            Assert.IsType<NewInlineCommentThreadViewModel>(target.Thread);
+            Assert.That(target.Thread, Is.InstanceOf(typeof(NewInlineCommentThreadViewModel)));
 
             target.Thread.Comments[0].Body = "New Comment";
 
@@ -101,10 +101,10 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             await target.Thread.Comments[0].CommitEdit.ExecuteAsyncTask(null);
 
-            Assert.IsType<InlineCommentThreadViewModel>(target.Thread);
+            Assert.That(target.Thread, Is.InstanceOf(typeof(NewInlineCommentThreadViewModel)));
         }
 
-        [Fact]
+        [Test]
         public async Task RefreshesWhenSessionInlineCommentThreadsChanges()
         {
             var sessionManager = CreateSessionManager();
@@ -118,8 +118,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             await target.Initialize();
 
-            Assert.IsType<InlineCommentThreadViewModel>(target.Thread);
-            Assert.Equal(2, target.Thread.Comments.Count);
+            Assert.That(target.Thread, Is.InstanceOf(typeof(NewInlineCommentThreadViewModel)));
+            Assert.AreEqual(2, target.Thread.Comments.Count);
 
             var file = await sessionManager.GetLiveFile(
                 RelativePath,
@@ -127,10 +127,10 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 peekSession.TextView.TextBuffer);
             AddCommentToExistingThread(file);
 
-            Assert.Equal(3, target.Thread.Comments.Count);
+            Assert.AreEqual(3, target.Thread.Comments.Count);
         }
 
-        [Fact]
+        [Test]
         public async Task RetainsCommentBeingEditedWhenSessionRefreshed()
         {
             var sessionManager = CreateSessionManager();
@@ -144,7 +144,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             await target.Initialize();
 
-            Assert.Equal(2, target.Thread.Comments.Count);
+            Assert.AreEqual(2, target.Thread.Comments.Count);
 
             var placeholder = target.Thread.Comments.Last();
             placeholder.BeginEdit.Execute(null);
@@ -157,12 +157,12 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             AddCommentToExistingThread(file);
 
             placeholder = target.Thread.Comments.Last();
-            Assert.Equal(3, target.Thread.Comments.Count);
-            Assert.Equal(CommentEditState.Editing, placeholder.EditState);
-            Assert.Equal("Comment being edited", placeholder.Body);
+            Assert.AreEqual(3, target.Thread.Comments.Count);
+            Assert.AreEqual(CommentEditState.Editing, placeholder.EditState);
+            Assert.AreEqual("Comment being edited", placeholder.Body);
         }
 
-        [Fact]
+        [Test]
         public async Task DoesntRetainSubmittedCommentInPlaceholderAfterPost()
         {
             var sessionManager = CreateSessionManager();
@@ -176,7 +176,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             await target.Initialize();
 
-            Assert.Equal(2, target.Thread.Comments.Count);
+            Assert.AreEqual(2, target.Thread.Comments.Count);
 
             sessionManager.CurrentSession.PostReviewComment(null, 0)
                 .ReturnsForAnyArgs(async x =>
@@ -195,8 +195,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             placeholder.CommitEdit.Execute(null);
 
             placeholder = target.Thread.Comments.Last();
-            Assert.Equal(CommentEditState.Placeholder, placeholder.EditState);
-            Assert.Equal(string.Empty, placeholder.Body);
+            Assert.AreEqual(CommentEditState.Placeholder, placeholder.EditState);
+            Assert.AreEqual(string.Empty, placeholder.Body);
         }
 
         void AddCommentToExistingThread(IPullRequestSessionFile file)

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentThreadViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentThreadViewModelTests.cs
@@ -21,24 +21,24 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 Substitute.For<IPullRequestSession>(),
                 CreateComments("Comment 1", "Comment 2"));
 
-            Assert.AreEqual(3, target.Comments.Count);
-            Assert.AreEqual(
+            Assert.That(3, Is.EqualTo(target.Comments.Count));
+            Assert.That(
                 new[] 
                 {
                     "Comment 1",
                     "Comment 2",
                     string.Empty
-                }, 
-                target.Comments.Select(x => x.Body));
+                },
+                Is.EqualTo(target.Comments.Select(x => x.Body)));
 
-            Assert.AreEqual(
+            Assert.That(
                 new[]
                 {
                     CommentEditState.None,
                     CommentEditState.None,
                     CommentEditState.Placeholder,
                 },
-                target.Comments.Select(x => x.EditState));
+                Is.EqualTo(target.Comments.Select(x => x.EditState)));
         }
 
         [Test]
@@ -48,10 +48,10 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 Substitute.For<IPullRequestSession>(),
                 CreateComments("Comment 1"));
 
-            Assert.False(target.Comments[1].CommitEdit.CanExecute(null));
+            Assert.That(target.Comments[1].CommitEdit.CanExecute(null), Is.False);
 
             target.Comments[1].Body = "Foo";
-            Assert.True(target.Comments[1].CommitEdit.CanExecute(null));
+            Assert.That(target.Comments[1].CommitEdit.CanExecute(null), Is.True);
         }
 
         [Test]

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentThreadViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentThreadViewModelTests.cs
@@ -8,21 +8,21 @@ using GitHub.Models;
 using GitHub.Services;
 using NSubstitute;
 using Octokit;
-using Xunit;
+using NUnit.Framework;
 
 namespace GitHub.InlineReviews.UnitTests.ViewModels
 {
     public class InlineCommentThreadViewModelTests
     {
-        [Fact]
+        [Test]
         public void CreatesComments()
         {
             var target = new InlineCommentThreadViewModel(
                 Substitute.For<IPullRequestSession>(),
                 CreateComments("Comment 1", "Comment 2"));
 
-            Assert.Equal(3, target.Comments.Count);
-            Assert.Equal(
+            Assert.AreEqual(3, target.Comments.Count);
+            Assert.AreEqual(
                 new[] 
                 {
                     "Comment 1",
@@ -31,7 +31,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 }, 
                 target.Comments.Select(x => x.Body));
 
-            Assert.Equal(
+            Assert.AreEqual(
                 new[]
                 {
                     CommentEditState.None,
@@ -41,7 +41,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 target.Comments.Select(x => x.EditState));
         }
 
-        [Fact]
+        [Test]
         public void PlaceholderCommitEnabledWhenCommentHasBody()
         {
             var target = new InlineCommentThreadViewModel(
@@ -54,7 +54,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             Assert.True(target.Comments[1].CommitEdit.CanExecute(null));
         }
 
-        [Fact]
+        [Test]
         public void PostsCommentInReplyToCorrectComment()
         {
             var session = CreateSession();

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/NewInlineCommentThreadViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/NewInlineCommentThreadViewModelTests.cs
@@ -22,7 +22,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 10,
                 false);
 
-            //Assert.Single(target.Comments);
+            Assert.That(target.Comments, Has.One.Items);
             Assert.AreEqual(string.Empty, target.Comments[0].Body);
             Assert.AreEqual(CommentEditState.Editing, target.Comments[0].EditState);
         }

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/NewInlineCommentThreadViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/NewInlineCommentThreadViewModelTests.cs
@@ -7,13 +7,13 @@ using GitHub.Models;
 using GitHub.Services;
 using NSubstitute;
 using Octokit;
-using Xunit;
+using NUnit.Framework;
 
 namespace GitHub.InlineReviews.UnitTests.ViewModels
 {
     public class NewInlineCommentThreadViewModelTests
     {
-        [Fact]
+        [Test]
         public void CreatesReplyPlaceholder()
         {
             var target = new NewInlineCommentThreadViewModel(
@@ -22,12 +22,12 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 10,
                 false);
 
-            Assert.Single(target.Comments);
-            Assert.Equal(string.Empty, target.Comments[0].Body);
-            Assert.Equal(CommentEditState.Editing, target.Comments[0].EditState);
+            /**Assert.Single(target.Comments);**/
+            Assert.AreEqual(string.Empty, target.Comments[0].Body);
+            Assert.AreEqual(CommentEditState.Editing, target.Comments[0].EditState);
         }
 
-        [Fact]
+        [Test]
         public void NeedsPushTracksFileCommitSha()
         {
             var file = CreateFile();
@@ -51,7 +51,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             Assert.True(target.PostComment.CanExecute(false));
         }
 
-        [Fact]
+        [Test]
         public void PlaceholderCommitEnabledWhenCommentHasBodyAndPostCommentIsEnabled()
         {
             var file = CreateFile();
@@ -73,7 +73,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             Assert.True(target.Comments[0].CommitEdit.CanExecute(null));
         }
 
-        [Fact]
+        [Test]
         public void PostsCommentToCorrectAddedLine()
         {
             var session = CreateSession();
@@ -90,7 +90,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 5);
         }
 
-        [Fact]
+        [Test]
         public void AddsCommentToCorrectDeletedLine()
         {
             var session = CreateSession();

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/NewInlineCommentThreadViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/NewInlineCommentThreadViewModelTests.cs
@@ -22,7 +22,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 10,
                 false);
 
-            /**Assert.Single(target.Comments);**/
+            //Assert.Single(target.Comments);
             Assert.AreEqual(string.Empty, target.Comments[0].Body);
             Assert.AreEqual(CommentEditState.Editing, target.Comments[0].EditState);
         }

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/NewInlineCommentThreadViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/NewInlineCommentThreadViewModelTests.cs
@@ -23,8 +23,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 false);
 
             Assert.That(target.Comments, Has.One.Items);
-            Assert.AreEqual(string.Empty, target.Comments[0].Body);
-            Assert.AreEqual(CommentEditState.Editing, target.Comments[0].EditState);
+            Assert.That(string.Empty, Is.EqualTo(target.Comments[0].Body));
+            Assert.That(CommentEditState.Editing, Is.EqualTo(target.Comments[0].EditState));
         }
 
         [Test]
@@ -37,18 +37,18 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 10,
                 false);
 
-            Assert.False(target.NeedsPush);
-            Assert.True(target.PostComment.CanExecute(false));
+            Assert.That(target.NeedsPush, Is.False);
+            Assert.That(target.PostComment.CanExecute(false), Is.True);
 
             file.CommitSha.Returns((string)null);
             RaisePropertyChanged(file, nameof(file.CommitSha));
-            Assert.True(target.NeedsPush);
-            Assert.False(target.PostComment.CanExecute(false));
+            Assert.That(target.NeedsPush, Is.True);
+            Assert.That(target.PostComment.CanExecute(false), Is.False);
 
             file.CommitSha.Returns("COMMIT_SHA");
             RaisePropertyChanged(file, nameof(file.CommitSha));
-            Assert.False(target.NeedsPush);
-            Assert.True(target.PostComment.CanExecute(false));
+            Assert.That(target.NeedsPush, Is.False);
+            Assert.That(target.PostComment.CanExecute(false), Is.True);
         }
 
         [Test]
@@ -63,14 +63,14 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             file.CommitSha.Returns((string)null);
             RaisePropertyChanged(file, nameof(file.CommitSha));
-            Assert.False(target.Comments[0].CommitEdit.CanExecute(null));
+            Assert.That(target.Comments[0].CommitEdit.CanExecute(null), Is.False);
 
             target.Comments[0].Body = "Foo";
-            Assert.False(target.Comments[0].CommitEdit.CanExecute(null));
+            Assert.That(target.Comments[0].CommitEdit.CanExecute(null), Is.False);
 
             file.CommitSha.Returns("COMMIT_SHA");
             RaisePropertyChanged(file, nameof(file.CommitSha));
-            Assert.True(target.Comments[0].CommitEdit.CanExecute(null));
+            Assert.That(target.Comments[0].CommitEdit.CanExecute(null), Is.True);
         }
 
         [Test]

--- a/test/GitHub.InlineReviews.UnitTests/packages.config
+++ b/test/GitHub.InlineReviews.UnitTests/packages.config
@@ -20,13 +20,10 @@
   <package id="System.Security.Cryptography.Encoding" version="4.0.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Primitives" version="4.0.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.1.0" targetFramework="net461" />
-  <package id="xunit" version="2.3.1" targetFramework="net461" />
-  <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
-  <package id="xunit.analyzers" version="0.7.0" targetFramework="net461" />
-  <package id="xunit.assert" version="2.3.1" targetFramework="net461" />
-  <package id="xunit.core" version="2.3.1" targetFramework="net461" />
-  <package id="xunit.extensibility.core" version="2.3.1" targetFramework="net461" />
-  <package id="xunit.extensibility.execution" version="2.3.1" targetFramework="net461" />
-  <package id="xunit.runner.console" version="2.3.1" targetFramework="net461" developmentDependency="true" />
-  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net461" developmentDependency="true" />
+  <package id="NUnit.Extension.AppVeyor.NUnit3ResultWriter" version="0.1" />
+  <package id="NUnit" version="2.6.4" targetFramework="net452" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net461" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
+  <package id="NUnit.Runners" version="2.6.4" targetFramework="net452" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net452" />  
 </packages>

--- a/test/GitHub.InlineReviews.UnitTests/packages.config
+++ b/test/GitHub.InlineReviews.UnitTests/packages.config
@@ -9,6 +9,12 @@
   <package id="Microsoft.VisualStudio.Text.UI" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net461" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net461" />
+  <package id="NUnit" version="3.9.0" targetFramework="net461" />
+  <package id="NUnit.Extension.AppVeyor.NUnit3ResultWriter" version="0.1" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net461" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
+  <package id="NUnit.Runners" version="2.6.4" targetFramework="net452" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net452" />
   <package id="Rx-Core" version="2.2.5-custom" targetFramework="net461" />
   <package id="Rx-Interfaces" version="2.2.5-custom" targetFramework="net461" />
   <package id="Rx-Linq" version="2.2.5-custom" targetFramework="net461" />
@@ -20,10 +26,4 @@
   <package id="System.Security.Cryptography.Encoding" version="4.0.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Primitives" version="4.0.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.1.0" targetFramework="net461" />
-  <package id="NUnit.Extension.AppVeyor.NUnit3ResultWriter" version="0.1" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
-  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net461" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
-  <package id="NUnit.Runners" version="2.6.4" targetFramework="net452" />
-  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net452" />  
 </packages>


### PR DESCRIPTION
This PR:
- Updates all the Inline Reviews unit tests to use nunit instead of xunit.
- Uses the latest version of nunit -> `3.9.0`
- Changes assertions from classic model (`Assert.Equal`) to constraint based model (`Assert.That(result, Is.EqualTo(x))`

  