### PR TITLE
Save the PR list filter settings.

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
@@ -206,6 +206,8 @@ namespace GitHub.ViewModels.GitHubPane
                     (filterTextIsNumber == false || pullRequest.Number == filterPullRequestNumber) &&
                     (filterTextIsString == false || pullRequest.Title.ToUpperInvariant().Contains(filText.ToUpperInvariant()));
             }
+
+            SaveSettings();
         }
 
         string searchQuery;


### PR DESCRIPTION
Somewhere along the line, the call to `SaveSettings` in `UpdateFilter` got removed, causing the filter settings not to get persisted. This reinstates that call.

Fixes #1494