### PR TITLE
Avoid using MEF for IVSUIContextFactory / ILocalRepositoryModelFactory

### DIFF
--- a/src/GitHub.TeamFoundation.14/Services/LocalRepositoryModelFactory.cs
+++ b/src/GitHub.TeamFoundation.14/Services/LocalRepositoryModelFactory.cs
@@ -3,8 +3,6 @@ using GitHub.Models;
 
 namespace GitHub.TeamFoundation.Services
 {
-    [Export(typeof(ILocalRepositoryModelFactory))]
-    [PartCreationPolicy(CreationPolicy.Shared)]
     class LocalRepositoryModelFactory : ILocalRepositoryModelFactory
     {
         public ILocalRepositoryModel Create(string localPath)

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.Composition;
 using GitHub.Models;
 using GitHub.Services;
 using GitHub.Logging;
+using GitHub.TeamFoundation.Services;
 using Serilog;
 using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
 using Task = System.Threading.Tasks.Task;
@@ -28,6 +29,11 @@ namespace GitHub.VisualStudio.Base
         IReadOnlyList<ILocalRepositoryModel> activeRepositories;
 
         [ImportingConstructor]
+        public VSGitExt(IGitHubServiceProvider serviceProvider)
+            : this(serviceProvider, new VSUIContextFactory(), new LocalRepositoryModelFactory())
+        {
+        }
+
         public VSGitExt(IGitHubServiceProvider serviceProvider, IVSUIContextFactory factory, ILocalRepositoryModelFactory repositoryFactory)
         {
             this.serviceProvider = serviceProvider;

--- a/src/GitHub.TeamFoundation.14/Services/VSUIContextFactory.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSUIContextFactory.cs
@@ -6,8 +6,6 @@ using GitHub.Services;
 
 namespace GitHub.TeamFoundation.Services
 {
-    [Export(typeof(IVSUIContextFactory))]
-    [PartCreationPolicy(CreationPolicy.Shared)]
     class VSUIContextFactory : IVSUIContextFactory
     {
         public IVSUIContext GetUIContext(Guid contextGuid)

--- a/src/GitHub.TeamFoundation.15/GitHub.TeamFoundation.15.csproj
+++ b/src/GitHub.TeamFoundation.15/GitHub.TeamFoundation.15.csproj
@@ -167,8 +167,14 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\GitHub.TeamFoundation.14\Services\LocalRepositoryModelFactory.cs">
+      <Link>Services\LocalRepositoryModelFactory.cs</Link>
+    </Compile>
     <Compile Include="..\GitHub.TeamFoundation.14\Services\VSGitExt.cs">
       <Link>Services\VSGitExt.cs</Link>
+    </Compile>
+    <Compile Include="..\GitHub.TeamFoundation.14\Services\VSUIContextFactory.cs">
+      <Link>Services\VSUIContextFactory.cs</Link>
     </Compile>
     <Compile Include="..\GitHub.TeamFoundation.14\Settings.cs">
       <Link>Settings.cs</Link>


### PR DESCRIPTION
This PR will avoid using MEF for `IVSUIContextFactory` and `ILocalRepositoryModelFactory`, ensuring that the following can't happen:

```
----- CompositionError level 1 ------
GitHub.VisualStudio.Base.VSGitExt.ctor(factory): expected exactly 1 export of GitHub.Services.IVSUIContextFactory but found 0.
   part definition GitHub.VisualStudio.Base.VSGitExt

GitHub.VisualStudio.Base.VSGitExt.ctor(repositoryFactory): expected exactly 1 export of GitHub.Models.ILocalRepositoryModelFactory but found 0.
   part definition GitHub.VisualStudio.Base.VSGitExt
```

This treats the symptom rather than the cause. With any luck it will mean users won't have to manually clear their MEF component cache.

We'll need to get the bottom of this issue for future releases when we add or change our MEF service interfaces!

Fixes #1455