### PR TITLE
Fix cloning after creating a repository.

### DIFF
--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -375,6 +375,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
 
         public void DoCreate()
         {
+            ServiceProvider.GitServiceProvider = TEServiceProvider;
             var dialogService = ServiceProvider.GetService<IDialogService>();
             dialogService.ShowCreateRepositoryDialog(SectionConnection);
         }


### PR DESCRIPTION
`DoCreate` needs to set `ServiceProvider.GitServiceProvider` in order for `IGitRepositoriesExt` to be found to clone the created repository.

Fixes #1446