### PR TITLE
Fix clearing navigation history with >10 pages.

### DIFF
--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/NavigationViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/NavigationViewModelTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -308,6 +310,36 @@ public class NavigationViewModelTests
                 first.Deactivated();
                 first.Dispose();
             });
+        }
+
+        [Test]
+        public void DoesntThrowWhenHistoryHasMoreThan10Items()
+        {
+            var target = new NavigationViewModel();
+            var pages = new List<IPanePageViewModel>();
+
+            for (var i = 0; i < 11; ++i)
+            {
+                var page = CreatePage();
+                pages.Add(page);
+                target.NavigateTo(page);
+            }
+
+            foreach (var page in pages)
+            {
+                page.ClearReceivedCalls();
+            }
+
+            target.Clear();
+
+            pages.Last().Received().Deactivated();
+            pages.Last().Received().Dispose();
+
+            foreach (var page in pages.Take(pages.Count - 1))
+            {
+                page.DidNotReceive().Deactivated();
+                page.Received().Dispose();
+            }
         }
     }
 


### PR DESCRIPTION
#1436 is a bug whereby clearing the GitHub pane navigation history (by moving to a new project) when there are more than 10 items in the history caused an exception.

We need to handle `Reset` collection events on the `Changing` handler so that we can get to the items before they're removed from the collection and `Dispose` them.

Fixes #1436.