### PR TITLE
Assume enterprise user/pass login available on older Enterprise versions.

### DIFF
--- a/src/GitHub.App/ViewModels/Dialog/LoginToGitHubForEnterpriseViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/LoginToGitHubForEnterpriseViewModel.cs
@@ -140,22 +140,14 @@ namespace GitHub.ViewModels.Dialog
 
             var enterpriseInstance = false;
             var loginMethods = (EnterpriseLoginMethods?)null;
+            var uri = new UriBuilder(url).Uri;
 
-            try
-            {
-                var uri = new UriBuilder(url).Uri;
-                ProbeStatus = EnterpriseProbeStatus.Checking;
+            ProbeStatus = EnterpriseProbeStatus.Checking;
 
-                if (await enterpriseCapabilities.Probe(uri) == EnterpriseProbeResult.Ok)
-                {
-                    loginMethods = await enterpriseCapabilities.ProbeLoginMethods(uri);
-                    enterpriseInstance = true;
-                }
-            }
-            catch
+            if (await enterpriseCapabilities.Probe(uri) == EnterpriseProbeResult.Ok)
             {
-                ProbeStatus = EnterpriseProbeStatus.Invalid;
-                loginMethods = null;
+                loginMethods = await enterpriseCapabilities.ProbeLoginMethods(uri);
+                enterpriseInstance = true;
             }
 
             if (url == EnterpriseUrl)


### PR DESCRIPTION
If the enterprise server doesn't return a value for `VerifiablePasswordAuthentication`, or the `api/meta` endpoint fails completely then we're on an older version of enterprise. In this case assume username and password login is available as we have no way to tell.

Fixes #1474