### PR TITLE
Moved changed files tree into its own view.

### DIFF
--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Services\PullRequestEditorService.cs" />
     <Compile Include="Services\TeamExplorerContext.cs" />
     <Compile Include="Services\OAuthCallbackListener.cs" />
+    <Compile Include="Services\TextViewCommandDispatcher.cs" />
     <Compile Include="ViewModels\Dialog\GistCreationViewModel.cs" />
     <Compile Include="ViewModels\Dialog\GitHubDialogWindowViewModel.cs" />
     <Compile Include="ViewModels\Dialog\LoginCredentialsViewModel.cs" />

--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -61,8 +61,16 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.ComponentModelHost.14.0.25424\lib\net45\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.CoreUtility.14.3.25407\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Editor, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Editor.14.3.25407\lib\net45\Microsoft.VisualStudio.Editor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6071\lib\Microsoft.VisualStudio.OLE.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -74,20 +82,59 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6071\lib\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6072\lib\net11\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.10.0.10.0.30320\lib\net20\Microsoft.VisualStudio.Shell.Interop.10.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.11.0.11.0.61031\lib\net20\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.12.0.12.0.30111\lib\net20\Microsoft.VisualStudio.Shell.Interop.12.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.8.0.8.0.50728\lib\net11\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.Data.14.3.25407\lib\net45\Microsoft.VisualStudio.Text.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.Logic.14.3.25407\lib\net45\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.UI.14.3.25407\lib\net45\Microsoft.VisualStudio.Text.UI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.UI.Wpf.14.3.25407\lib\net45\Microsoft.VisualStudio.Text.UI.Wpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6071\lib\net11\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50728\lib\net11\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Threading, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.14.1.131\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Utilities, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Utilities.14.3.25407\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -152,6 +199,7 @@
     <Compile Include="Models\IssueCommentModel.cs" />
     <Compile Include="Models\PullRequestReviewCommentModel.cs" />
     <Compile Include="Models\PullRequestDetailArgument.cs" />
+    <Compile Include="SampleData\PullRequestFilesViewModelDesigner.cs" />
     <Compile Include="Services\EnterpriseCapabilitiesService.cs" />
     <Compile Include="Services\GlobalConnection.cs" />
     <Compile Include="Services\PullRequestEditorService.cs" />
@@ -172,6 +220,7 @@
     <Compile Include="ViewModels\GitHubPane\LoggedOutViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\NavigationViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\GitHubPaneViewModel.cs" />
+    <Compile Include="ViewModels\GitHubPane\PullRequestFilesViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\PullRequestListViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\PanePageViewModelBase.cs" />
     <Compile Include="ViewModels\GitHubPane\PullRequestDetailViewModel.cs" />

--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -31,8 +31,6 @@ namespace GitHub.SampleData
     [ExcludeFromCodeCoverage]
     public class PullRequestDetailViewModelDesigner : PanePageViewModelBase, IPullRequestDetailViewModel
     {
-        private List<IPullRequestChangeNode> changedFilesTree;
-
         public PullRequestDetailViewModelDesigner()
         {
             var repoPath = @"C:\Repo";
@@ -69,8 +67,7 @@ This requires that errors be propagated from the viewmodel to the view and from 
             modelsDir.Files.Add(oldBranchModel);
             gitHubDir.Directories.Add(modelsDir);
 
-            changedFilesTree = new List<IPullRequestChangeNode>();
-            changedFilesTree.Add(gitHubDir);
+            Files = new PullRequestFilesViewModelDesigner();
         }
 
         public IPullRequestModel Model { get; }
@@ -84,7 +81,7 @@ This requires that errors be propagated from the viewmodel to the view and from 
         public bool IsCheckedOut { get; }
         public bool IsFromFork { get; }
         public string Body { get; }
-        public IReadOnlyList<IPullRequestChangeNode> ChangedFilesTree => changedFilesTree;
+        public IPullRequestFilesViewModel Files { get; set; }
         public IPullRequestCheckoutState CheckoutState { get; set; }
         public IPullRequestUpdateState UpdateState { get; set; }
         public string OperationError { get; set; }
@@ -94,12 +91,7 @@ This requires that errors be propagated from the viewmodel to the view and from 
         public ReactiveCommand<Unit> Checkout { get; }
         public ReactiveCommand<Unit> Pull { get; }
         public ReactiveCommand<Unit> Push { get; }
-        public ReactiveCommand<Unit> SyncSubmodules { get; }
         public ReactiveCommand<object> OpenOnGitHub { get; }
-        public ReactiveCommand<object> DiffFile { get; }
-        public ReactiveCommand<object> DiffFileWithWorkingDirectory { get; }
-        public ReactiveCommand<object> OpenFileInWorkingDirectory { get; }
-        public ReactiveCommand<object> ViewFile { get; }
 
         public Task InitializeAsync(ILocalRepositoryModel localRepository, IConnection connection, string owner, string repo, int number) => Task.CompletedTask;
 

--- a/src/GitHub.App/SampleData/PullRequestFilesViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestFilesViewModelDesigner.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Threading.Tasks;
+using GitHub.Models;
+using GitHub.Services;
+using GitHub.ViewModels.GitHubPane;
+using ReactiveUI;
+
+namespace GitHub.SampleData
+{
+    public class PullRequestFilesViewModelDesigner : PanePageViewModelBase, IPullRequestFilesViewModel
+    {
+        public PullRequestFilesViewModelDesigner()
+        {
+            Items = new[]
+            {
+                new PullRequestDirectoryNode("src")
+                {
+                    Files =
+                    {
+                        new PullRequestFileNode("x", "src/File1.cs", "x", PullRequestFileStatus.Added, null),
+                        new PullRequestFileNode("x", "src/File2.cs", "x", PullRequestFileStatus.Modified, null),
+                        new PullRequestFileNode("x", "src/File3.cs", "x", PullRequestFileStatus.Removed, null),
+                        new PullRequestFileNode("x", "src/File4.cs", "x", PullRequestFileStatus.Renamed, "src/Old.cs"),
+                    }
+                }
+            };
+            ChangedFilesCount = 4;
+        }
+
+        public int ChangedFilesCount { get; set; }
+        public IReadOnlyList<IPullRequestChangeNode> Items { get; }
+        public ReactiveCommand<Unit> DiffFile { get; }
+        public ReactiveCommand<Unit> ViewFile { get; }
+        public ReactiveCommand<Unit> DiffFileWithWorkingDirectory { get; }
+        public ReactiveCommand<Unit> OpenFileInWorkingDirectory { get; }
+        public ReactiveCommand<Unit> OpenFirstComment { get; }
+
+        public Task InitializeAsync(
+            IPullRequestSession session,
+            Func<IInlineCommentThreadModel, bool> commentFilter = null)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -1,25 +1,195 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using GitHub.Commands;
+using GitHub.Extensions;
+using GitHub.Models;
+using GitHub.VisualStudio;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.TextManager.Interop;
-using GitHub.Models;
+using Task = System.Threading.Tasks.Task;
 
 namespace GitHub.Services
 {
+    /// <summary>
+    /// Services for opening views of pull request files in Visual Studio.
+    /// </summary>
     [Export(typeof(IPullRequestEditorService))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
     public class PullRequestEditorService : IPullRequestEditorService
     {
-        readonly IGitHubServiceProvider serviceProvider;
-
         // If the target line doesn't have a unique match, search this number of lines above looking for a match.
         public const int MatchLinesAboveTarget = 4;
 
+        readonly IGitHubServiceProvider serviceProvider;
+        readonly IPullRequestService pullRequestService;
+        readonly IVsEditorAdaptersFactoryService vsEditorAdaptersFactory;
+        readonly IStatusBarNotificationService statusBar;
+        readonly IUsageTracker usageTracker;
+
         [ImportingConstructor]
-        public PullRequestEditorService(IGitHubServiceProvider serviceProvider)
+        public PullRequestEditorService(
+            IGitHubServiceProvider serviceProvider,
+            IPullRequestService pullRequestService,
+            IVsEditorAdaptersFactoryService vsEditorAdaptersFactory,
+            IStatusBarNotificationService statusBar,
+            IUsageTracker usageTracker)
         {
+            Guard.ArgumentNotNull(serviceProvider, nameof(serviceProvider));
+            Guard.ArgumentNotNull(pullRequestService, nameof(pullRequestService));
+            Guard.ArgumentNotNull(vsEditorAdaptersFactory, nameof(vsEditorAdaptersFactory));
+            Guard.ArgumentNotNull(statusBar, nameof(statusBar));
+            Guard.ArgumentNotNull(usageTracker, nameof(usageTracker));
+
             this.serviceProvider = serviceProvider;
+            this.pullRequestService = pullRequestService;
+            this.vsEditorAdaptersFactory = vsEditorAdaptersFactory;
+            this.statusBar = statusBar;
+            this.usageTracker = usageTracker;
+        }
+
+        /// <inheritdoc/>
+        public async Task OpenFile(
+            IPullRequestSession session,
+            string relativePath,
+            bool workingDirectory)
+        {
+            Guard.ArgumentNotNull(session, nameof(session));
+            Guard.ArgumentNotEmptyString(relativePath, nameof(relativePath));
+
+            try
+            {
+                var file = await session.GetFile(relativePath);
+                var fullPath = GetAbsolutePath(session, file);
+                var fileName = workingDirectory ? fullPath : await ExtractFile(session, file, true);
+
+                using (workingDirectory ? null : OpenInProvisionalTab())
+                {
+                    var window = VisualStudio.Services.Dte.ItemOperations.OpenFile(fileName);
+                    window.Document.ReadOnly = !workingDirectory;
+
+                    var buffer = GetBufferAt(fileName);
+
+                    if (!workingDirectory)
+                    {
+                        AddBufferTag(buffer, session, fullPath, null);
+                    }
+                }
+
+                if (workingDirectory)
+                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsOpenFileInSolution);
+                else
+                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsViewFile);
+            }
+            catch (Exception e)
+            {
+                ShowErrorInStatusBar("Error opening file", e);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task OpenDiff(
+            IPullRequestSession session,
+            string relativePath,
+            bool workingDirectory)
+        {
+            Guard.ArgumentNotNull(session, nameof(session));
+            Guard.ArgumentNotEmptyString(relativePath, nameof(relativePath));
+
+            try
+            {
+                var file = await session.GetFile(relativePath);
+                var rightPath = file.RelativePath;
+                var leftPath = await GetBaseFileName(session, file);
+                var rightFile = workingDirectory ? GetAbsolutePath(session, file) : await ExtractFile(session, file, true);
+                var leftFile = await ExtractFile(session, file, false);
+                var leftLabel = $"{leftPath};{session.GetBaseBranchDisplay()}";
+                var rightLabel = workingDirectory ? rightPath : $"{rightPath};PR {session.PullRequest.Number}";
+                var caption = $"Diff - {Path.GetFileName(file.RelativePath)}";
+                var options = __VSDIFFSERVICEOPTIONS.VSDIFFOPT_DetectBinaryFiles |
+                    __VSDIFFSERVICEOPTIONS.VSDIFFOPT_LeftFileIsTemporary;
+
+                if (!workingDirectory)
+                {
+                    options |= __VSDIFFSERVICEOPTIONS.VSDIFFOPT_RightFileIsTemporary;
+                }
+
+                IVsWindowFrame frame;
+                using (OpenInProvisionalTab())
+                {
+                    var tooltip = $"{leftLabel}\nvs.\n{rightLabel}";
+
+                    // Diff window will open in provisional (right hand) tab until document is touched.
+                    frame = VisualStudio.Services.DifferenceService.OpenComparisonWindow2(
+                        leftFile,
+                        rightFile,
+                        caption,
+                        tooltip,
+                        leftLabel,
+                        rightLabel,
+                        string.Empty,
+                        string.Empty,
+                        (uint)options);
+                }
+
+                object docView;
+                frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out docView);
+                var diffViewer = ((IVsDifferenceCodeWindow)docView).DifferenceViewer;
+
+                AddBufferTag(diffViewer.LeftView.TextBuffer, session, leftPath, DiffSide.Left);
+
+                if (!workingDirectory)
+                {
+                    AddBufferTag(diffViewer.RightView.TextBuffer, session, rightPath, DiffSide.Right);
+                }
+
+                if (workingDirectory)
+                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsCompareWithSolution);
+                else
+                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsViewChanges);
+            }
+            catch (Exception e)
+            {
+                ShowErrorInStatusBar("Error opening file", e);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task OpenDiff(
+            IPullRequestSession session,
+            string relativePath,
+            IInlineCommentThreadModel thread)
+        {
+            Guard.ArgumentNotNull(session, nameof(session));
+            Guard.ArgumentNotEmptyString(relativePath, nameof(relativePath));
+            Guard.ArgumentNotNull(thread, nameof(thread));
+
+            await OpenDiff(session, relativePath, false);
+
+            // HACK: We need to wait here for the diff view to set itself up and move its cursor
+            // to the first changed line. There must be a better way of doing this.
+            await Task.Delay(1500);
+
+            var param = (object)new InlineCommentNavigationParams
+            {
+                FromLine = thread.LineNumber - 1,
+            };
+
+            VisualStudio.Services.Dte.Commands.Raise(
+                Guids.CommandSetString,
+                PkgCmdIDList.NextInlineCommentId,
+                ref param,
+                null);
         }
 
         public IVsTextView NavigateToEquivalentPosition(IVsTextView sourceView, string targetFile)
@@ -178,6 +348,92 @@ namespace GitHub.Services
             IVsTextView view;
             VsShellUtilities.OpenDocument(serviceProvider, fullPath, logicalView, out hierarchy, out itemID, out windowFrame, out view);
             return view;
+        }
+
+        void ShowErrorInStatusBar(string message, Exception e)
+        {
+            statusBar.ShowMessage(message + ": " + e.Message);
+        }
+
+        void AddBufferTag(ITextBuffer buffer, IPullRequestSession session, string path, DiffSide? side)
+        {
+            buffer.Properties.GetOrCreateSingletonProperty(
+                typeof(PullRequestTextBufferInfo),
+                () => new PullRequestTextBufferInfo(session, path, side));
+
+            var projection = buffer as IProjectionBuffer;
+
+            if (projection != null)
+            {
+                foreach (var source in projection.SourceBuffers)
+                {
+                    AddBufferTag(source, session, path, side);
+                }
+            }
+        }
+
+        async Task<string> ExtractFile(IPullRequestSession session, IPullRequestSessionFile file, bool head)
+        {
+            var encoding = pullRequestService.GetEncoding(session.LocalRepository, file.RelativePath);
+            var relativePath = head ? file.RelativePath : await GetBaseFileName(session, file);
+
+            return await pullRequestService.ExtractFile(
+                session.LocalRepository,
+                session.PullRequest,
+                relativePath,
+                head,
+                encoding).ToTask();
+        }
+
+        ITextBuffer GetBufferAt(string filePath)
+        {
+            IVsUIHierarchy uiHierarchy;
+            uint itemID;
+            IVsWindowFrame windowFrame;
+
+            if (VsShellUtilities.IsDocumentOpen(
+                    serviceProvider,
+                    filePath,
+                    Guid.Empty,
+                    out uiHierarchy,
+                    out itemID,
+                    out windowFrame))
+            {
+                IVsTextView view = VsShellUtilities.GetTextView(windowFrame);
+                IVsTextLines lines;
+                if (view.GetBuffer(out lines) == 0)
+                {
+                    var buffer = lines as IVsTextBuffer;
+                    if (buffer != null)
+                        return vsEditorAdaptersFactory.GetDataBuffer(buffer);
+                }
+            }
+
+            return null;
+        }
+
+        async Task<string> GetBaseFileName(IPullRequestSession session, IPullRequestSessionFile file)
+        {
+            using (var changes = await pullRequestService.GetTreeChanges(
+                session.LocalRepository,
+                session.PullRequest))
+            {
+                var fileChange = changes.FirstOrDefault(x => x.Path == file.RelativePath);
+                return fileChange?.Status == LibGit2Sharp.ChangeKind.Renamed ?
+                    fileChange.OldPath : file.RelativePath;
+            }
+        }
+
+        static string GetAbsolutePath(IPullRequestSession session, IPullRequestSessionFile file)
+        {
+            return Path.Combine(session.LocalRepository.LocalPath, file.RelativePath);
+        }
+
+        static IDisposable OpenInProvisionalTab()
+        {
+            return new NewDocumentStateScope(
+                __VSNEWDOCUMENTSTATE.NDS_Provisional,
+                VSConstants.NewDocumentStateReason.SolutionExplorer);
         }
 
         static IList<string> ReadLines(string text)

--- a/src/GitHub.App/Services/TextViewCommandDispatcher.cs
+++ b/src/GitHub.App/Services/TextViewCommandDispatcher.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 
-namespace GitHub.VisualStudio.Views.GitHubPane
+namespace GitHub.Services
 {
     /// <summary>
     /// Intercepts all commands sent to a <see cref="IVsTextView"/> and fires <see href="Exec"/> when a specified command is encountered.

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
@@ -42,7 +42,6 @@ namespace GitHub.ViewModels.GitHubPane
         string targetBranchDisplayName;
         int commentCount;
         string body;
-        IReadOnlyList<IPullRequestChangeNode> changedFilesTree;
         IPullRequestCheckoutState checkoutState;
         IPullRequestUpdateState updateState;
         string operationError;
@@ -69,7 +68,8 @@ namespace GitHub.ViewModels.GitHubPane
             IModelServiceFactory modelServiceFactory,
             IUsageTracker usageTracker,
             ITeamExplorerContext teamExplorerContext,
-            IStatusBarNotificationService statusBarNotificationService)
+            IStatusBarNotificationService statusBarNotificationService,
+            IPullRequestFilesViewModel files)
         {
             Guard.ArgumentNotNull(pullRequestsService, nameof(pullRequestsService));
             Guard.ArgumentNotNull(sessionManager, nameof(sessionManager));
@@ -84,6 +84,7 @@ namespace GitHub.ViewModels.GitHubPane
             this.usageTracker = usageTracker;
             this.teamExplorerContext = teamExplorerContext;
             this.statusBarNotificationService = statusBarNotificationService;
+            Files = files;
 
             Checkout = ReactiveCommand.CreateAsyncObservable(
                 this.WhenAnyValue(x => x.CheckoutState)
@@ -116,10 +117,6 @@ namespace GitHub.ViewModels.GitHubPane
             SubscribeOperationError(SyncSubmodules);
 
             OpenOnGitHub = ReactiveCommand.Create();
-            DiffFile = ReactiveCommand.Create();
-            DiffFileWithWorkingDirectory = ReactiveCommand.Create(this.WhenAnyValue(x => x.IsCheckedOut));
-            OpenFileInWorkingDirectory = ReactiveCommand.Create(this.WhenAnyValue(x => x.IsCheckedOut));
-            ViewFile = ReactiveCommand.Create();
         }
 
         /// <summary>
@@ -248,13 +245,9 @@ namespace GitHub.ViewModels.GitHubPane
         }
 
         /// <summary>
-        /// Gets the changed files as a tree.
+        /// Gets the pull request's changed files.
         /// </summary>
-        public IReadOnlyList<IPullRequestChangeNode> ChangedFilesTree
-        {
-            get { return changedFilesTree; }
-            private set { this.RaiseAndSetIfChanged(ref changedFilesTree, value); }
-        }
+        public IPullRequestFilesViewModel Files { get; }
 
         /// <summary>
         /// Gets the web URL for the pull request.
@@ -289,27 +282,6 @@ namespace GitHub.ViewModels.GitHubPane
         /// Gets a command that opens the pull request on GitHub.
         /// </summary>
         public ReactiveCommand<object> OpenOnGitHub { get; }
-
-        /// <summary>
-        /// Gets a command that diffs an <see cref="IPullRequestFileNode"/> between BASE and HEAD.
-        /// </summary>
-        public ReactiveCommand<object> DiffFile { get; }
-
-        /// <summary>
-        /// Gets a command that diffs an <see cref="IPullRequestFileNode"/> between the version in
-        /// the working directory and HEAD.
-        /// </summary>
-        public ReactiveCommand<object> DiffFileWithWorkingDirectory { get; }
-
-        /// <summary>
-        /// Gets a command that opens an <see cref="IPullRequestFileNode"/> from disk.
-        /// </summary>
-        public ReactiveCommand<object> OpenFileInWorkingDirectory { get; }
-
-        /// <summary>
-        /// Gets a command that opens an <see cref="IPullRequestFileNode"/> as it appears in the PR.
-        /// </summary>
-        public ReactiveCommand<object> ViewFile { get; }
 
         /// <summary>
         /// Initializes the view model.
@@ -381,9 +353,7 @@ namespace GitHub.ViewModels.GitHubPane
                 TargetBranchDisplayName = GetBranchDisplayName(IsFromFork, pullRequest.Base?.Label);
                 CommentCount = pullRequest.Comments.Count + pullRequest.ReviewComments.Count;
                 Body = !string.IsNullOrWhiteSpace(pullRequest.Body) ? pullRequest.Body : Resources.NoDescriptionProvidedMarkdown;
-
-                var changes = await pullRequestsService.GetTreeChanges(LocalRepository, pullRequest);
-                ChangedFilesTree = (await CreateChangedFilesTree(pullRequest, changes)).Children.ToList();
+                await Files.InitializeAsync(Session);
 
                 var localBranches = await pullRequestsService.GetLocalBranches(LocalRepository, pullRequest).ToList();
 
@@ -507,15 +477,15 @@ namespace GitHub.ViewModels.GitHubPane
         /// <returns>The path to a temporary file.</returns>
         public Task<string> ExtractFile(IPullRequestFileNode file, bool head)
         {
-            var relativePath = Path.Combine(file.DirectoryPath, file.FileName);
-            var encoding = pullRequestsService.GetEncoding(LocalRepository, relativePath);
+            var path = file.RelativePath;
+            var encoding = pullRequestsService.GetEncoding(LocalRepository, path);
 
             if (!head && file.OldPath != null)
             {
-                relativePath = file.OldPath;
+                path = file.OldPath;
             }
 
-            return pullRequestsService.ExtractFile(LocalRepository, model, relativePath, head, encoding).ToTask();
+            return pullRequestsService.ExtractFile(LocalRepository, model, path, head, encoding).ToTask();
         }
 
         /// <summary>
@@ -525,7 +495,7 @@ namespace GitHub.ViewModels.GitHubPane
         /// <returns>The full path to the file in the working directory.</returns>
         public string GetLocalFilePath(IPullRequestFileNode file)
         {
-            return Path.Combine(LocalRepository.LocalPath, file.DirectoryPath, file.FileName);
+            return Path.Combine(LocalRepository.LocalPath, file.RelativePath);
         }
 
         /// <inheritdoc/>
@@ -560,54 +530,6 @@ namespace GitHub.ViewModels.GitHubPane
             command.IsExecuting.Select(x => x).Subscribe(x => OperationError = null);
         }
 
-        async Task<IPullRequestDirectoryNode> CreateChangedFilesTree(IPullRequestModel pullRequest, TreeChanges changes)
-        {
-            var dirs = new Dictionary<string, PullRequestDirectoryNode>
-            {
-                { string.Empty, new PullRequestDirectoryNode(string.Empty) }
-            };
-
-            foreach (var changedFile in pullRequest.ChangedFiles)
-            {
-                var node = new PullRequestFileNode(
-                    LocalRepository.LocalPath,
-                    changedFile.FileName,
-                    changedFile.Sha,
-                    changedFile.Status,
-                    GetOldFileName(changedFile, changes));
-
-                var file = await Session.GetFile(changedFile.FileName);
-                var fileCommentCount = file?.WhenAnyValue(x => x.InlineCommentThreads)
-                    .Subscribe(x => node.CommentCount = x.Count(y => y.LineNumber != -1));
-
-                var dir = GetDirectory(node.DirectoryPath, dirs);
-                dir.Files.Add(node);
-            }
-
-            return dirs[string.Empty];
-        }
-
-        static PullRequestDirectoryNode GetDirectory(string path, Dictionary<string, PullRequestDirectoryNode> dirs)
-        {
-            PullRequestDirectoryNode dir;
-
-            if (!dirs.TryGetValue(path, out dir))
-            {
-                var parentPath = Path.GetDirectoryName(path);
-                var parentDir = GetDirectory(parentPath, dirs);
-
-                dir = new PullRequestDirectoryNode(path);
-
-                if (!parentDir.Directories.Any(x => x.DirectoryName == dir.DirectoryName))
-                {
-                    parentDir.Directories.Add(dir);
-                    dirs.Add(path, dir);
-                }
-            }
-
-            return dir;
-        }
-
         static string GetBranchDisplayName(bool isFromFork, string targetBranchLabel)
         {
             if (targetBranchLabel != null)
@@ -618,17 +540,6 @@ namespace GitHub.ViewModels.GitHubPane
             {
                 return Resources.InvalidBranchName;
             }
-        }
-
-        string GetOldFileName(IPullRequestFileModel file, TreeChanges changes)
-        {
-            if (file.Status == PullRequestFileStatus.Renamed)
-            {
-                var fileName = file.FileName.Replace("/", "\\");
-                return changes?.Renamed.FirstOrDefault(x => x.Path == fileName)?.OldPath;
-            }
-
-            return null;
         }
 
         IObservable<Unit> DoCheckout(object unused)

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDirectoryNode.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDirectoryNode.cs
@@ -13,10 +13,10 @@ namespace GitHub.ViewModels.GitHubPane
         /// Initializes a new instance of the <see cref="PullRequestDirectoryNode"/> class.
         /// </summary>
         /// <param name="path">The path to the directory, relative to the repository.</param>
-        public PullRequestDirectoryNode(string fullPath)
+        public PullRequestDirectoryNode(string relativePath)
         {
-            DirectoryName = System.IO.Path.GetFileName(fullPath);
-            DirectoryPath = fullPath;
+            DirectoryName = System.IO.Path.GetFileName(relativePath);
+            RelativePath = relativePath.Replace("/", "\\");
             Directories = new List<IPullRequestDirectoryNode>();
             Files = new List<IPullRequestFileNode>();
         }
@@ -27,9 +27,9 @@ namespace GitHub.ViewModels.GitHubPane
         public string DirectoryName { get; }
 
         /// <summary>
-        /// Gets the full directory path, relative to the root of the repository.
+        /// Gets the path to the directory, relative to the root of the repository.
         /// </summary>
-        public string DirectoryPath { get; }
+        public string RelativePath { get; }
 
         /// <summary>
         /// Gets the directory children of the node.

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestFileNode.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestFileNode.cs
@@ -18,7 +18,7 @@ namespace GitHub.ViewModels.GitHubPane
         /// Initializes a new instance of the <see cref="PullRequestFileNode"/> class.
         /// </summary>
         /// <param name="repositoryPath">The absolute path to the repository.</param>
-        /// <param name="path">The path to the file, relative to the repository.</param>
+        /// <param name="relativePath">The path to the file, relative to the repository.</param>
         /// <param name="sha">The SHA of the file.</param>
         /// <param name="status">The way the file was changed.</param>
         /// <param name="statusDisplay">The string to display in the [message] box next to the filename.</param>
@@ -28,17 +28,17 @@ namespace GitHub.ViewModels.GitHubPane
         /// </param>
         public PullRequestFileNode(
             string repositoryPath,
-            string path,
+            string relativePath,
             string sha,
             PullRequestFileStatus status,
             string oldPath)
         {
             Guard.ArgumentNotEmptyString(repositoryPath, nameof(repositoryPath));
-            Guard.ArgumentNotEmptyString(path, nameof(path));
+            Guard.ArgumentNotEmptyString(relativePath, nameof(relativePath));
             Guard.ArgumentNotEmptyString(sha, nameof(sha));
 
-            FileName = Path.GetFileName(path);
-            DirectoryPath = Path.GetDirectoryName(path);
+            FileName = Path.GetFileName(relativePath);
+            RelativePath = relativePath.Replace("/", "\\");
             Sha = sha;
             Status = status;
             OldPath = oldPath;
@@ -51,7 +51,7 @@ namespace GitHub.ViewModels.GitHubPane
             {
                 if (oldPath != null)
                 {
-                    StatusDisplay = Path.GetDirectoryName(oldPath) == Path.GetDirectoryName(path) ?
+                    StatusDisplay = Path.GetDirectoryName(oldPath) == Path.GetDirectoryName(relativePath) ?
                             Path.GetFileName(oldPath) : oldPath;
                 }
                 else
@@ -67,9 +67,9 @@ namespace GitHub.ViewModels.GitHubPane
         public string FileName { get; }
 
         /// <summary>
-        /// Gets the path to the file's directory, relative to the root of the repository.
+        /// Gets the path to the file, relative to the root of the repository.
         /// </summary>
-        public string DirectoryPath { get; }
+        public string RelativePath { get; }
 
         /// <summary>
         /// Gets the old path of a moved/renamed file, relative to the root of the repository.

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModel.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using GitHub.Extensions;
+using GitHub.Models;
+using GitHub.Services;
+using LibGit2Sharp;
+using ReactiveUI;
+using Task = System.Threading.Tasks.Task;
+
+namespace GitHub.ViewModels.GitHubPane
+{
+    /// <summary>
+    /// View model displaying a tree of changed files in a pull request.
+    /// </summary>
+    [Export(typeof(IPullRequestFilesViewModel))]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public sealed class PullRequestFilesViewModel : ViewModelBase, IPullRequestFilesViewModel
+    {
+        readonly IPullRequestService service;
+        readonly BehaviorSubject<bool> isBranchCheckedOut = new BehaviorSubject<bool>(false);
+
+        IPullRequestSession pullRequestSession;
+        Func<IInlineCommentThreadModel, bool> commentFilter;
+        int changedFilesCount;
+        IReadOnlyList<IPullRequestChangeNode> items;
+        CompositeDisposable subscriptions;
+
+        [ImportingConstructor]
+        public PullRequestFilesViewModel(
+            IPullRequestService service,
+            IPullRequestEditorService editorService)
+        {
+            Guard.ArgumentNotNull(service, nameof(service));
+            Guard.ArgumentNotNull(editorService, nameof(editorService));
+
+            this.service = service;
+
+            DiffFile = ReactiveCommand.CreateAsyncTask(x =>
+                editorService.OpenDiff(pullRequestSession, ((IPullRequestFileNode)x).RelativePath, false));
+            ViewFile = ReactiveCommand.CreateAsyncTask(x =>
+                editorService.OpenFile(pullRequestSession, ((IPullRequestFileNode)x).RelativePath, false));
+            DiffFileWithWorkingDirectory = ReactiveCommand.CreateAsyncTask(
+                isBranchCheckedOut,
+                x => editorService.OpenDiff(pullRequestSession, ((IPullRequestFileNode)x).RelativePath, true));
+            OpenFileInWorkingDirectory = ReactiveCommand.CreateAsyncTask(
+                isBranchCheckedOut,
+                x => editorService.OpenFile(pullRequestSession, ((IPullRequestFileNode)x).RelativePath, true));
+
+            OpenFirstComment = ReactiveCommand.CreateAsyncTask(async x =>
+            {
+                var file = (IPullRequestFileNode)x;
+                var thread = await GetFirstCommentThread(file);
+
+                if (thread != null)
+                {
+                    await editorService.OpenDiff(pullRequestSession, file.RelativePath, thread);
+                }
+            });
+        }
+
+        /// <inheritdoc/>
+        public int ChangedFilesCount
+        {
+            get { return changedFilesCount; }
+            private set { this.RaiseAndSetIfChanged(ref changedFilesCount, value); }
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyList<IPullRequestChangeNode> Items
+        {
+            get { return items; }
+            private set { this.RaiseAndSetIfChanged(ref items, value); }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            subscriptions?.Dispose();
+            subscriptions = null;
+        }
+
+        /// <inheritdoc/>
+        public async Task InitializeAsync(
+            IPullRequestSession session,
+            Func<IInlineCommentThreadModel, bool> filter = null)
+        {
+            Guard.ArgumentNotNull(session, nameof(session));
+
+            subscriptions?.Dispose();
+            this.pullRequestSession = session;
+            this.commentFilter = filter;
+            subscriptions = new CompositeDisposable();
+            subscriptions.Add(session.WhenAnyValue(x => x.IsCheckedOut).Subscribe(isBranchCheckedOut));
+
+            var dirs = new Dictionary<string, PullRequestDirectoryNode>
+            {
+                { string.Empty, new PullRequestDirectoryNode(string.Empty) }
+            };
+
+            using (var changes = await service.GetTreeChanges(session.LocalRepository, session.PullRequest))
+            {
+                foreach (var changedFile in session.PullRequest.ChangedFiles)
+                {
+                    var node = new PullRequestFileNode(
+                        session.LocalRepository.LocalPath,
+                        changedFile.FileName,
+                        changedFile.Sha,
+                        changedFile.Status,
+                        GetOldFileName(changedFile, changes));
+                    var file = await session.GetFile(changedFile.FileName);
+
+                    if (file != null)
+                    {
+                        subscriptions.Add(file.WhenAnyValue(x => x.InlineCommentThreads)
+                            .Subscribe(x => node.CommentCount = CountComments(x, filter)));
+                    }
+
+                    var dir = GetDirectory(Path.GetDirectoryName(node.RelativePath), dirs);
+                    dir.Files.Add(node);
+                }
+            }
+
+            ChangedFilesCount = session.PullRequest.ChangedFiles.Count;
+            Items = dirs[string.Empty].Children.ToList();
+        }
+
+        /// <inheritdoc/>
+        public ReactiveCommand<Unit> DiffFile { get; }
+
+        /// <inheritdoc/>
+        public ReactiveCommand<Unit> ViewFile { get; }
+
+        /// <inheritdoc/>
+        public ReactiveCommand<Unit> DiffFileWithWorkingDirectory { get; }
+
+        /// <inheritdoc/>
+        public ReactiveCommand<Unit> OpenFileInWorkingDirectory { get; }
+
+        /// <inheritdoc/>
+        public ReactiveCommand<Unit> OpenFirstComment { get; }
+
+        static int CountComments(
+            IEnumerable<IInlineCommentThreadModel> thread,
+            Func<IInlineCommentThreadModel, bool> commentFilter)
+        {
+            return thread.Count(x => x.LineNumber != -1 && (commentFilter?.Invoke(x) ?? true));
+        }
+
+        static PullRequestDirectoryNode GetDirectory(string path, Dictionary<string, PullRequestDirectoryNode> dirs)
+        {
+            PullRequestDirectoryNode dir;
+
+            if (!dirs.TryGetValue(path, out dir))
+            {
+                var parentPath = Path.GetDirectoryName(path);
+                var parentDir = GetDirectory(parentPath, dirs);
+
+                dir = new PullRequestDirectoryNode(path);
+
+                if (!parentDir.Directories.Any(x => x.DirectoryName == dir.DirectoryName))
+                {
+                    parentDir.Directories.Add(dir);
+                    dirs.Add(path, dir);
+                }
+            }
+
+            return dir;
+        }
+
+        static string GetOldFileName(IPullRequestFileModel file, TreeChanges changes)
+        {
+            if (file.Status == PullRequestFileStatus.Renamed)
+            {
+                var fileName = file.FileName.Replace("/", "\\");
+                return changes?.Renamed.FirstOrDefault(x => x.Path == fileName)?.OldPath;
+            }
+
+            return null;
+        }
+
+        async Task<IInlineCommentThreadModel> GetFirstCommentThread(IPullRequestFileNode file)
+        {
+            var sessionFile = await pullRequestSession.GetFile(file.RelativePath);
+            var threads = sessionFile.InlineCommentThreads.AsEnumerable();
+
+            if (commentFilter != null)
+            {
+                threads = threads.Where(commentFilter);
+            }
+
+            return threads.FirstOrDefault();
+        }
+    }
+}

--- a/src/GitHub.App/packages.config
+++ b/src/GitHub.App/packages.config
@@ -3,12 +3,23 @@
   <package id="LibGit2Sharp" version="0.23.1" targetFramework="net461" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.164" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.ComponentModelHost" version="14.0.25424" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="14.3.25407" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Editor" version="14.3.25407" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6071" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.10.0" version="10.0.30319" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6072" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30320" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61031" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.12.0" version="12.0.30111" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50728" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Text.Data" version="14.3.25407" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Text.Logic" version="14.3.25407" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Text.UI" version="14.3.25407" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="14.3.25407" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6071" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50728" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Utilities" version="14.3.25407" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Rothko" version="0.0.3-ghfvs" targetFramework="net461" />
   <package id="Rx-Core" version="2.2.5-custom" targetFramework="net45" />

--- a/src/GitHub.Exports.Reactive/GitHub.Exports.Reactive.csproj
+++ b/src/GitHub.Exports.Reactive/GitHub.Exports.Reactive.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Services\IShowDialogService.cs" />
     <Compile Include="Services\LocalRepositoriesExtensions.cs" />
     <Compile Include="Services\ModelServiceExtensions.cs" />
+    <Compile Include="Services\PullRequestSessionExtensions.cs" />
     <Compile Include="ViewModels\Dialog\IDialogContentViewModel.cs" />
     <Compile Include="ViewModels\Dialog\IGitHubDialogWindowViewModel.cs" />
     <Compile Include="ViewModels\Dialog\IGistCreationViewModel.cs" />
@@ -194,6 +195,7 @@
     <Compile Include="ViewModels\GitHubPane\ILoggedOutViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\INavigationViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\IPanePageViewModel.cs" />
+    <Compile Include="ViewModels\GitHubPane\IPullRequestFilesViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\IPullRequestListViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\ISearchablePageViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\IPullRequestCreationViewModel.cs" />

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestEditorService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestEditorService.cs
@@ -1,9 +1,48 @@
-﻿using Microsoft.VisualStudio.TextManager.Interop;
+﻿using System.Threading.Tasks;
+using GitHub.Models;
+using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace GitHub.Services
 {
+    /// <summary>
+    /// Services for opening views of pull request files in Visual Studio.
+    /// </summary>
     public interface IPullRequestEditorService
     {
+        /// <summary>
+        /// Opens an editor for a file in a pull request.
+        /// </summary>
+        /// <param name="session">The pull request session.</param>
+        /// <param name="relativePath">The path to the file, relative to the repository.</param>
+        /// <param name="workingDirectory">
+        /// If true opens the file in the working directory, if false opens the file in the HEAD
+        /// commit of the pull request.
+        /// </param>
+        /// <returns>A task tracking the operation.</returns>
+        Task OpenFile(IPullRequestSession session, string relativePath, bool workingDirectory);
+
+        /// <summary>
+        /// Opens an diff viewer for a file in a pull request.
+        /// </summary>
+        /// <param name="session">The pull request session.</param>
+        /// <param name="relativePath">The path to the file, relative to the repository.</param>
+        /// <param name="workingDirectory">
+        /// If true the right hand side of the diff will be the current state of the file in the
+        /// working directory, if false it will be the HEAD commit of the pull request.
+        /// </param>
+        /// <returns>A task tracking the operation.</returns>
+        Task OpenDiff(IPullRequestSession session, string relativePath, bool workingDirectory);
+
+        /// <summary>
+        /// Opens an diff viewer for a file in a pull request with the specified inline comment
+        /// thread open.
+        /// </summary>
+        /// <param name="session">The pull request session.</param>
+        /// <param name="relativePath">The path to the file, relative to the repository.</param>
+        /// <param name="thread">The thread to open</param>
+        /// <returns>A task tracking the operation.</returns>
+        Task OpenDiff(IPullRequestSession session, string relativePath, IInlineCommentThreadModel thread);
+
         /// <summary>
         /// Find the active text view.
         /// </summary>

--- a/src/GitHub.Exports.Reactive/Services/PullRequestSessionExtensions.cs
+++ b/src/GitHub.Exports.Reactive/Services/PullRequestSessionExtensions.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Linq;
+using GitHub.Extensions;
+
+namespace GitHub.Services
+{
+    /// <summary>
+    /// Extension methods for <see cref="IPullRequestSession"/>.
+    /// </summary>
+    public static class PullRequestSessionExtensions
+    {
+        /// <summary>
+        /// Gets the head (source) branch label for a pull request, stripping the owner if the pull
+        /// request is not from a fork.
+        /// </summary>
+        /// <param name="session">The pull request session.</param>
+        /// <returns>The head branch label</returns>
+        public static string GetHeadBranchDisplay(this IPullRequestSession session)
+        {
+            Guard.ArgumentNotNull(session, nameof(session));
+            return GetBranchDisplay(session.IsPullRequestFromFork(), session.PullRequest?.Head?.Label);
+        }
+
+        /// <summary>
+        /// Gets the head (target) branch label for a pull request, stripping the owner if the pull
+        /// request is not from a fork.
+        /// </summary>
+        /// <param name="session">The pull request session.</param>
+        /// <returns>The head branch label</returns>
+        public static string GetBaseBranchDisplay(this IPullRequestSession session)
+        {
+            Guard.ArgumentNotNull(session, nameof(session));
+            return GetBranchDisplay(session.IsPullRequestFromFork(), session.PullRequest?.Base?.Label);
+        }
+
+        /// <summary>
+        /// Returns a value that determines whether the pull request comes from a fork.
+        /// </summary>
+        /// <param name="session">The pull request session.</param>
+        /// <returns>True if the pull request is from a fork, otherwise false.</returns>
+        public static bool IsPullRequestFromFork(this IPullRequestSession session)
+        {
+            Guard.ArgumentNotNull(session, nameof(session));
+
+            var headUrl = session.PullRequest.Head.RepositoryCloneUrl?.ToRepositoryUrl();
+            var localUrl = session.LocalRepository.CloneUrl?.ToRepositoryUrl();
+            return headUrl != null && localUrl != null ? headUrl != localUrl : false;
+        }
+
+        static string GetBranchDisplay(bool fork, string label)
+        {
+            if (label != null)
+            {
+                return fork ? label : label.Split(':').Last();
+            }
+
+            return "[invalid]";
+        }
+    }
+}

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestChangeNode.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestChangeNode.cs
@@ -8,9 +8,8 @@ namespace GitHub.ViewModels.GitHubPane
     public interface IPullRequestChangeNode
     {
         /// <summary>
-        /// Gets the path to the file (not including the filename) or directory, relative to the
-        /// root of the repository.
+        /// Gets the path to the file or directory, relative to the root of the repository.
         /// </summary>
-        string DirectoryPath { get; }
+        string RelativePath { get; }
     }
 }

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestDetailViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestDetailViewModel.cs
@@ -126,9 +126,9 @@ namespace GitHub.ViewModels.GitHubPane
         string Body { get; }
 
         /// <summary>
-        /// Gets the changed files as a tree.
+        /// Gets the pull request's changed files.
         /// </summary>
-        IReadOnlyList<IPullRequestChangeNode> ChangedFilesTree { get; }
+        IPullRequestFilesViewModel Files { get; }
 
         /// <summary>
         /// Gets the state associated with the <see cref="Checkout"/> command.
@@ -164,27 +164,6 @@ namespace GitHub.ViewModels.GitHubPane
         /// Gets a command that opens the pull request on GitHub.
         /// </summary>
         ReactiveCommand<object> OpenOnGitHub { get; }
-
-        /// <summary>
-        /// Gets a command that diffs an <see cref="IPullRequestFileNode"/> between BASE and HEAD.
-        /// </summary>
-        ReactiveCommand<object> DiffFile { get; }
-
-        /// <summary>
-        /// Gets a command that diffs an <see cref="IPullRequestFileNode"/> between the version in
-        /// the working directory and HEAD.
-        /// </summary>
-        ReactiveCommand<object> DiffFileWithWorkingDirectory { get; }
-
-        /// <summary>
-        /// Gets a command that opens an <see cref="IPullRequestFileNode"/> from disk.
-        /// </summary>
-        ReactiveCommand<object> OpenFileInWorkingDirectory { get; }
-
-        /// <summary>
-        /// Gets a command that opens an <see cref="IPullRequestFileNode"/> as it appears in the PR.
-        /// </summary>
-        ReactiveCommand<object> ViewFile { get; }
 
         /// <summary>
         /// Initializes the view model.

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestFilesViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestFilesViewModel.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Threading.Tasks;
+using GitHub.Models;
+using GitHub.Services;
+using LibGit2Sharp;
+using ReactiveUI;
+
+namespace GitHub.ViewModels.GitHubPane
+{
+    /// <summary>
+    /// Represents a tree of changed files in a pull request.
+    /// </summary>
+    public interface IPullRequestFilesViewModel : IViewModel, IDisposable
+    {
+        /// <summary>
+        /// Gets the number of changed files in the pull request.
+        /// </summary>
+        int ChangedFilesCount { get; }
+
+        /// <summary>
+        /// Gets the root nodes of the tree.
+        /// </summary>
+        IReadOnlyList<IPullRequestChangeNode> Items { get; }
+
+        /// <summary>
+        /// Gets a command that diffs an <see cref="IPullRequestFileNode"/> between BASE and HEAD.
+        /// </summary>
+        ReactiveCommand<Unit> DiffFile { get; }
+
+        /// <summary>
+        /// Gets a command that opens an <see cref="IPullRequestFileNode"/> as it appears in the PR.
+        /// </summary>
+        ReactiveCommand<Unit> ViewFile { get; }
+
+        /// <summary>
+        /// Gets a command that diffs an <see cref="IPullRequestFileNode"/> between the version in
+        /// the working directory and HEAD.
+        /// </summary>
+        ReactiveCommand<Unit> DiffFileWithWorkingDirectory { get; }
+
+        /// <summary>
+        /// Gets a command that opens an <see cref="IPullRequestFileNode"/> from disk.
+        /// </summary>
+        ReactiveCommand<Unit> OpenFileInWorkingDirectory { get; }
+
+        /// <summary>
+        /// Gets a command that opens the first comment for a <see cref="IPullRequestFileNode"/> in
+        /// the diff viewer.
+        /// </summary>
+        ReactiveCommand<Unit> OpenFirstComment { get; }
+
+        /// <summary>
+        /// Initializes the view model.
+        /// </summary>
+        /// <param name="session">The pull request session.</param>
+        /// <param name="commentFilter">An optional review comment filter.</param>
+        Task InitializeAsync(
+            IPullRequestSession session,
+            Func<IInlineCommentThreadModel, bool> commentFilter = null);
+    }
+}

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -374,6 +374,9 @@
     <Compile Include="Views\GitHubPane\GitHubPaneView.xaml.cs">
       <DependentUpon>GitHubPaneView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\GitHubPane\PullRequestFilesView.xaml.cs">
+      <DependentUpon>PullRequestFilesView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\GitHubPane\PullRequestListView.xaml.cs">
       <DependentUpon>PullRequestListView.xaml</DependentUpon>
     </Compile>
@@ -524,6 +527,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\GitHubPane\GitHubPaneView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\GitHubPane\PullRequestFilesView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -392,7 +392,6 @@
     <Compile Include="Views\GitHubPane\NotAGitRepositoryView.xaml.cs">
       <DependentUpon>NotAGitRepositoryView.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Views\GitHubPane\TextViewCommandDispatcher.cs" />
     <Compile Include="Views\TeamExplorer\RepositoryPublishView.xaml.cs">
       <DependentUpon>RepositoryPublishView.xaml</DependentUpon>
     </Compile>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -2,41 +2,36 @@
                                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                                    xmlns:cache="clr-namespace:GitHub.UI.Helpers;assembly=GitHub.UI"
-                                    xmlns:controls="clr-namespace:GitHub.VisualStudio.UI.Controls;assembly=GitHub.VisualStudio.UI"
+                                    xmlns:ghfvs="https://github.com/github/VisualStudio"
                                     xmlns:local="clr-namespace:GitHub.VisualStudio.Views.GitHubPane"
                                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                                    xmlns:sampleData="clr-namespace:GitHub.SampleData;assembly=GitHub.App"
-                                    xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
-                                    xmlns:uir="clr-namespace:GitHub.UI;assembly=GitHub.UI.Reactive"
-                                    xmlns:vm="clr-namespace:GitHub.ViewModels.GitHubPane;assembly=GitHub.App"
                                     xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI"
                                     xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
+                                    xmlns:vsui="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
                                     Background="{DynamicResource GitHubVsToolWindowBackground}"
                                     Foreground="{DynamicResource GitHubVsWindowText}"
                                     DataContext="{Binding ViewModel}"
                                     d:DesignWidth="356"
                                     d:DesignHeight="800"
-                                    mc:Ignorable="d"
-                                    xmlns:vsui="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0">
+                                    mc:Ignorable="d">
     <d:DesignProperties.DataContext>
         <Binding>
             <Binding.Source>
-                <sampleData:PullRequestDetailViewModelDesigner SourceBranchDisplayName="shana/error-handling-a-ridiculously-long-branch-name-because-why-not"
+                <ghfvs:PullRequestDetailViewModelDesigner SourceBranchDisplayName="shana/error-handling-a-ridiculously-long-branch-name-because-why-not"
                                                                TargetBranchDisplayName="master-is-always-stable"
                                                                CommentCount="10">
                     <!--
-                    <sampleData:PullRequestDetailViewModelDesigner.CheckoutState>
-                        <sampleData:PullRequestCheckoutStateDesigner Caption="Checkout error-handling/>
-                    </sampleData:PullRequestDetailViewModelDesigner.CheckoutState>
+                    <ghfvs:PullRequestDetailViewModelDesigner.CheckoutState>
+                        <ghfvs:PullRequestCheckoutStateDesigner Caption="Checkout error-handling/>
+                    </ghfvs:PullRequestDetailViewModelDesigner.CheckoutState>
                     -->
-                    <sampleData:PullRequestDetailViewModelDesigner.UpdateState>
-                        <sampleData:PullRequestUpdateStateDesigner CommitsAhead="0" CommitsBehind="0" UpToDate="True"/>
-                    </sampleData:PullRequestDetailViewModelDesigner.UpdateState>
-                    <sampleData:PullRequestDetailViewModelDesigner.OperationError>
+                    <ghfvs:PullRequestDetailViewModelDesigner.UpdateState>
+                        <ghfvs:PullRequestUpdateStateDesigner CommitsAhead="0" CommitsBehind="0" UpToDate="True"/>
+                    </ghfvs:PullRequestDetailViewModelDesigner.UpdateState>
+                    <ghfvs:PullRequestDetailViewModelDesigner.OperationError>
                         Unable to connect to the internets over here!
-                    </sampleData:PullRequestDetailViewModelDesigner.OperationError>
-                </sampleData:PullRequestDetailViewModelDesigner>
+                    </ghfvs:PullRequestDetailViewModelDesigner.OperationError>
+                </ghfvs:PullRequestDetailViewModelDesigner>
             </Binding.Source>
         </Binding>
     </d:DesignProperties.DataContext>
@@ -44,10 +39,10 @@
     <Control.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
-                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
-                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
-                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/Assets/Markdown.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/Assets/Markdown.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <Style x:Key="Separator" TargetType="Rectangle">
@@ -78,7 +73,7 @@
                 <Setter Property="Foreground" Value="Red" />
             </Style>
 
-            <ui:AllCapsConverter x:Key="AllCaps"/>
+            <ghfvs:AllCapsConverter x:Key="AllCaps"/>
         </ResourceDictionary>
     </Control.Resources>
 
@@ -130,7 +125,7 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <ui:OcticonImage Grid.Column="0" VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.5" Margin="0 0 3 0" />
+                    <ghfvs:OcticonImage Grid.Column="0" VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.5" Margin="0 0 3 0" />
                     <Border Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
                         <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding SourceBranchDisplayName, Mode=OneWay}" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" />
                     </Border>
@@ -150,54 +145,54 @@
                     </Grid.ColumnDefinitions>
 
                     <TextBlock Grid.Column="0" Opacity="0.5" VerticalAlignment="Center"
-                               Text="{Binding Model.UpdatedAt, StringFormat={x:Static prop:Resources.UpdatedFormat}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
+                               Text="{Binding Model.UpdatedAt, StringFormat={x:Static prop:Resources.UpdatedFormat}, Converter={ghfvs:DurationToStringConverter}, Mode=OneWay}"/>
 
                     <Rectangle Grid.Column="1" Margin="5" Width="1" Height="12" VerticalAlignment="Top" Style="{DynamicResource Separator}" />
 
                     <!-- Checkout pull request button -->
-                    <ui:GitHubActionLink Command="{Binding Checkout}"
+                    <ghfvs:GitHubActionLink Command="{Binding Checkout}"
                                          Content="{Binding CheckoutState.Caption}"
                                          Grid.Column="2"
                                          VerticalAlignment="Center"
                                          TextTrimming="CharacterEllipsis"
-                                         Visibility="{Binding CheckoutState, Converter={ui:NullToVisibilityConverter}}"
+                                         Visibility="{Binding CheckoutState, Converter={ghfvs:NullToVisibilityConverter}}"
                                          ToolTip="{Binding CheckoutState.ToolTip}"
                                          ToolTipService.ShowOnDisabled="True"/>
 
                     <!-- Pull/push buttons -->
                     <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center"
-                            Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToInverseVisibilityConverter}}">
-                        <ui:OcticonImage Icon="arrow_down"/>
+                            Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ghfvs:BooleanToInverseVisibilityConverter}}">
+                        <ghfvs:OcticonImage Icon="arrow_down"/>
                         <TextBlock Text="{Binding UpdateState.CommitsBehind}" VerticalAlignment="Center"/>
-                        <ui:GitHubActionLink Content="Pull"
+                        <ghfvs:GitHubActionLink Content="Pull"
                                              Command="{Binding Pull}"
                                              Margin="4,0"
                                              ToolTip="{Binding UpdateState.PullToolTip}"
                                              ToolTipService.ShowOnDisabled="True"
                                              VerticalAlignment="Center"/>
-                        <ui:OcticonImage Icon="arrow_up"/>
+                        <ghfvs:OcticonImage Icon="arrow_up"/>
                         <TextBlock Text="{Binding UpdateState.CommitsAhead}" VerticalAlignment="Center"/>
-                        <ui:GitHubActionLink Content="Push"
+                        <ghfvs:GitHubActionLink Content="Push"
                                              Command="{Binding Push}"
                                              Margin="4,0"
                                              ToolTip="{Binding UpdateState.PushToolTip}"
                                              ToolTipService.ShowOnDisabled="True"
                                              VerticalAlignment="Center"/>
                         <!-- Sync submodules -->
-                        <ui:OcticonImage Icon="package"
-                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
+                        <ghfvs:OcticonImage Icon="package"
+                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ghfvs:BooleanToVisibilityConverter}}" />
                         <TextBlock  Margin="4 0 0 0" Text="{Binding UpdateState.SubmodulesToSync}" VerticalAlignment="Center"
-                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
-                        <ui:GitHubActionLink Content="Sync"
+                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ghfvs:BooleanToVisibilityConverter}}" />
+                        <ghfvs:GitHubActionLink Content="Sync"
                             Command="{Binding SyncSubmodules}"
                             Margin="4 0"
                             ToolTip="{Binding UpdateState.SyncSubmodulesToolTip}"
-                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
+                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ghfvs:BooleanToVisibilityConverter}}" />
                     </StackPanel>
 
                     <!-- Branch checked out and up-to-date -->
                     <TextBlock Grid.Column="2" VerticalAlignment="Center" TextWrapping="Wrap"
-                           Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
+                           Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ghfvs:BooleanToVisibilityConverter}}">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutMessage}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -214,7 +209,7 @@
                                 </Style.Triggers>
                             </Style>
                         </TextBlock.Style>
-                    <ui:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
+                    <ghfvs:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
                     <Run Text="{x:Static prop:Resources.LocalBranchUpToDate}"/>
                     </TextBlock>
                 </Grid>
@@ -230,7 +225,7 @@
                      VerticalAlignment="Center"
                      TextWrapping="Wrap"
                      Style="{StaticResource FlatReadOnlyTextBox}"
-                     Visibility="{Binding OperationError, Converter={ui:NullToVisibilityConverter}}"/>
+                     Visibility="{Binding OperationError, Converter={ghfvs:NullToVisibilityConverter}}"/>
         </Grid>
 
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,5,-8,0"/>
@@ -254,7 +249,7 @@
 
                 <!-- Author and open time -->
                 <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
-                    <controls:AccountAvatar Account="{Binding Model.Author}"
+                    <ghfvs:AccountAvatar Account="{Binding Model.Author}"
                                             VerticalAlignment="Top"
                                             Width="16"
                                             Height="16"/>
@@ -272,18 +267,18 @@
                                         Markdown="{Binding Body}"/>
 
                 <!-- View conversation on GitHub -->
-                <ui:GitHubActionLink Grid.Column="2" Grid.Row="2" Margin="0 6" Command="{Binding OpenOnGitHub}">
+                <ghfvs:GitHubActionLink Grid.Column="2" Grid.Row="2" Margin="0 6" Command="{Binding OpenOnGitHub}">
                     View conversation on GitHub
-                </ui:GitHubActionLink>
+                </ghfvs:GitHubActionLink>
 
                 <!-- Files changed -->
-                <ui:SectionControl Name="changesSection" 
+                <ghfvs:SectionControl Name="changesSection" 
                                    Grid.Row="4"
                                    IsExpanded="True"
                                    HeaderText="{Binding Files.ChangedFilesCount, StringFormat={x:Static prop:Resources.ChangesCountFormat}}"
                                    Margin="0 5 10 0">
                     <local:PullRequestFilesView DataContext="{Binding Files}"/>
-                </ui:SectionControl>
+                </ghfvs:SectionControl>
             </Grid>
         </ScrollViewer>
     </DockPanel>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -2,36 +2,41 @@
                                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                                    xmlns:ghfvs="https://github.com/github/VisualStudio"
+                                    xmlns:cache="clr-namespace:GitHub.UI.Helpers;assembly=GitHub.UI"
+                                    xmlns:controls="clr-namespace:GitHub.VisualStudio.UI.Controls;assembly=GitHub.VisualStudio.UI"
                                     xmlns:local="clr-namespace:GitHub.VisualStudio.Views.GitHubPane"
                                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                                    xmlns:sampleData="clr-namespace:GitHub.SampleData;assembly=GitHub.App"
+                                    xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
+                                    xmlns:uir="clr-namespace:GitHub.UI;assembly=GitHub.UI.Reactive"
+                                    xmlns:vm="clr-namespace:GitHub.ViewModels.GitHubPane;assembly=GitHub.App"
                                     xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI"
                                     xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
-                                    xmlns:vsui="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
                                     Background="{DynamicResource GitHubVsToolWindowBackground}"
                                     Foreground="{DynamicResource GitHubVsWindowText}"
                                     DataContext="{Binding ViewModel}"
                                     d:DesignWidth="356"
                                     d:DesignHeight="800"
-                                    mc:Ignorable="d">
+                                    mc:Ignorable="d"
+                                    xmlns:vsui="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0">
     <d:DesignProperties.DataContext>
         <Binding>
             <Binding.Source>
-                <ghfvs:PullRequestDetailViewModelDesigner SourceBranchDisplayName="shana/error-handling-a-ridiculously-long-branch-name-because-why-not"
+                <sampleData:PullRequestDetailViewModelDesigner SourceBranchDisplayName="shana/error-handling-a-ridiculously-long-branch-name-because-why-not"
                                                                TargetBranchDisplayName="master-is-always-stable"
                                                                CommentCount="10">
                     <!--
-                    <ghfvs:PullRequestDetailViewModelDesigner.CheckoutState>
-                        <ghfvs:PullRequestCheckoutStateDesigner Caption="Checkout error-handling/>
-                    </ghfvs:PullRequestDetailViewModelDesigner.CheckoutState>
+                    <sampleData:PullRequestDetailViewModelDesigner.CheckoutState>
+                        <sampleData:PullRequestCheckoutStateDesigner Caption="Checkout error-handling/>
+                    </sampleData:PullRequestDetailViewModelDesigner.CheckoutState>
                     -->
-                    <ghfvs:PullRequestDetailViewModelDesigner.UpdateState>
-                        <ghfvs:PullRequestUpdateStateDesigner CommitsAhead="0" CommitsBehind="0" UpToDate="True"/>
-                    </ghfvs:PullRequestDetailViewModelDesigner.UpdateState>
-                    <ghfvs:PullRequestDetailViewModelDesigner.OperationError>
+                    <sampleData:PullRequestDetailViewModelDesigner.UpdateState>
+                        <sampleData:PullRequestUpdateStateDesigner CommitsAhead="0" CommitsBehind="0" UpToDate="True"/>
+                    </sampleData:PullRequestDetailViewModelDesigner.UpdateState>
+                    <sampleData:PullRequestDetailViewModelDesigner.OperationError>
                         Unable to connect to the internets over here!
-                    </ghfvs:PullRequestDetailViewModelDesigner.OperationError>
-                </ghfvs:PullRequestDetailViewModelDesigner>
+                    </sampleData:PullRequestDetailViewModelDesigner.OperationError>
+                </sampleData:PullRequestDetailViewModelDesigner>
             </Binding.Source>
         </Binding>
     </d:DesignProperties.DataContext>
@@ -39,10 +44,10 @@
     <Control.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
-                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
-                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
-                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/Assets/Markdown.xaml" />
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/Assets/Markdown.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <Style x:Key="Separator" TargetType="Rectangle">
@@ -73,7 +78,7 @@
                 <Setter Property="Foreground" Value="Red" />
             </Style>
 
-            <ghfvs:AllCapsConverter x:Key="AllCaps"/>
+            <ui:AllCapsConverter x:Key="AllCaps"/>
         </ResourceDictionary>
     </Control.Resources>
 
@@ -125,7 +130,7 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <ghfvs:OcticonImage Grid.Column="0" VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.5" Margin="0 0 3 0" />
+                    <ui:OcticonImage Grid.Column="0" VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.5" Margin="0 0 3 0" />
                     <Border Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
                         <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding SourceBranchDisplayName, Mode=OneWay}" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" />
                     </Border>
@@ -145,54 +150,54 @@
                     </Grid.ColumnDefinitions>
 
                     <TextBlock Grid.Column="0" Opacity="0.5" VerticalAlignment="Center"
-                               Text="{Binding Model.UpdatedAt, StringFormat={x:Static prop:Resources.UpdatedFormat}, Converter={ghfvs:DurationToStringConverter}, Mode=OneWay}"/>
+                               Text="{Binding Model.UpdatedAt, StringFormat={x:Static prop:Resources.UpdatedFormat}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
 
                     <Rectangle Grid.Column="1" Margin="5" Width="1" Height="12" VerticalAlignment="Top" Style="{DynamicResource Separator}" />
 
                     <!-- Checkout pull request button -->
-                    <ghfvs:GitHubActionLink Command="{Binding Checkout}"
+                    <ui:GitHubActionLink Command="{Binding Checkout}"
                                          Content="{Binding CheckoutState.Caption}"
                                          Grid.Column="2"
                                          VerticalAlignment="Center"
                                          TextTrimming="CharacterEllipsis"
-                                         Visibility="{Binding CheckoutState, Converter={ghfvs:NullToVisibilityConverter}}"
+                                         Visibility="{Binding CheckoutState, Converter={ui:NullToVisibilityConverter}}"
                                          ToolTip="{Binding CheckoutState.ToolTip}"
                                          ToolTipService.ShowOnDisabled="True"/>
 
                     <!-- Pull/push buttons -->
                     <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center"
-                            Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ghfvs:BooleanToInverseVisibilityConverter}}">
-                        <ghfvs:OcticonImage Icon="arrow_down"/>
+                            Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToInverseVisibilityConverter}}">
+                        <ui:OcticonImage Icon="arrow_down"/>
                         <TextBlock Text="{Binding UpdateState.CommitsBehind}" VerticalAlignment="Center"/>
-                        <ghfvs:GitHubActionLink Content="Pull"
+                        <ui:GitHubActionLink Content="Pull"
                                              Command="{Binding Pull}"
                                              Margin="4,0"
                                              ToolTip="{Binding UpdateState.PullToolTip}"
                                              ToolTipService.ShowOnDisabled="True"
                                              VerticalAlignment="Center"/>
-                        <ghfvs:OcticonImage Icon="arrow_up"/>
+                        <ui:OcticonImage Icon="arrow_up"/>
                         <TextBlock Text="{Binding UpdateState.CommitsAhead}" VerticalAlignment="Center"/>
-                        <ghfvs:GitHubActionLink Content="Push"
+                        <ui:GitHubActionLink Content="Push"
                                              Command="{Binding Push}"
                                              Margin="4,0"
                                              ToolTip="{Binding UpdateState.PushToolTip}"
                                              ToolTipService.ShowOnDisabled="True"
                                              VerticalAlignment="Center"/>
                         <!-- Sync submodules -->
-                        <ghfvs:OcticonImage Icon="package"
-                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ghfvs:BooleanToVisibilityConverter}}" />
+                        <ui:OcticonImage Icon="package"
+                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
                         <TextBlock  Margin="4 0 0 0" Text="{Binding UpdateState.SubmodulesToSync}" VerticalAlignment="Center"
-                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ghfvs:BooleanToVisibilityConverter}}" />
-                        <ghfvs:GitHubActionLink Content="Sync"
+                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
+                        <ui:GitHubActionLink Content="Sync"
                             Command="{Binding SyncSubmodules}"
                             Margin="4 0"
                             ToolTip="{Binding UpdateState.SyncSubmodulesToolTip}"
-                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ghfvs:BooleanToVisibilityConverter}}" />
+                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
                     </StackPanel>
 
                     <!-- Branch checked out and up-to-date -->
                     <TextBlock Grid.Column="2" VerticalAlignment="Center" TextWrapping="Wrap"
-                           Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ghfvs:BooleanToVisibilityConverter}}">
+                           Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutMessage}">
                                 <Setter Property="Visibility" Value="Collapsed"/>
@@ -209,7 +214,7 @@
                                 </Style.Triggers>
                             </Style>
                         </TextBlock.Style>
-                    <ghfvs:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
+                    <ui:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
                     <Run Text="{x:Static prop:Resources.LocalBranchUpToDate}"/>
                     </TextBlock>
                 </Grid>
@@ -225,7 +230,7 @@
                      VerticalAlignment="Center"
                      TextWrapping="Wrap"
                      Style="{StaticResource FlatReadOnlyTextBox}"
-                     Visibility="{Binding OperationError, Converter={ghfvs:NullToVisibilityConverter}}"/>
+                     Visibility="{Binding OperationError, Converter={ui:NullToVisibilityConverter}}"/>
         </Grid>
 
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="-8,5,-8,0"/>
@@ -249,7 +254,7 @@
 
                 <!-- Author and open time -->
                 <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
-                    <ghfvs:AccountAvatar Account="{Binding Model.Author}"
+                    <controls:AccountAvatar Account="{Binding Model.Author}"
                                             VerticalAlignment="Top"
                                             Width="16"
                                             Height="16"/>
@@ -267,125 +272,18 @@
                                         Markdown="{Binding Body}"/>
 
                 <!-- View conversation on GitHub -->
-                <ghfvs:GitHubActionLink Grid.Column="2" Grid.Row="2" Margin="0 6" Command="{Binding OpenOnGitHub}">
+                <ui:GitHubActionLink Grid.Column="2" Grid.Row="2" Margin="0 6" Command="{Binding OpenOnGitHub}">
                     View conversation on GitHub
-                </ghfvs:GitHubActionLink>
+                </ui:GitHubActionLink>
 
                 <!-- Files changed -->
-                <ghfvs:SectionControl Name="changesSection" 
-                                   Grid.Row="3"
+                <ui:SectionControl Name="changesSection" 
+                                   Grid.Row="4"
                                    IsExpanded="True"
-                                   HeaderText="{Binding Model.ChangedFiles.Count, StringFormat={x:Static prop:Resources.ChangesCountFormat}}"
+                                   HeaderText="{Binding Files.ChangedFilesCount, StringFormat={x:Static prop:Resources.ChangesCountFormat}}"
                                    Margin="0 5 10 0">
-
-                    <ghfvs:SectionControl.Content>
-                        <Grid>
-                            <Grid.Resources>
-                                <!-- When invoked from the TreeView and the ListView we programmatically bind the 
-                                     DataContext and update the CommandParameter to the changed file -->
-                                <ContextMenu x:Key="FileContextMenu">
-                                    <MenuItem Header="{x:Static prop:Resources.ViewChanges}" Command="{Binding DiffFile}"/>
-                                    <MenuItem Header="{x:Static prop:Resources.ViewFile}" Command="{Binding ViewFile}"/>
-                                    <MenuItem Header="{x:Static prop:Resources.ViewChangesInSolution}" Command="{Binding DiffFileWithWorkingDirectory}"/>
-                                    <MenuItem Header="{x:Static prop:Resources.OpenFileInSolution}" Command="{Binding OpenFileInWorkingDirectory}"/>
-                                </ContextMenu>
-                            </Grid.Resources>
-
-                            <!-- Tree View -->
-                            <TreeView Name="changesTree"
-                                      ItemsSource="{Binding ChangedFilesTree}"
-                                      ContextMenuOpening="TreeView_ContextMenuOpening"
-                                      ContextMenu="{StaticResource FileContextMenu}"
-                                      Background="Transparent"
-                                      BorderThickness="0"
-                                      Margin="0 6 0 0"
-                                      KeyUp="FileListKeyUp"
-                                      MouseRightButtonDown="FileListMouseRightButtonDown"
-                                      MouseDoubleClick="FileListMouseDoubleClick">
-                                <TreeView.ItemContainerStyle>
-                                    <Style TargetType="TreeViewItem">
-                                        <Setter Property="IsExpanded" Value="True"/>
-                                        <Setter Property="Foreground" Value="{DynamicResource GitHubVsWindowText}"/>
-                                    </Style>
-                                </TreeView.ItemContainerStyle>
-                                <TreeView.Resources>
-                                    <HierarchicalDataTemplate DataType="{x:Type ghfvs:PullRequestDirectoryNode}"
-                                                              ItemsSource="{Binding Children}">
-                                        <StackPanel Orientation="Horizontal">
-                                            <ghfvs:OcticonImage Icon="file_directory" Foreground="{DynamicResource GitHubDirectoryIconForeground}" Margin="0,0,0,2"/>
-                                            <TextBlock Text="{Binding DirectoryName}" Margin="4 2" VerticalAlignment="Center"/>
-                                        </StackPanel>
-                                    </HierarchicalDataTemplate>
-                                    <DataTemplate DataType="{x:Type ghfvs:PullRequestFileNode}">
-                                        <StackPanel Orientation="Horizontal"
-                                                    Tag="{Binding DataContext, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type ghfvs:SectionControl}}}"
-                                                    KeyboardNavigation.DirectionalNavigation="None">
-                                            <ghfvs:OcticonImage Icon="file_code" Margin="0,0,0,2">
-                                                <ghfvs:OcticonImage.Style>
-                                                    <Style TargetType="ghfvs:OcticonImage" BasedOn="{StaticResource OcticonImage}">
-                                                        <Style.Triggers>
-                                                            <MultiDataTrigger>
-                                                                <MultiDataTrigger.Conditions>
-                                                                    <Condition Binding="{Binding Status}" Value="Removed"/>
-                                                                    <Condition Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type TreeViewItem}}, Path=IsSelected}" Value="False"/>
-                                                                </MultiDataTrigger.Conditions>
-                                                                <Setter Property="Foreground" Value="{DynamicResource GitHubDeletedFileIconBrush}"/>
-                                                            </MultiDataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </ghfvs:OcticonImage.Style>
-                                            </ghfvs:OcticonImage>
-                                            <TextBlock Text="{Binding FileName}" Margin="4 2" VerticalAlignment="Center">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding Status}" Value="Removed">
-                                                                <Setter Property="TextDecorations" Value="Strikethrough"/>
-                                                            </DataTrigger>
-                                                            <MultiDataTrigger>
-                                                                <MultiDataTrigger.Conditions>
-                                                                    <Condition Binding="{Binding Status}" Value="Removed"/>
-                                                                    <Condition Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type TreeViewItem}}, Path=IsSelected}" Value="False"/>
-                                                                </MultiDataTrigger.Conditions>
-                                                                <Setter Property="Foreground" Value="{DynamicResource GitHubDeletedFileBrush}"/>
-                                                            </MultiDataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-                                            <TextBlock Text="{Binding StatusDisplay, StringFormat=[{0}]}" VerticalAlignment="Center" Opacity="0.5">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Null}">
-                                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-                                            <TextBlock VerticalAlignment="Center" Margin="4 0">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding CommentCount}" Value="0">
-                                                                <Setter Property="Visibility" Value="Collapsed"/>
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                                <ghfvs:OcticonImage Icon="comment_discussion" Height="10" Margin="-2 0"/>
-                                                <Hyperlink Click="ViewFileCommentsClick">
-                                                    <Run Text="{Binding CommentCount, Mode=OneWay}"/>
-                                                </Hyperlink>
-                                            </TextBlock>
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </TreeView.Resources>
-                            </TreeView>
-                        </Grid>
-                    </ghfvs:SectionControl.Content>
-                </ghfvs:SectionControl>
+                    <local:PullRequestFilesView DataContext="{Binding Files}"/>
+                </ui:SectionControl>
             </Grid>
         </ScrollViewer>
     </DockPanel>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml.cs
@@ -1,32 +1,17 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using System.Globalization;
-using System.Linq;
 using System.Reactive.Linq;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using GitHub.Commands;
 using GitHub.Exports;
 using GitHub.Extensions;
-using GitHub.Models;
 using GitHub.Services;
 using GitHub.UI;
 using GitHub.UI.Helpers;
 using GitHub.ViewModels.GitHubPane;
 using GitHub.VisualStudio.UI.Helpers;
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Editor;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Text.Projection;
-using Microsoft.VisualStudio.TextManager.Interop;
 using ReactiveUI;
-using Task = System.Threading.Tasks.Task;
 
 namespace GitHub.VisualStudio.Views.GitHubPane
 {
@@ -47,37 +32,11 @@ namespace GitHub.VisualStudio.Views.GitHubPane
             this.WhenActivated(d =>
             {
                 d(ViewModel.OpenOnGitHub.Subscribe(_ => DoOpenOnGitHub()));
-                d(ViewModel.DiffFile.Subscribe(x => DoDiffFile((IPullRequestFileNode)x, false).Forget()));
-                d(ViewModel.ViewFile.Subscribe(x => DoOpenFile((IPullRequestFileNode)x, false).Forget()));
-                d(ViewModel.DiffFileWithWorkingDirectory.Subscribe(x => DoDiffFile((IPullRequestFileNode)x, true).Forget()));
-                d(ViewModel.OpenFileInWorkingDirectory.Subscribe(x => DoOpenFile((IPullRequestFileNode)x, true).Forget()));
             });
-
-            bodyGrid.RequestBringIntoView += BodyFocusHack;
         }
-
-        [Import]
-        ITeamExplorerServiceHolder TeamExplorerServiceHolder { get; set; }
 
         [Import]
         IVisualStudioBrowser VisualStudioBrowser { get; set; }
-
-        [Import]
-        IEditorOptionsFactoryService EditorOptionsFactoryService { get; set; }
-
-        [Import]
-        IUsageTracker UsageTracker { get; set; }
-
-        [Import]
-        IPullRequestEditorService NavigationService { get; set; }
-
-        [Import]
-        IVsEditorAdaptersFactoryService EditorAdaptersFactoryService { get; set; }
-
-        protected override void OnVisualParentChanged(DependencyObject oldParent)
-        {
-            base.OnVisualParentChanged(oldParent);
-        }
 
         void DoOpenOnGitHub()
         {
@@ -93,315 +52,6 @@ namespace GitHub.VisualStudio.Views.GitHubPane
             return new Uri(url);
         }
 
-        async Task DoOpenFile(IPullRequestFileNode file, bool workingDirectory)
-        {
-            try
-            {
-                var fullPath = ViewModel.GetLocalFilePath(file);
-                var fileName = workingDirectory ? fullPath : await ViewModel.ExtractFile(file, true);
-
-                using (workingDirectory ? null : OpenInProvisionalTab())
-                {
-                    var window = GitHub.VisualStudio.Services.Dte.ItemOperations.OpenFile(fileName);
-                    window.Document.ReadOnly = !workingDirectory;
-
-                    var buffer = GetBufferAt(fileName);
-
-                    if (!workingDirectory)
-                    {
-                        AddBufferTag(buffer, ViewModel.Session, fullPath, null);
-
-                        var textView = NavigationService.FindActiveView();
-                        EnableNavigateToEditor(textView, file);
-                    }
-                }
-
-                if (workingDirectory)
-                    await UsageTracker.IncrementCounter(x => x.NumberOfPRDetailsOpenFileInSolution);
-                else
-                    await UsageTracker.IncrementCounter(x => x.NumberOfPRDetailsViewFile);
-            }
-            catch (Exception e)
-            {
-                ShowErrorInStatusBar("Error opening file", e);
-            }
-        }
-
-        async Task DoNavigateToEditor(IPullRequestFileNode file)
-        {
-            try
-            {
-                if (!ViewModel.IsCheckedOut)
-                {
-                    ShowInfoMessage("Checkout PR branch before opening file in solution.");
-                    return;
-                }
-
-                var fullPath = ViewModel.GetLocalFilePath(file);
-
-                var activeView = NavigationService.FindActiveView();
-                if (activeView == null)
-                {
-                    ShowErrorInStatusBar("Couldn't find active view");
-                    return;
-                }
-
-                NavigationService.NavigateToEquivalentPosition(activeView, fullPath);
-
-                await UsageTracker.IncrementCounter(x => x.NumberOfPRDetailsNavigateToEditor);
-            }
-            catch (Exception e)
-            {
-                ShowErrorInStatusBar("Error navigating to editor", e);
-            }
-        }
-
-        static void ShowInfoMessage(string message)
-        {
-            ErrorHandler.ThrowOnFailure(VsShellUtilities.ShowMessageBox(
-                Services.GitHubServiceProvider, message, null,
-                OLEMSGICON.OLEMSGICON_INFO, OLEMSGBUTTON.OLEMSGBUTTON_OK, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST));
-        }
-
-        async Task DoDiffFile(IPullRequestFileNode file, bool workingDirectory)
-        {
-            try
-            {
-                var rightPath = System.IO.Path.Combine(file.DirectoryPath, file.FileName);
-                var leftPath = file.OldPath ?? rightPath;
-                var rightFile = workingDirectory ? ViewModel.GetLocalFilePath(file) : await ViewModel.ExtractFile(file, true);
-                var leftFile = await ViewModel.ExtractFile(file, false);
-                var leftLabel = $"{leftPath};{ViewModel.TargetBranchDisplayName}";
-                var rightLabel = workingDirectory ? rightPath : $"{rightPath};PR {ViewModel.Model.Number}";
-                var caption = $"Diff - {file.FileName}";
-                var options = __VSDIFFSERVICEOPTIONS.VSDIFFOPT_DetectBinaryFiles |
-                    __VSDIFFSERVICEOPTIONS.VSDIFFOPT_LeftFileIsTemporary;
-
-                if (!workingDirectory)
-                {
-                    options |= __VSDIFFSERVICEOPTIONS.VSDIFFOPT_RightFileIsTemporary;
-                }
-
-                IVsWindowFrame frame;
-                using (OpenInProvisionalTab())
-                {
-                    var tooltip = $"{leftLabel}\nvs.\n{rightLabel}";
-
-                    // Diff window will open in provisional (right hand) tab until document is touched.
-                    frame = GitHub.VisualStudio.Services.DifferenceService.OpenComparisonWindow2(
-                        leftFile,
-                        rightFile,
-                        caption,
-                        tooltip,
-                        leftLabel,
-                        rightLabel,
-                        string.Empty,
-                        string.Empty,
-                        (uint)options);
-                }
-
-                object docView;
-                frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out docView);
-                var diffViewer = ((IVsDifferenceCodeWindow)docView).DifferenceViewer;
-
-                var session = ViewModel.Session;
-                AddBufferTag(diffViewer.LeftView.TextBuffer, session, leftPath, DiffSide.Left);
-
-                if (!workingDirectory)
-                {
-                    AddBufferTag(diffViewer.RightView.TextBuffer, session, rightPath, DiffSide.Right);
-                    EnableNavigateToEditor(diffViewer.LeftView, file);
-                    EnableNavigateToEditor(diffViewer.RightView, file);
-                    EnableNavigateToEditor(diffViewer.InlineView, file);
-                }
-
-                if (workingDirectory)
-                    await UsageTracker.IncrementCounter(x => x.NumberOfPRDetailsCompareWithSolution);
-                else
-                    await UsageTracker.IncrementCounter(x => x.NumberOfPRDetailsViewChanges);
-            }
-            catch (Exception e)
-            {
-                ShowErrorInStatusBar("Error opening file", e);
-            }
-        }
-
-        void AddBufferTag(ITextBuffer buffer, IPullRequestSession session, string path, DiffSide? side)
-        {
-            buffer.Properties.GetOrCreateSingletonProperty(
-                typeof(PullRequestTextBufferInfo),
-                () => new PullRequestTextBufferInfo(session, path, side));
-
-            var projection = buffer as IProjectionBuffer;
-
-            if (projection != null)
-            {
-                foreach (var source in projection.SourceBuffers)
-                {
-                    AddBufferTag(source, session, path, side);
-                }
-            }
-        }
-
-        void EnableNavigateToEditor(IWpfTextView textView, IPullRequestFileNode file)
-        {
-            var view = EditorAdaptersFactoryService.GetViewAdapter(textView);
-            EnableNavigateToEditor(view, file);
-        }
-
-        void EnableNavigateToEditor(IVsTextView textView, IPullRequestFileNode file)
-        {
-            var commandGroup = VSConstants.CMDSETID.StandardCommandSet2K_guid;
-            var commandId = (int)VSConstants.VSStd2KCmdID.RETURN;
-            new TextViewCommandDispatcher(textView, commandGroup, commandId).Exec += async (s, e) => await DoNavigateToEditor(file);
-
-            var contextMenuCommandGroup = new Guid(Guids.guidContextMenuSetString);
-            var goToCommandId = PkgCmdIDList.openFileInSolutionCommand;
-            new TextViewCommandDispatcher(textView, contextMenuCommandGroup, goToCommandId).Exec += async (s, e) => await DoNavigateToEditor(file);
-        }
-
-        void ShowErrorInStatusBar(string message, Exception e = null)
-        {
-            var ns = GitHub.VisualStudio.Services.DefaultExportProvider.GetExportedValue<IStatusBarNotificationService>();
-            if (e != null)
-            {
-                message += ": " + e.Message;
-            }
-            ns?.ShowMessage(message);
-        }
-
-        private void FileListKeyUp(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Return)
-            {
-                var file = (e.OriginalSource as FrameworkElement)?.DataContext as IPullRequestFileNode;
-                if (file != null)
-                {
-                    DoDiffFile(file, false).Forget();
-                }
-            }
-        }
-
-        void FileListMouseDoubleClick(object sender, MouseButtonEventArgs e)
-        {
-            var file = (e.OriginalSource as FrameworkElement)?.DataContext as IPullRequestFileNode;
-
-            if (file != null)
-            {
-                DoDiffFile(file, false).Forget();
-            }
-        }
-
-        void FileListMouseRightButtonDown(object sender, MouseButtonEventArgs e)
-        {
-            var item = (e.OriginalSource as Visual)?.GetSelfAndVisualAncestors().OfType<TreeViewItem>().FirstOrDefault();
-
-            if (item != null)
-            {
-                // Select tree view item on right click.
-                item.IsSelected = true;
-            }
-        }
-
-        ITextBuffer GetBufferAt(string filePath)
-        {
-            var editorAdapterFactoryService = GitHub.VisualStudio.Services.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
-            IVsUIHierarchy uiHierarchy;
-            uint itemID;
-            IVsWindowFrame windowFrame;
-
-            if (VsShellUtilities.IsDocumentOpen(
-                GitHub.VisualStudio.Services.GitHubServiceProvider,
-                filePath,
-                Guid.Empty,
-                out uiHierarchy,
-                out itemID,
-                out windowFrame))
-            {
-                IVsTextView view = VsShellUtilities.GetTextView(windowFrame);
-                IVsTextLines lines;
-                if (view.GetBuffer(out lines) == 0)
-                {
-                    var buffer = lines as IVsTextBuffer;
-                    if (buffer != null)
-                        return editorAdapterFactoryService.GetDataBuffer(buffer);
-                }
-            }
-
-            return null;
-        }
-
-        void TreeView_ContextMenuOpening(object sender, ContextMenuEventArgs e)
-        {
-            ApplyContextMenuBinding<TreeViewItem>(sender, e);
-        }
-
-        void ApplyContextMenuBinding<TItem>(object sender, ContextMenuEventArgs e) where TItem : Control
-        {
-            var container = (Control)sender;
-            var item = (e.OriginalSource as Visual)?.GetSelfAndVisualAncestors().OfType<TItem>().FirstOrDefault();
-
-            e.Handled = true;
-
-            if (item != null)
-            {
-                var fileNode = item.DataContext as IPullRequestFileNode;
-
-                if (fileNode != null)
-                {
-                    container.ContextMenu.DataContext = this.DataContext;
-
-                    foreach (var menuItem in container.ContextMenu.Items.OfType<MenuItem>())
-                    {
-                        menuItem.CommandParameter = fileNode;
-                    }
-
-                    e.Handled = false;
-                }
-            }
-        }
-
-        void BodyFocusHack(object sender, RequestBringIntoViewEventArgs e)
-        {
-            if (e.TargetObject == bodyMarkdown)
-            {
-                // Hack to prevent pane scrolling to top. Instead focus selected tree view item.
-                // See https://github.com/github/VisualStudio/issues/1042
-                var node = changesTree.GetTreeViewItem(changesTree.SelectedItem);
-                node?.Focus();
-                e.Handled = true;
-            }
-        }
-
-        async void ViewFileCommentsClick(object sender, RoutedEventArgs e)
-        {
-            try
-            {
-                var file = (e.OriginalSource as Hyperlink)?.DataContext as IPullRequestFileNode;
-
-                if (file != null)
-                {
-                    var param = (object)new InlineCommentNavigationParams
-                    {
-                        FromLine = -1,
-                    };
-
-                    await DoDiffFile(file, false);
-
-                    // HACK: We need to wait here for the diff view to set itself up and move its cursor
-                    // to the first changed line. There must be a better way of doing this.
-                    await Task.Delay(1500);
-
-                    GitHub.VisualStudio.Services.Dte.Commands.Raise(
-                        Guids.CommandSetString,
-                        PkgCmdIDList.NextInlineCommentId,
-                        ref param,
-                        null);
-                }
-            }
-            catch { }
-        }
-
         void OpenHyperlink(object sender, ExecutedRoutedEventArgs e)
         {
             Uri uri;
@@ -410,13 +60,6 @@ namespace GitHub.VisualStudio.Views.GitHubPane
             {
                 VisualStudioBrowser.OpenUrl(uri);
             }
-        }
-
-        static IDisposable OpenInProvisionalTab()
-        {
-            return new NewDocumentStateScope
-                (__VSNEWDOCUMENTSTATE.NDS_Provisional,
-                VSConstants.NewDocumentStateReason.SolutionExplorer);
         }
     }
 }

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml
@@ -43,6 +43,7 @@
         <TreeView.ItemContainerStyle>
             <Style TargetType="TreeViewItem">
                 <Setter Property="IsExpanded" Value="True"/>
+                <Setter Property="Foreground" Value="{DynamicResource GitHubVsWindowText}"/>
             </Style>
         </TreeView.ItemContainerStyle>
         <TreeView.Resources>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml
@@ -2,26 +2,23 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:cache="clr-namespace:GitHub.UI.Helpers;assembly=GitHub.UI"
-             xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
-             xmlns:vm="clr-namespace:GitHub.ViewModels.GitHubPane;assembly=GitHub.App"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ghfvs="https://github.com/github/VisualStudio"
              xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI"
-             xmlns:sample="clr-namespace:GitHub.SampleData;assembly=GitHub.App"
              mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300"
              Name="root">
 
     <d:DesignProperties.DataContext>
-        <sample:PullRequestFilesViewModelDesigner/>
+        <ghfvs:PullRequestFilesViewModelDesigner/>
     </d:DesignProperties.DataContext>
 
     <Control.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
-                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
-                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
-                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/Assets/Markdown.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/Assets/Markdown.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <ContextMenu x:Key="FileContextMenu">
@@ -49,15 +46,15 @@
             </Style>
         </TreeView.ItemContainerStyle>
         <TreeView.Resources>
-            <HierarchicalDataTemplate DataType="{x:Type vm:PullRequestDirectoryNode}"
+            <HierarchicalDataTemplate DataType="{x:Type ghfvs:PullRequestDirectoryNode}"
                                       ItemsSource="{Binding Children}">
                 <StackPanel Orientation="Horizontal">
-                    <ui:OcticonImage Icon="file_directory" Foreground="{DynamicResource GitHubDirectoryIconForeground}" Margin="0,0,0,2"/>
+                    <ghfvs:OcticonImage Icon="file_directory" Foreground="{DynamicResource GitHubDirectoryIconForeground}" Margin="0,0,0,2"/>
                     <TextBlock Text="{Binding DirectoryName}" Margin="4 2" VerticalAlignment="Center"/>
                 </StackPanel>
             </HierarchicalDataTemplate>
 
-            <DataTemplate DataType="{x:Type vm:PullRequestFileNode}">
+            <DataTemplate DataType="{x:Type ghfvs:PullRequestFileNode}">
                 <StackPanel Orientation="Horizontal"
                             Tag="{Binding DataContext, ElementName=root}"
                             KeyboardNavigation.DirectionalNavigation="None">
@@ -81,7 +78,7 @@
                                 </Style.Triggers>
                             </Style>
                         </Decorator.Style>
-                        <ui:OcticonImage Icon="file_code" Margin="0,0,0,2"/>
+                        <ghfvs:OcticonImage Icon="file_code" Margin="0,0,0,2"/>
                     </Decorator>
 
                     <TextBlock Text="{Binding FileName}" Margin="4 2" VerticalAlignment="Center">
@@ -125,7 +122,7 @@
                                 </Style.Triggers>
                             </Style>
                         </TextBlock.Style>
-                        <ui:OcticonImage Icon="comment_discussion" Height="10" Margin="-2 0"/>
+                        <ghfvs:OcticonImage Icon="comment_discussion" Height="10" Margin="-2 0"/>
                         <Hyperlink Command="{Binding DataContext.OpenFirstComment, ElementName=root}"
                                    CommandParameter="{Binding}">
                             <Run Text="{Binding CommentCount, Mode=OneWay}"/>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml
@@ -1,0 +1,138 @@
+﻿<UserControl x:Class="GitHub.VisualStudio.Views.GitHubPane.PullRequestFilesView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:cache="clr-namespace:GitHub.UI.Helpers;assembly=GitHub.UI"
+             xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
+             xmlns:vm="clr-namespace:GitHub.ViewModels.GitHubPane;assembly=GitHub.App"
+             xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI"
+             xmlns:sample="clr-namespace:GitHub.SampleData;assembly=GitHub.App"
+             mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300"
+             Name="root">
+
+    <d:DesignProperties.DataContext>
+        <sample:PullRequestFilesViewModelDesigner/>
+    </d:DesignProperties.DataContext>
+
+    <Control.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
+                <cache:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/Assets/Markdown.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <ContextMenu x:Key="FileContextMenu">
+                <MenuItem Header="{x:Static prop:Resources.ViewChanges}" Command="{Binding DiffFile}"/>
+                <MenuItem Header="{x:Static prop:Resources.ViewFile}" Command="{Binding ViewFile}"/>
+                <MenuItem Header="{x:Static prop:Resources.ViewChangesInSolution}" Command="{Binding DiffFileWithWorkingDirectory}"/>
+                <MenuItem Header="{x:Static prop:Resources.OpenFileInSolution}" Command="{Binding OpenFileInWorkingDirectory}"/>
+            </ContextMenu>
+        </ResourceDictionary>
+    </Control.Resources>
+
+    <TreeView Name="changesTree"
+              ItemsSource="{Binding Items}"
+              ContextMenu="{StaticResource FileContextMenu}"
+              Background="Transparent"
+              BorderThickness="0"
+              Margin="0 6 0 0"
+              ContextMenuOpening="changesTree_ContextMenuOpening"
+              KeyUp="changesTree_KeyUp"
+              MouseDoubleClick="changesTree_MouseDoubleClick"
+              MouseRightButtonDown="changesTree_MouseRightButtonDown">
+        <TreeView.ItemContainerStyle>
+            <Style TargetType="TreeViewItem">
+                <Setter Property="IsExpanded" Value="True"/>
+            </Style>
+        </TreeView.ItemContainerStyle>
+        <TreeView.Resources>
+            <HierarchicalDataTemplate DataType="{x:Type vm:PullRequestDirectoryNode}"
+                                      ItemsSource="{Binding Children}">
+                <StackPanel Orientation="Horizontal">
+                    <ui:OcticonImage Icon="file_directory" Foreground="{DynamicResource GitHubDirectoryIconForeground}" Margin="0,0,0,2"/>
+                    <TextBlock Text="{Binding DirectoryName}" Margin="4 2" VerticalAlignment="Center"/>
+                </StackPanel>
+            </HierarchicalDataTemplate>
+
+            <DataTemplate DataType="{x:Type vm:PullRequestFileNode}">
+                <StackPanel Orientation="Horizontal"
+                            Tag="{Binding DataContext, ElementName=root}"
+                            KeyboardNavigation.DirectionalNavigation="None">
+
+                    <!-- 
+                      We need to change the color of the file icon when the file is deleted, but applying the style
+                      to OcticonImage directly borks the designer (see #1410). Work around this by applying the color
+                      to a parent control and let the foreground be inherited by the icon.
+                    -->
+                    <Decorator>
+                        <Decorator.Style>
+                            <Style TargetType="Decorator">
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding Status}" Value="Removed"/>
+                                            <Condition Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type TreeViewItem}}, Path=IsSelected}" Value="False"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="TextBlock.Foreground" Value="{DynamicResource GitHubDeletedFileIconBrush}"/>
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Decorator.Style>
+                        <ui:OcticonImage Icon="file_code" Margin="0,0,0,2"/>
+                    </Decorator>
+
+                    <TextBlock Text="{Binding FileName}" Margin="4 2" VerticalAlignment="Center">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Status}" Value="Removed">
+                                        <Setter Property="TextDecorations" Value="Strikethrough"/>
+                                    </DataTrigger>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding Status}" Value="Removed"/>
+                                            <Condition Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type TreeViewItem}}, Path=IsSelected}" Value="False"/>
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Foreground" Value="{DynamicResource GitHubDeletedFileBrush}"/>
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <TextBlock Text="{Binding StatusDisplay, StringFormat=[{0}]}" VerticalAlignment="Center" Opacity="0.5">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <TextBlock VerticalAlignment="Center" Margin="4 0">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CommentCount}" Value="0">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                        <ui:OcticonImage Icon="comment_discussion" Height="10" Margin="-2 0"/>
+                        <Hyperlink Command="{Binding DataContext.OpenFirstComment, ElementName=root}"
+                                   CommandParameter="{Binding}">
+                            <Run Text="{Binding CommentCount, Mode=OneWay}"/>
+                        </Hyperlink>
+                    </TextBlock>
+                </StackPanel>
+            </DataTemplate>
+        </TreeView.Resources>
+    </TreeView>
+</UserControl>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml.cs
@@ -1,0 +1,87 @@
+﻿using System.ComponentModel.Composition;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using GitHub.Exports;
+using GitHub.UI.Helpers;
+using GitHub.ViewModels.GitHubPane;
+
+namespace GitHub.VisualStudio.Views.GitHubPane
+{
+    [ExportViewFor(typeof(IPullRequestFilesViewModel))]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public partial class PullRequestFilesView : UserControl
+    {
+        public PullRequestFilesView()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnMouseDown(MouseButtonEventArgs e)
+        {
+            base.OnMouseDown(e);
+        }
+
+        void changesTree_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            ApplyContextMenuBinding<TreeViewItem>(sender, e);
+        }
+
+        void changesTree_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            var file = (e.OriginalSource as FrameworkElement)?.DataContext as IPullRequestFileNode;
+            (DataContext as IPullRequestFilesViewModel)?.DiffFile.Execute(file);
+        }
+
+        void changesTree_MouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var item = (e.OriginalSource as Visual)?.GetSelfAndVisualAncestors().OfType<TreeViewItem>().FirstOrDefault();
+
+            if (item != null)
+            {
+                // Select tree view item on right click.
+                item.IsSelected = true;
+            }
+        }
+
+        void ApplyContextMenuBinding<TItem>(object sender, ContextMenuEventArgs e) where TItem : Control
+        {
+            var container = (Control)sender;
+            var item = (e.OriginalSource as Visual)?.GetSelfAndVisualAncestors().OfType<TItem>().FirstOrDefault();
+
+            e.Handled = true;
+
+            if (item != null)
+            {
+                var fileNode = item.DataContext as IPullRequestFileNode;
+
+                if (fileNode != null)
+                {
+                    container.ContextMenu.DataContext = this.DataContext;
+
+                    foreach (var menuItem in container.ContextMenu.Items.OfType<MenuItem>())
+                    {
+                        menuItem.CommandParameter = fileNode;
+                    }
+
+                    e.Handled = false;
+                }
+            }
+        }
+
+        private void changesTree_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Return)
+            {
+                var file = (e.OriginalSource as FrameworkElement)?.DataContext as IPullRequestFileNode;
+
+                if (file != null)
+                {
+                    (DataContext as IPullRequestFilesViewModel)?.DiffFile.Execute(file);
+                }
+            }
+        }
+    }
+}

--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModelTests.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using GitHub.Models;
+using GitHub.Services;
+using GitHub.ViewModels.GitHubPane;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace UnitTests.GitHub.App.ViewModels.GitHubPane
+{
+    public class PullRequestFilesViewModelTests
+    {
+        static readonly Uri Uri = new Uri("http://foo");
+
+        [Test]
+        public async Task ShouldCreateChangesTree()
+        {
+            var target = CreateTarget();
+            var session = CreateSession();
+
+            session.PullRequest.ChangedFiles.Returns(new[]
+            {
+                    new PullRequestFileModel("readme.md", "abc", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/f1.cs", "abc", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/f2.cs", "abc", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir1/dir1a/f3.cs", "abc", PullRequestFileStatus.Modified),
+                    new PullRequestFileModel("dir2/f4.cs", "abc", PullRequestFileStatus.Modified),
+            });
+
+            await target.InitializeAsync(session);
+
+            Assert.That(target.Items.Count, Is.EqualTo(3));
+
+            var dir1 = (PullRequestDirectoryNode)target.Items[0];
+            Assert.That(dir1.DirectoryName, Is.EqualTo("dir1"));
+            Assert.That(dir1.Files, Has.Exactly(2).Items);
+
+            Assert.That(dir1.Directories, Has.One.Items);
+            Assert.That(dir1.Files[0].FileName, Is.EqualTo("f1.cs"));
+            Assert.That(dir1.Files[1].FileName, Is.EqualTo("f2.cs"));
+            Assert.That(dir1.Files[0].RelativePath, Is.EqualTo("dir1\\f1.cs"));
+            Assert.That(dir1.Files[1].RelativePath, Is.EqualTo("dir1\\f2.cs"));
+
+            var dir1a = (PullRequestDirectoryNode)dir1.Directories[0];
+            Assert.That(dir1a.DirectoryName, Is.EqualTo("dir1a"));
+            Assert.That(dir1a.Files, Has.One.Items);
+            Assert.That(dir1a.Directories, Is.Empty);
+
+            var dir2 = (PullRequestDirectoryNode)target.Items[1];
+            Assert.That(dir2.DirectoryName, Is.EqualTo("dir2"));
+            Assert.That(dir2.Files, Has.One.Items);
+            Assert.That(dir2.Directories, Is.Empty);
+
+            var readme = (PullRequestFileNode)target.Items[2];
+            Assert.That(readme.FileName, Is.EqualTo("readme.md"));
+        }
+
+        [Test]
+        public async Task FileCommentCountShouldTrackSessionInlineComments()
+        {
+            var outdatedThread = CreateThread(-1);
+            var session = CreateSession();
+
+            session.PullRequest.ChangedFiles.Returns(new[]
+            {
+                new PullRequestFileModel("readme.md", "abc", PullRequestFileStatus.Modified),
+            });
+
+            var file = Substitute.For<IPullRequestSessionFile>();
+            var thread1 = CreateThread(5);
+            var thread2 = CreateThread(6);
+            file.InlineCommentThreads.Returns(new[] { thread1 });
+            session.GetFile("readme.md").Returns(Task.FromResult(file));
+
+            var target = CreateTarget();
+
+            await target.InitializeAsync(session);
+            Assert.That(((IPullRequestFileNode)target.Items[0]).CommentCount, Is.EqualTo(1));
+
+            file.InlineCommentThreads.Returns(new[] { thread1, thread2 });
+            RaisePropertyChanged(file, nameof(file.InlineCommentThreads));
+            Assert.That(((IPullRequestFileNode)target.Items[0]).CommentCount, Is.EqualTo(2));
+
+            // Outdated comment is not included in the count.
+            file.InlineCommentThreads.Returns(new[] { thread1, thread2, outdatedThread });
+            RaisePropertyChanged(file, nameof(file.InlineCommentThreads));
+            Assert.That(((IPullRequestFileNode)target.Items[0]).CommentCount, Is.EqualTo(2));
+
+            file.Received(1).PropertyChanged += Arg.Any<PropertyChangedEventHandler>();
+        }
+
+        static PullRequestFilesViewModel CreateTarget()
+        {
+            var pullRequestService = Substitute.For<IPullRequestService>();
+            var editorService = Substitute.For<IPullRequestEditorService>();
+            return new PullRequestFilesViewModel(pullRequestService, editorService);
+        }
+
+        static IPullRequestSession CreateSession()
+        {
+            var author = Substitute.For<IAccount>();
+            var pr = Substitute.For<IPullRequestModel>();
+
+            var repository = Substitute.For<ILocalRepositoryModel>();
+            repository.LocalPath.Returns(@"C:\Foo");
+
+            var result = Substitute.For<IPullRequestSession>();
+            result.LocalRepository.Returns(repository);
+            result.PullRequest.Returns(pr);
+            return result;
+        }
+
+        IInlineCommentThreadModel CreateThread(int lineNumber)
+        {
+            var result = Substitute.For<IInlineCommentThreadModel>();
+            result.LineNumber.Returns(lineNumber);
+            return result;
+        }
+
+        void RaisePropertyChanged<T>(T o, string propertyName)
+            where T : INotifyPropertyChanged
+        {
+            o.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/test/UnitTests/GitHub.Exports.Reactive/Services/PullRequestEditorServiceTests.cs
+++ b/test/UnitTests/GitHub.Exports.Reactive/Services/PullRequestEditorServiceTests.cs
@@ -2,6 +2,7 @@
 using GitHub.Services;
 using NUnit.Framework;
 using NSubstitute;
+using Microsoft.VisualStudio.Editor;
 
 public class PullRequestEditorServiceTests
 {
@@ -48,6 +49,15 @@ public class PullRequestEditorServiceTests
     static PullRequestEditorService CreateNavigationService()
     {
         var sp = Substitute.For<IGitHubServiceProvider>();
-        return new PullRequestEditorService(sp);
+        var pullRequestService = Substitute.For<IPullRequestService>();
+        var vsEditorAdaptersFactory = Substitute.For<IVsEditorAdaptersFactoryService>();
+        var statusBar = Substitute.For<IStatusBarNotificationService>();
+        var usageTracker = Substitute.For<IUsageTracker>();
+        return new PullRequestEditorService(
+            sp,
+            pullRequestService,
+            vsEditorAdaptersFactory,
+            statusBar,
+            usageTracker);
     }
 }

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -82,6 +82,10 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.CoreUtility.14.3.25407\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Editor, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Editor.14.3.25407\lib\net45\Microsoft.VisualStudio.Editor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Language.Intellisense.14.3.25407\lib\net45\Microsoft.VisualStudio.Language.Intellisense.dll</HintPath>
       <Private>True</Private>
@@ -240,6 +244,7 @@
     <Compile Include="GitHub.App\Models\RepositoryModelTests.cs" />
     <Compile Include="GitHub.App\Services\AvatarProviderTests.cs" />
     <Compile Include="GitHub.App\Services\GitClientTests.cs" />
+    <Compile Include="GitHub.App\ViewModels\GitHubPane\PullRequestFilesViewModelTests.cs" />
     <Compile Include="GitHub.Exports.Reactive\Services\PullRequestEditorServiceTests.cs" />
     <Compile Include="GitHub.App\Services\OAuthCallbackListenerTests.cs" />
     <Compile Include="GitHub.App\Services\PullRequestServiceTests.cs" />

--- a/test/UnitTests/packages.config
+++ b/test/UnitTests/packages.config
@@ -6,6 +6,7 @@
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.164" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.ComponentModelHost" version="14.0.25424" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="14.3.25407" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Editor" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Language.Intellisense" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.14.0" version="14.3.25407" targetFramework="net461" />


### PR DESCRIPTION
Ported from #1415. Moves the PR details changed files tree into its own view so that it can be shared by the PR review authoring view.

Part of #1491