### PR TITLE
Fix SimpleApiClient.IsEnterprise().

### DIFF
--- a/src/GitHub.Api/SimpleApiClient.cs
+++ b/src/GitHub.Api/SimpleApiClient.cs
@@ -72,7 +72,7 @@ namespace GitHub.Api
                         if (repo != null)
                         {
                             hasWiki = await HasWikiInternal(repo);
-                            isEnterprise = await IsEnterpriseInternal();
+                            isEnterprise = isEnterprise ?? await IsEnterpriseInternal();
                             repositoryCache = repo;
                         }
                         owner = ownerLogin;
@@ -99,9 +99,14 @@ namespace GitHub.Api
             return hasWiki.HasValue && hasWiki.Value;
         }
 
-        public bool IsEnterprise()
+        public async Task<bool> IsEnterprise()
         {
-            return isEnterprise.HasValue && isEnterprise.Value;
+            if (!isEnterprise.HasValue)
+            {
+                isEnterprise = await IsEnterpriseInternal();
+            }
+
+            return isEnterprise ?? false;
         }
 
         async Task<bool> HasWikiInternal(Repository repo)

--- a/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
@@ -366,7 +366,7 @@ namespace GitHub.ViewModels.GitHubPane
             var repositoryUrl = repository.CloneUrl.ToRepositoryUrl();
             var isDotCom = HostAddress.IsGitHubDotComUri(repositoryUrl);
             var client = await apiClientFactory.Create(repository.CloneUrl);
-            var isEnterprise = isDotCom ? false : client.IsEnterprise();
+            var isEnterprise = isDotCom ? false : await client.IsEnterprise();
 
             if ((isDotCom || isEnterprise) && await IsValidRepository(client))
             {

--- a/src/GitHub.Exports/Api/ISimpleApiClient.cs
+++ b/src/GitHub.Exports/Api/ISimpleApiClient.cs
@@ -11,7 +11,7 @@ namespace GitHub.Api
         UriString OriginalUrl { get; }
         Task<Repository> GetRepository();
         bool HasWiki();
-        bool IsEnterprise();
+        Task<bool> IsEnterprise();
         bool IsAuthenticated();
     }
 }

--- a/src/GitHub.VisualStudio.UI/Base/TeamExplorerItemBase.cs
+++ b/src/GitHub.VisualStudio.UI/Base/TeamExplorerItemBase.cs
@@ -126,7 +126,7 @@ namespace GitHub.VisualStudio.Base
             {
                 var repo = await SimpleApiClient.GetRepository();
 
-                if ((repo.FullName == ActiveRepoName || repo.Id == 0) && SimpleApiClient.IsEnterprise())
+                if ((repo.FullName == ActiveRepoName || repo.Id == 0) && await SimpleApiClient.IsEnterprise())
                 {
                     return RepositoryOrigin.Enterprise;
                 }

--- a/src/GitHub.VisualStudio/Menus/MenuBase.cs
+++ b/src/GitHub.VisualStudio/Menus/MenuBase.cs
@@ -123,7 +123,7 @@ namespace GitHub.VisualStudio
             {
                 var repo = await SimpleApiClient.GetRepository();
                 var activeRepoFullName = ActiveRepo.Owner + '/' + ActiveRepo.Name;
-                return (repo.FullName == activeRepoFullName || repo.Id == 0) && SimpleApiClient.IsEnterprise();
+                return (repo.FullName == activeRepoFullName || repo.Id == 0) && await SimpleApiClient.IsEnterprise();
             }
             return isdotcom;
         }

--- a/test/UnitTests/GitHub.Api/SimpleApiClientTests.cs
+++ b/test/UnitTests/GitHub.Api/SimpleApiClientTests.cs
@@ -132,10 +132,10 @@ public class SimpleApiClientTests
                 new Lazy<IWikiProbe>(() => wikiProbe));
             await client.GetRepository();
 
-            var result = client.IsEnterprise();
+            var result = await client.IsEnterprise();
 
             Assert.That(expected, Is.EqualTo(result));
-            Assert.That(expected, Is.EqualTo(client.IsEnterprise()));
+            Assert.That(expected, Is.EqualTo(await client.IsEnterprise()));
         }
 
         [Test]
@@ -151,7 +151,7 @@ public class SimpleApiClientTests
                 new Lazy<IEnterpriseProbe>(() => enterpriseProbe),
                 new Lazy<IWikiProbe>(() => wikiProbe));
 
-            var result = client.IsEnterprise();
+            var result = client.IsEnterprise().Result;
 
             Assert.False(result);
         }


### PR DESCRIPTION
Previous unless you had called `GetRepository` on a `SimpleApiClient` instance, `IsEnterprise()` simply returned `false` without checking. Make sure we actually perform the check.

Fixes #1473