### PR TITLE
Ensure correct ordering of VSGitExt.ActiveRepositoriesChanged.

### DIFF
--- a/src/GitHub.App/Services/TeamExplorerContext.cs
+++ b/src/GitHub.App/Services/TeamExplorerContext.cs
@@ -76,7 +76,7 @@ namespace GitHub.Services
 
                     if (newRepositoryPath != repositoryPath)
                     {
-                        log.Debug("Fire PropertyChanged event for ActiveRepository");
+                        log.Debug("ActiveRepository changed to {CloneUrl} @ {Path}", repo?.CloneUrl, newRepositoryPath);
                         ActiveRepository = repo;
                     }
                     else if (newBranchName != branchName)

--- a/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
@@ -11,11 +11,13 @@ using GitHub.Api;
 using GitHub.Extensions;
 using GitHub.Factories;
 using GitHub.Info;
+using GitHub.Logging;
 using GitHub.Models;
 using GitHub.Primitives;
 using GitHub.Services;
 using GitHub.VisualStudio;
 using ReactiveUI;
+using Serilog;
 using OleMenuCommand = Microsoft.VisualStudio.Shell.OleMenuCommand;
 
 namespace GitHub.ViewModels.GitHubPane
@@ -27,6 +29,7 @@ namespace GitHub.ViewModels.GitHubPane
     [PartCreationPolicy(CreationPolicy.NonShared)]
     public sealed class GitHubPaneViewModel : ViewModelBase, IGitHubPaneViewModel, IDisposable
     {
+        static readonly ILogger log = LogManager.ForContext<GitHubPaneViewModel>();
         static readonly Regex pullUri = CreateRoute("/:owner/:repo/pull/:number");
 
         readonly IViewViewModelFactory viewModelFactory;
@@ -360,6 +363,8 @@ namespace GitHub.ViewModels.GitHubPane
 
         async Task UpdateContent(ILocalRepositoryModel repository)
         {
+            log.Debug("UpdateContent called with {CloneUrl}", repository?.CloneUrl);
+
             LocalRepository = repository;
             Connection = null;
             Content = null;
@@ -367,11 +372,13 @@ namespace GitHub.ViewModels.GitHubPane
 
             if (repository == null)
             {
+                log.Debug("Not a git repository: {CloneUrl}", repository?.CloneUrl);
                 Content = notAGitRepository;
                 return;
             }
             else if (string.IsNullOrWhiteSpace(repository.CloneUrl))
             {
+                log.Debug("Not a GitHub repository: {CloneUrl}", repository?.CloneUrl);
                 Content = notAGitHubRepository;
                 return;
             }
@@ -389,16 +396,19 @@ namespace GitHub.ViewModels.GitHubPane
 
                 if (Connection?.IsLoggedIn == true)
                 {
+                    log.Debug("Found a GitHub repository: {CloneUrl}", repository?.CloneUrl);
                     Content = navigator;
                     await ShowDefaultPage();
                 }
                 else
                 {
+                    log.Debug("Found a a GitHub repository but not logged in: {CloneUrl}", repository?.CloneUrl);
                     Content = loggedOut;
                 }
             }
             else
             {
+                log.Debug("Not a GitHub repository: {CloneUrl}", repository?.CloneUrl);
                 Content = notAGitHubRepository;
             }
         }

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -127,7 +127,7 @@ namespace GitHub.VisualStudio.Base
             {
                 if (value != activeRepositories)
                 {
-                    log.Debug("ActiveRepositories changed to {Repositories}", value.Select(x => x.CloneUrl));
+                    log.Debug("ActiveRepositories changed to {Repositories}", value?.Select(x => x.CloneUrl));
                     activeRepositories = value;
                     ActiveRepositoriesChanged?.Invoke();
                 }

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -24,6 +24,7 @@ namespace GitHub.VisualStudio.Base
         readonly IGitHubServiceProvider serviceProvider;
         readonly IVSUIContext context;
         readonly ILocalRepositoryModelFactory repositoryFactory;
+        readonly object refreshLock = new object();
 
         IGitExt gitService;
         IReadOnlyList<ILocalRepositoryModel> activeRepositories;
@@ -98,12 +99,15 @@ namespace GitHub.VisualStudio.Base
         {
             try
             {
-                log.Debug(
-                    "IGitExt.ActiveRepositories (#{Id}) returned {Repositories}",
-                    gitService.GetHashCode(),
-                    gitService?.ActiveRepositories.Select(x => x.RepositoryPath));
+                lock (refreshLock)
+                {
+                    log.Debug(
+                        "IGitExt.ActiveRepositories (#{Id}) returned {Repositories}",
+                        gitService.GetHashCode(),
+                        gitService?.ActiveRepositories.Select(x => x.RepositoryPath));
 
-                ActiveRepositories = gitService?.ActiveRepositories.Select(x => repositoryFactory.Create(x.RepositoryPath)).ToList();
+                    ActiveRepositories = gitService?.ActiveRepositories.Select(x => repositoryFactory.Create(x.RepositoryPath)).ToList();
+                }
             }
             catch (Exception e)
             {

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -98,6 +98,11 @@ namespace GitHub.VisualStudio.Base
         {
             try
             {
+                log.Debug(
+                    "IGitExt.ActiveRepositories (#{Id}) returned {Repositories}",
+                    gitService.GetHashCode(),
+                    gitService?.ActiveRepositories.Select(x => x.RepositoryPath));
+
                 ActiveRepositories = gitService?.ActiveRepositories.Select(x => repositoryFactory.Create(x.RepositoryPath)).ToList();
             }
             catch (Exception e)
@@ -118,6 +123,7 @@ namespace GitHub.VisualStudio.Base
             {
                 if (value != activeRepositories)
                 {
+                    log.Debug("ActiveRepositories changed to {Repositories}", value.Select(x => x.CloneUrl));
                     activeRepositories = value;
                     ActiveRepositoriesChanged?.Invoke();
                 }

--- a/test/UnitTests/GitHub.TeamFoundation/VSGitExtTests.cs
+++ b/test/UnitTests/GitHub.TeamFoundation/VSGitExtTests.cs
@@ -9,6 +9,9 @@ using GitHub.VisualStudio.Base;
 using NUnit.Framework;
 using NSubstitute;
 using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
+using System.Threading.Tasks;
+using System.Linq;
+using GitHub.TeamFoundation.Services;
 
 public class VSGitExtTests
 {
@@ -171,9 +174,32 @@ public class VSGitExtTests
             repoFactory.Received(1).Create(repoPath);
             Assert.That(activeRepositories.Count, Is.EqualTo(0));
         }
+
+        [Test]
+        public async Task ThreadingStressTest()
+        {
+            for (var i = 0; i < 100; ++i)
+            {
+                var gitExt = new MockGitExt();
+                var repoFactory = new MockRepositoryFactory();
+                var target = CreateVSGitExt(gitExt: gitExt, repoFactory: repoFactory);
+                var activeRepositories1 = CreateActiveRepositories("repo1");
+                var activeRepositories2 = CreateActiveRepositories("repo2");
+                var task1 = Task.Run(() => gitExt.ActiveRepositories = activeRepositories1);
+                await Task.Delay(1);
+                var task2 = Task.Run(() => gitExt.ActiveRepositories = activeRepositories2);
+
+                await Task.WhenAll(task1, task2);
+
+                Assert.That(
+                    target.ActiveRepositories.Single().LocalPath,
+                    Is.EqualTo("repo2"),
+                    $"Failed at iteration {i}");
+            }
+        }
     }
 
-    static IReadOnlyList<IGitRepositoryInfo> CreateActiveRepositories(IList<string> repositoryPaths)
+    static IReadOnlyList<IGitRepositoryInfo> CreateActiveRepositories(params string[] repositoryPaths)
     {
         var repositories = new List<IGitRepositoryInfo>();
         foreach (var repositoryPath in repositoryPaths)
@@ -203,9 +229,8 @@ public class VSGitExtTests
         return vsGitExt;
     }
 
-    static IGitExt CreateGitExt(IList<string> repositoryPaths = null)
+    static IGitExt CreateGitExt(params string[] repositoryPaths)
     {
-        repositoryPaths = repositoryPaths ?? Array.Empty<string>();
         var gitExt = Substitute.For<IGitExt>();
         var repoList = CreateActiveRepositories(repositoryPaths);
         gitExt.ActiveRepositories.Returns(repoList);
@@ -217,5 +242,35 @@ public class VSGitExtTests
         var context = Substitute.For<IVSUIContext>();
         context.IsActive.Returns(isActive);
         return context;
+    }
+
+    class MockGitExt : IGitExt
+    {
+        IReadOnlyList<IGitRepositoryInfo> activeRepositories = new IGitRepositoryInfo[0];
+
+        public IReadOnlyList<IGitRepositoryInfo> ActiveRepositories
+        {
+            get { return activeRepositories; }
+            set
+            {
+                if (activeRepositories != value)
+                {
+                    activeRepositories = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ActiveRepositories)));
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+    }
+
+    class MockRepositoryFactory : ILocalRepositoryModelFactory
+    {
+        public ILocalRepositoryModel Create(string localPath)
+        {
+            var result = Substitute.For<ILocalRepositoryModel>();
+            result.LocalPath.Returns(localPath);
+            return result;
+        }
     }
 }


### PR DESCRIPTION
Wait on a lock in `VSGitExt.RefreshActiveRepositories` so that `ActiveRepositoriesChanged` notifications are raised in the correct order.

Also added a unit test that demonstrated the failure before the fix.

Fixes #1493 
