### PR TITLE
Make sure we always create a valid index if the database has old/invalid json data

### DIFF
--- a/src/GitHub.App/Caches/CacheIndex.cs
+++ b/src/GitHub.App/Caches/CacheIndex.cs
@@ -62,6 +62,7 @@ namespace GitHub.Caches
             Guard.ArgumentNotNull(item, nameof(item));
 
             return cache.GetOrCreateObject(indexKey, () => Create(indexKey))
+                .Select(x => x.IndexKey == null ? Create(indexKey) : x)
                 .Do(index =>
                 {
                     var k = string.Format(CultureInfo.InvariantCulture, "{0}|{1}", index.IndexKey, item.Key);


### PR DESCRIPTION
If the database has json that we're not expecting in index entries, avakache throws a json deserialization exception, but I can't seem to catch it anywhere for some reason, which means it ends up returning a default `CacheIndex` instance with all empty fields, which meeeeans later on we crash trying to save it. So, make sure we always return a valid index.

Fixes #1319