### PR TITLE
Ignore inline comment if it contains no diff line context

### DIFF
--- a/src/GitHub.InlineReviews/Models/InlineCommentThreadModel.cs
+++ b/src/GitHub.InlineReviews/Models/InlineCommentThreadModel.cs
@@ -31,6 +31,7 @@ namespace GitHub.InlineReviews.Models
             string originalCommitSha,
             int originalPosition,
             IList<DiffLine> diffMatch,
+            DiffChangeType diffLineType,
             IEnumerable<IPullRequestReviewCommentModel> comments)
         {
             Guard.ArgumentNotNull(relativePath, nameof(relativePath));
@@ -39,6 +40,7 @@ namespace GitHub.InlineReviews.Models
 
             Comments = comments.ToList();
             DiffMatch = diffMatch;
+            DiffLineType = diffLineType;
             OriginalCommitSha = originalCommitSha;
             OriginalPosition = originalPosition;
             RelativePath = relativePath;
@@ -51,7 +53,7 @@ namespace GitHub.InlineReviews.Models
         public IList<DiffLine> DiffMatch { get; }
 
         /// <inheritdoc/>
-        public DiffChangeType DiffLineType => DiffMatch.First().Type;
+        public DiffChangeType DiffLineType { get; }
 
         /// <inheritdoc/>
         public bool IsStale

--- a/src/GitHub.InlineReviews/Models/InlineCommentThreadModel.cs
+++ b/src/GitHub.InlineReviews/Models/InlineCommentThreadModel.cs
@@ -31,7 +31,6 @@ namespace GitHub.InlineReviews.Models
             string originalCommitSha,
             int originalPosition,
             IList<DiffLine> diffMatch,
-            DiffChangeType diffLineType,
             IEnumerable<IPullRequestReviewCommentModel> comments)
         {
             Guard.ArgumentNotNull(relativePath, nameof(relativePath));
@@ -40,7 +39,7 @@ namespace GitHub.InlineReviews.Models
 
             Comments = comments.ToList();
             DiffMatch = diffMatch;
-            DiffLineType = diffLineType;
+            DiffLineType = diffMatch[0].Type;
             OriginalCommitSha = originalCommitSha;
             OriginalPosition = originalPosition;
             RelativePath = relativePath;

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -93,14 +93,13 @@ namespace GitHub.InlineReviews.Services
                 var chunk = chunks.Last();
                 var diffLines = chunk.Lines.Reverse().Take(5).ToList();
                 var firstLine = diffLines.FirstOrDefault();
-                var diffLineType = firstLine != null ? firstLine.Type : DiffChangeType.None;
-
                 if (firstLine == null)
                 {
-                    log.Warning("Couldn't find diff lines for inline comment. RelativePath={RelativePath}, OriginalCommitSha={Sha}, OriginalPosition={Position}, Chunks={Chunks}, DiffHunk={DiffHunk}",
-                        relativePath, comments.Key.Item1, comments.Key.Item2, chunks.Count(), hunk);
+                    log.Warning("Ignoring in-line comment in {RelativePath} with no diff line context", relativePath);
+                    continue;
                 }
 
+                var diffLineType = firstLine.Type;
                 var thread = new InlineCommentThreadModel(
                     relativePath,
                     comments.Key.Item1,

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -99,13 +99,11 @@ namespace GitHub.InlineReviews.Services
                     continue;
                 }
 
-                var diffLineType = firstLine.Type;
                 var thread = new InlineCommentThreadModel(
                     relativePath,
                     comments.Key.Item1,
                     comments.Key.Item2,
                     diffLines,
-                    diffLineType,
                     comments);
                 threads.Add(thread);
             }

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionServiceTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionServiceTests.cs
@@ -54,6 +54,29 @@ Line 4";
             }
 
             [Test]
+            public async Task IgnoreCommentsWithNoDiffLineContext()
+            {
+                var baseContents = "Line 1";
+                var headContents = "Line 1";
+
+                var comment = CreateComment(@"@@ -10,7 +10,6 @@ class Program");
+
+                using (var diffService = new FakeDiffService(FilePath, baseContents))
+                {
+                    var diff = await diffService.Diff(FilePath, headContents);
+                    var pullRequest = CreatePullRequest(FilePath, comment);
+                    var target = CreateTarget(diffService);
+
+                    var result = target.BuildCommentThreads(
+                        pullRequest,
+                        FilePath,
+                        diff);
+
+                    Assert.That(result, Is.Empty);
+                }
+            }
+
+            [Test]
             public async Task MatchesReviewCommentOnDifferentLine()
             {
                 var baseContents = @"Line 1
@@ -212,7 +235,7 @@ Line 4";
 
                     Assert.That(3, Is.EqualTo(threads[0].LineNumber));
                     Assert.That(
-                        new[] 
+                        new[]
                         {
                             Tuple.Create(2, DiffSide.Right),
                             Tuple.Create(3, DiffSide.Right)


### PR DESCRIPTION
It's possible (if unlikely) that an inline comment contains no diff line context. For example, the following comment has no context:

grokys/PullRequestSandbox#24

```
    Body: "comment on main"
    CommitId: "080d67f93efeb557f8bb24a009effb85bde353aa"
    CreatedAt: {01/06/2017 13:55:49 +00:00}
    DiffHunk: "@@ -10,7 +10,6 @@ class Program"
    Id: 119620146
    OriginalCommitId: "b328e39e53c85ea15208a60c7af74698d3e146d2"
    OriginalPosition: 6
    Path: "PullRequestSandbox/Program.cs"
    Position: 0
    User: Account: Login: jcansdale IsUser: True
```

This was caused a comment with a `Position` of `0` (it should be 1 or above). Diff file line numbers are `1` based, so this comment is outside the bounds of the diff. Although this wouldn't normally happen, there is a comment like this in `PullRequestSandbox` that would be hit from time to time when testing.

This PR simply ignores and logs comment like this.

Fixes #1435 