### PR TITLE
Fix PullRequest TreeView Keyboard navigation

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -294,6 +294,7 @@
                                       Background="Transparent"
                                       BorderThickness="0"
                                       Margin="0 6 0 0"
+                                      KeyUp="FileListKeyUp"
                                       MouseRightButtonDown="FileListMouseRightButtonDown"
                                       MouseDoubleClick="FileListMouseDoubleClick">
                                 <TreeView.ItemContainerStyle>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -312,7 +312,8 @@
                                     </HierarchicalDataTemplate>
                                     <DataTemplate DataType="{x:Type vm:PullRequestFileNode}">
                                         <StackPanel Orientation="Horizontal"
-                                                    Tag="{Binding DataContext, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type ui:SectionControl}}}">
+                                                    Tag="{Binding DataContext, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type ui:SectionControl}}}"
+                                                    KeyboardNavigation.DirectionalNavigation="None">
                                             <ui:OcticonImage Icon="file_code" Margin="0,0,0,2">
                                                 <ui:OcticonImage.Style>
                                                     <Style TargetType="ui:OcticonImage" BasedOn="{StaticResource OcticonImage}">

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml.cs
@@ -202,6 +202,18 @@ namespace GitHub.VisualStudio.Views.GitHubPane
             ns?.ShowMessage(message + ": " + e.Message);
         }
 
+        private void FileListKeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Return)
+            {
+                var file = (e.OriginalSource as FrameworkElement)?.DataContext as IPullRequestFileNode;
+                if (file != null)
+                {
+                    DoDiffFile(file, false).Forget();
+                }
+            }
+        }
+
         void FileListMouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
             var file = (e.OriginalSource as FrameworkElement)?.DataContext as IPullRequestFileNode;


### PR DESCRIPTION
Fixes #1416

- Repair keyboard directional navigation
  - Setting `DirectionalNavigation` to `None` on `TreeViewItem` contents allows standard `TreeView` navigation
- Performing the default operation of `DoDiffFile` on `Enter`
