### PR TITLE
Use GraphQL in ModelService to read PR reviews/comments.

### DIFF
--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -46,6 +46,18 @@
   </PropertyGroup>
   <Import Project="$(SolutionDir)\src\common\signing.props" />
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Octokit.GraphQL, Version=0.0.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Octokit.GraphQL.0.0.1\lib\netstandard1.1\Octokit.GraphQL.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Octokit.GraphQL.Core, Version=0.0.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Octokit.GraphQL.0.0.1\lib\netstandard1.1\Octokit.GraphQL.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.5.0\lib\net46\Serilog.dll</HintPath>
       <Private>True</Private>
@@ -66,6 +78,9 @@
       <Link>ApiClientConfiguration_User.cs</Link>
     </Compile>
     <Compile Include="ApiClientConfiguration_User.cs" Condition="$(Buildtype) != 'Internal'" />
+    <Compile Include="GraphQLKeychainCredentialStore.cs" />
+    <Compile Include="IGraphQLClientFactory.cs" />
+    <Compile Include="GraphQLClientFactory.cs" />
     <Compile Include="IKeychain.cs" />
     <Compile Include="ILoginManager.cs" />
     <Compile Include="IOAuthCallbackListener.cs" />

--- a/src/GitHub.Api/GraphQLClientFactory.cs
+++ b/src/GitHub.Api/GraphQLClientFactory.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using GitHub.Models;
+using GitHub.Primitives;
+using Octokit.GraphQL;
+
+namespace GitHub.Api
+{
+    /// <summary>
+    /// Creates GraphQL <see cref="Octokit.GraphQL.IConnection"/>s for querying the
+    /// GitHub GraphQL API.
+    /// </summary>
+    [Export(typeof(IGraphQLClientFactory))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class GraphQLClientFactory : IGraphQLClientFactory
+    {
+        readonly IKeychain keychain;
+        readonly IProgram program;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GraphQLClientFactory"/> class.
+        /// </summary>
+        /// <param name="keychain">The <see cref="IKeychain"/> to use.</param>
+        /// <param name="program">The program details.</param>
+        [ImportingConstructor]
+        public GraphQLClientFactory(IKeychain keychain, IProgram program)
+        {
+            this.keychain = keychain;
+            this.program = program;
+        }
+
+        /// <inheirtdoc/>
+        public Task<Octokit.GraphQL.IConnection> CreateConnection(HostAddress address)
+        {
+            var credentials = new GraphQLKeychainCredentialStore(keychain, address);
+            var header = new ProductHeaderValue(program.ProductHeader.Name, program.ProductHeader.Version);
+            return Task.FromResult<Octokit.GraphQL.IConnection>(new Connection(header, credentials));
+        }
+    }
+}

--- a/src/GitHub.Api/GraphQLKeychainCredentialStore.cs
+++ b/src/GitHub.Api/GraphQLKeychainCredentialStore.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading.Tasks;
+using GitHub.Extensions;
+using GitHub.Primitives;
+using Octokit.GraphQL;
+
+namespace GitHub.Api
+{
+    /// <summary>
+    /// An Octokit.GraphQL credential store that reads from an <see cref="IKeychain"/>.
+    /// </summary>
+    public class GraphQLKeychainCredentialStore : ICredentialStore
+    {
+        readonly IKeychain keychain;
+        readonly HostAddress address;
+
+        public GraphQLKeychainCredentialStore(IKeychain keychain, HostAddress address)
+        {
+            Guard.ArgumentNotNull(keychain, nameof(keychain));
+            Guard.ArgumentNotNull(address, nameof(keychain));
+
+            this.keychain = keychain;
+            this.address = address;
+        }
+
+        public async Task<string> GetCredentials()
+        {
+            var userPass = await keychain.Load(address).ConfigureAwait(false);
+            return userPass?.Item2;
+        }
+    }
+}

--- a/src/GitHub.Api/IGraphQLClientFactory.cs
+++ b/src/GitHub.Api/IGraphQLClientFactory.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using GitHub.Primitives;
+
+namespace GitHub.Api
+{
+    /// <summary>
+    /// Creates GraphQL <see cref="Octokit.GraphQL.IConnection"/>s for querying the
+    /// GitHub GraphQL API.
+    /// </summary>
+    public interface IGraphQLClientFactory
+    {
+        /// <summary>
+        /// Creates a new <see cref="Octokit.GraphQL.IConnection"/>.
+        /// </summary>
+        /// <param name="address">The address of the server.</param>
+        /// <returns>A task returning the created connection.</returns>
+        Task<Octokit.GraphQL.IConnection> CreateConnection(HostAddress address);
+    }
+}

--- a/src/GitHub.Api/packages.config
+++ b/src/GitHub.Api/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
+  <package id="Octokit.GraphQL" version="0.0.1" targetFramework="net461" />
   <package id="Serilog" version="2.5.0" targetFramework="net461" />
 </packages>

--- a/src/GitHub.App/Factories/ModelServiceFactory.cs
+++ b/src/GitHub.App/Factories/ModelServiceFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
+using GitHub.Api;
 using GitHub.Caches;
 using GitHub.Models;
 using GitHub.Services;
@@ -15,6 +16,7 @@ namespace GitHub.Factories
     public sealed class ModelServiceFactory : IModelServiceFactory, IDisposable
     {
         readonly IApiClientFactory apiClientFactory;
+        readonly IGraphQLClientFactory graphQLClientFactory;
         readonly IHostCacheFactory hostCacheFactory;
         readonly IAvatarProvider avatarProvider;
         readonly Dictionary<IConnection, ModelService> cache = new Dictionary<IConnection, ModelService>();
@@ -23,10 +25,12 @@ namespace GitHub.Factories
         [ImportingConstructor]
         public ModelServiceFactory(
             IApiClientFactory apiClientFactory,
+            IGraphQLClientFactory graphQLClientFactory,
             IHostCacheFactory hostCacheFactory,
             IAvatarProvider avatarProvider)
         {
             this.apiClientFactory = apiClientFactory;
+            this.graphQLClientFactory = graphQLClientFactory;
             this.hostCacheFactory = hostCacheFactory;
             this.avatarProvider = avatarProvider;
         }
@@ -43,6 +47,7 @@ namespace GitHub.Factories
                 {
                     result = new ModelService(
                         await apiClientFactory.Create(connection.HostAddress),
+                        await graphQLClientFactory.CreateConnection(connection.HostAddress),
                         await hostCacheFactory.Create(connection.HostAddress),
                         avatarProvider);
                     result.InsertUser(AccountCacheItem.Create(connection.User));

--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -89,10 +89,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.14.1.131\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Octokit.GraphQL, Version=0.0.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Octokit.GraphQL.0.0.1\lib\netstandard1.1\Octokit.GraphQL.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Octokit.GraphQL.Core, Version=0.0.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Octokit.GraphQL.0.0.1\lib\netstandard1.1\Octokit.GraphQL.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -152,6 +159,7 @@
     <Compile Include="Models\IssueCommentModel.cs" />
     <Compile Include="Models\PullRequestReviewCommentModel.cs" />
     <Compile Include="Models\PullRequestDetailArgument.cs" />
+    <Compile Include="Models\PullRequestReviewModel.cs" />
     <Compile Include="Services\EnterpriseCapabilitiesService.cs" />
     <Compile Include="Services\GlobalConnection.cs" />
     <Compile Include="Services\PullRequestEditorService.cs" />

--- a/src/GitHub.App/Models/Account.cs
+++ b/src/GitHub.App/Models/Account.cs
@@ -23,6 +23,7 @@ namespace GitHub.Models
             bool isEnterprise,
             int ownedPrivateRepositoryCount,
             long privateRepositoryInPlanCount,
+            string avatarUrl,
             IObservable<BitmapSource> bitmapSource)
         {
             Guard.ArgumentNotEmptyString(login, nameof(login));
@@ -34,6 +35,7 @@ namespace GitHub.Models
             PrivateReposInPlan = privateRepositoryInPlanCount;
             IsOnFreePlan = privateRepositoryInPlanCount == 0;
             HasMaximumPrivateRepositories = OwnedPrivateRepos >= PrivateReposInPlan;
+            AvatarUrl = avatarUrl;
             this.bitmapSource = bitmapSource;
 
             bitmapSourceSubscription = bitmapSource
@@ -54,6 +56,7 @@ namespace GitHub.Models
             OwnedPrivateRepos = account.OwnedPrivateRepos;
             IsOnFreePlan = PrivateReposInPlan == 0;
             HasMaximumPrivateRepositories = OwnedPrivateRepos >= PrivateReposInPlan;
+            AvatarUrl = account.AvatarUrl;
         }
 
         public Account(Octokit.Account account, IObservable<BitmapSource> bitmapSource)
@@ -77,13 +80,15 @@ namespace GitHub.Models
 
         public long PrivateReposInPlan { get; private set; }
 
+        public string AvatarUrl { get; private set; }
+
         public BitmapSource Avatar
         {
             get { return avatar; }
             set { avatar = value; this.RaisePropertyChanged(); }
         }
 
-#region Equality things
+        #region Equality things
         public void CopyFrom(IAccount other)
         {
             if (!Equals(other))
@@ -115,7 +120,7 @@ namespace GitHub.Models
 
         public override int GetHashCode()
         {
-            return (Login?.GetHashCode() ?? 0) ^ IsUser .GetHashCode() ^ IsEnterprise.GetHashCode();
+            return (Login?.GetHashCode() ?? 0) ^ IsUser.GetHashCode() ^ IsEnterprise.GetHashCode();
         }
 
         bool IEquatable<IAccount>.Equals(IAccount other)

--- a/src/GitHub.App/Models/IssueCommentModel.cs
+++ b/src/GitHub.App/Models/IssueCommentModel.cs
@@ -4,8 +4,9 @@ namespace GitHub.Models
 {
     public class IssueCommentModel : ICommentModel
     {
-        public string Body { get; set; }
         public int Id { get; set; }
+        public string NodeId { get; set; }
+        public string Body { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
         public IAccount User { get; set; }
     }

--- a/src/GitHub.App/Models/PullRequestModel.cs
+++ b/src/GitHub.App/Models/PullRequestModel.cs
@@ -162,11 +162,23 @@ namespace GitHub.Models
         public DateTimeOffset CreatedAt { get; set; }
         public DateTimeOffset UpdatedAt { get; set; }
         public IAccount Author { get; set; }
-        public IReadOnlyCollection<IPullRequestFileModel> ChangedFiles { get; set; } = new IPullRequestFileModel[0];
-        public IReadOnlyCollection<ICommentModel> Comments { get; set; } = new ICommentModel[0];
+        public IReadOnlyList<IPullRequestFileModel> ChangedFiles { get; set; } = new IPullRequestFileModel[0];
+        public IReadOnlyList<ICommentModel> Comments { get; set; } = new ICommentModel[0];
 
-        IReadOnlyCollection<IPullRequestReviewCommentModel> reviewComments = new IPullRequestReviewCommentModel[0];
-        public IReadOnlyCollection<IPullRequestReviewCommentModel> ReviewComments
+        IReadOnlyList<IPullRequestReviewModel> reviews = new IPullRequestReviewModel[0];
+        public IReadOnlyList<IPullRequestReviewModel> Reviews
+        {
+            get { return reviews; }
+            set
+            {
+                Guard.ArgumentNotNull(value, nameof(value));
+                reviews = value;
+                this.RaisePropertyChange();
+            }
+        }
+
+        IReadOnlyList<IPullRequestReviewCommentModel> reviewComments = new IPullRequestReviewCommentModel[0];
+        public IReadOnlyList<IPullRequestReviewCommentModel> ReviewComments
         {
             get { return reviewComments; }
             set

--- a/src/GitHub.App/Models/PullRequestReviewCommentModel.cs
+++ b/src/GitHub.App/Models/PullRequestReviewCommentModel.cs
@@ -5,6 +5,8 @@ namespace GitHub.Models
     public class PullRequestReviewCommentModel : IPullRequestReviewCommentModel
     {
         public int Id { get; set; }
+        public string NodeId { get; set; }
+        public int PullRequestReviewId { get; set; }
         public string Path { get; set; }
         public int? Position { get; set; }
         public int? OriginalPosition { get; set; }
@@ -14,5 +16,6 @@ namespace GitHub.Models
         public IAccount User { get; set; }
         public string Body { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
+        public bool IsPending { get; set; }
     }
 }

--- a/src/GitHub.App/Models/PullRequestReviewModel.cs
+++ b/src/GitHub.App/Models/PullRequestReviewModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace GitHub.Models
+{
+    public class PullRequestReviewModel : IPullRequestReviewModel
+    {
+        public long Id { get; set; }
+        public string NodeId { get; set; }
+        public IAccount User { get; set; }
+        public string Body { get; set; }
+        public PullRequestReviewState State { get; set; }
+        public string CommitId { get; set; }
+    }
+}

--- a/src/GitHub.App/SampleData/AccountDesigner.cs
+++ b/src/GitHub.App/SampleData/AccountDesigner.cs
@@ -32,6 +32,7 @@ namespace GitHub.SampleData
         public string Login { get; set; }
         public int OwnedPrivateRepos { get; set; }
         public long PrivateReposInPlan { get; set; }
+        public string AvatarUrl { get; set; }
 
         public override string ToString()
         {

--- a/src/GitHub.App/Services/AvatarProvider.cs
+++ b/src/GitHub.App/Services/AvatarProvider.cs
@@ -70,6 +70,21 @@ namespace GitHub.Services
                 .Catch<BitmapSource, Exception>(_ => Observable.Return(DefaultAvatar(apiAccount)));
         }
 
+        public IObservable<BitmapSource> GetAvatar(string url)
+        {
+            if (url == null)
+            {
+                return Observable.Return(DefaultUserBitmapImage);
+            }
+
+            Uri avatarUrl;
+            Uri.TryCreate(url, UriKind.Absolute, out avatarUrl);
+            Log.Assert(avatarUrl != null, "Cannot have a null avatar url");
+
+            return imageCache.GetImage(avatarUrl)
+                .Catch<BitmapSource, Exception>(_ => Observable.Return(DefaultUserBitmapImage));
+        }
+
         public IObservable<Unit> InvalidateAvatar(IAvatarContainer apiAccount)
         {
             return String.IsNullOrWhiteSpace(apiAccount?.Login)

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
@@ -285,7 +285,7 @@ namespace GitHub.ViewModels.GitHubPane
             set { this.RaiseAndSetIfChanged(ref selectedAssignee, value); }
         }
 
-        IAccount emptyUser = new Account("[None]", false, false, 0, 0, Observable.Empty<BitmapSource>());
+        IAccount emptyUser = new Account("[None]", false, false, 0, 0, string.Empty, Observable.Empty<BitmapSource>());
         public IAccount EmptyUser
         {
             get { return emptyUser; }

--- a/src/GitHub.App/packages.config
+++ b/src/GitHub.App/packages.config
@@ -9,7 +9,8 @@
   <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
+  <package id="Octokit.GraphQL" version="0.0.1" targetFramework="net461" />
   <package id="Rothko" version="0.0.3-ghfvs" targetFramework="net461" />
   <package id="Rx-Core" version="2.2.5-custom" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5-custom" targetFramework="net45" />

--- a/src/GitHub.Exports.Reactive/Services/IAvatarProvider.cs
+++ b/src/GitHub.Exports.Reactive/Services/IAvatarProvider.cs
@@ -10,6 +10,7 @@ namespace GitHub.Services
         BitmapImage DefaultUserBitmapImage { get; }
         BitmapImage DefaultOrgBitmapImage { get; }
         IObservable<BitmapSource> GetAvatar(IAvatarContainer account);
+        IObservable<BitmapSource> GetAvatar(string avatarUri);
         IObservable<Unit> InvalidateAvatar(IAvatarContainer account);
     }
 }

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Models\IInlineCommentModel.cs" />
     <Compile Include="Models\ILocalRepositoryModelFactory.cs" />
     <Compile Include="Models\IPullRequestReviewCommentModel.cs" />
+    <Compile Include="Models\IPullRequestReviewModel.cs" />
     <Compile Include="Services\IEnterpriseCapabilitiesService.cs" />
     <Compile Include="Services\IGlobalConnection.cs" />
     <Compile Include="Services\ILocalRepositories.cs" />

--- a/src/GitHub.Exports/Models/IAccount.cs
+++ b/src/GitHub.Exports/Models/IAccount.cs
@@ -14,6 +14,7 @@ namespace GitHub.Models
         string Login { get; }
         int OwnedPrivateRepos { get; }
         long PrivateReposInPlan { get; }
-        BitmapSource Avatar { get; } 
+        string AvatarUrl { get; }
+        BitmapSource Avatar { get; }
     }
 }

--- a/src/GitHub.Exports/Models/ICommentModel.cs
+++ b/src/GitHub.Exports/Models/ICommentModel.cs
@@ -13,6 +13,11 @@ namespace GitHub.Models
         int Id { get; }
 
         /// <summary>
+        /// Gets the GraphQL ID of the comment.
+        /// </summary>
+        string NodeId { get; }
+
+        /// <summary>
         /// Gets the author of the comment.
         /// </summary>
         IAccount User { get; }

--- a/src/GitHub.Exports/Models/IPullRequestModel.cs
+++ b/src/GitHub.Exports/Models/IPullRequestModel.cs
@@ -31,8 +31,9 @@ namespace GitHub.Models
         DateTimeOffset UpdatedAt { get; }
         IAccount Author { get; }
         IAccount Assignee { get; }
-        IReadOnlyCollection<IPullRequestFileModel> ChangedFiles { get; }
-        IReadOnlyCollection<ICommentModel> Comments { get; }
-        IReadOnlyCollection<IPullRequestReviewCommentModel> ReviewComments { get; set; }
+        IReadOnlyList<IPullRequestFileModel> ChangedFiles { get; }
+        IReadOnlyList<ICommentModel> Comments { get; }
+        IReadOnlyList<IPullRequestReviewModel> Reviews { get; set; }
+        IReadOnlyList<IPullRequestReviewCommentModel> ReviewComments { get; set; }
     }
 }

--- a/src/GitHub.Exports/Models/IPullRequestReviewCommentModel.cs
+++ b/src/GitHub.Exports/Models/IPullRequestReviewCommentModel.cs
@@ -8,6 +8,11 @@ namespace GitHub.Models
     public interface IPullRequestReviewCommentModel : ICommentModel
     {
         /// <summary>
+        /// Gets the ID of the related pull request review.
+        /// </summary>
+        int PullRequestReviewId { get; set; }
+
+        /// <summary>
         /// The relative path to the file that the comment was made on.
         /// </summary>
         string Path { get; }
@@ -38,5 +43,10 @@ namespace GitHub.Models
         /// The diff hunk used to match the pull request.
         /// </summary>
         string DiffHunk { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the comment is part of a pending review.
+        /// </summary>
+        bool IsPending { get; }
     }
 }

--- a/src/GitHub.Exports/Models/IPullRequestReviewModel.cs
+++ b/src/GitHub.Exports/Models/IPullRequestReviewModel.cs
@@ -1,0 +1,71 @@
+﻿using System;
+
+namespace GitHub.Models
+{
+    /// <summary>
+    /// The possible states of a pull request review.
+    /// </summary>
+    public enum PullRequestReviewState
+    {
+        /// <summary>
+        /// A review that has not yet been submitted.
+        /// </summary>
+        Pending,
+
+        /// <summary>
+        /// An informational review.
+        /// </summary>
+        Commented,
+
+        /// <summary>
+        /// A review allowing the pull request to merge.
+        /// </summary>
+        Approved,
+
+        /// <summary>
+        /// A review blocking the pull request from merging.
+        /// </summary>
+        ChangesRequested,
+
+        /// <summary>
+        /// A review that has been dismissed.
+        /// </summary>
+        Dismissed,
+    }
+
+    /// <summary>
+    /// Represents a review of a pull request.
+    /// </summary>
+    public interface IPullRequestReviewModel
+    {
+        /// <summary>
+        /// Gets the ID of the review.
+        /// </summary>
+        long Id { get; }
+
+        /// <summary>
+        /// Gets the GraphQL ID for the review.
+        /// </summary>
+        string NodeId { get; set; }
+
+        /// <summary>
+        /// Gets the author of the review.
+        /// </summary>
+        IAccount User { get; }
+
+        /// <summary>
+        /// Gets the body of the review.
+        /// </summary>
+        string Body { get; }
+
+        /// <summary>
+        /// Gets the state of the review.
+        /// </summary>
+        PullRequestReviewState State { get; }
+
+        /// <summary>
+        /// Gets the SHA of the commit that the review was submitted on.
+        /// </summary>
+        string CommitId { get; }
+    }
+}

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -235,8 +235,16 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Octokit.GraphQL, Version=0.0.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Octokit.GraphQL.0.0.1\lib\netstandard1.1\Octokit.GraphQL.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Octokit.GraphQL.Core, Version=0.0.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Octokit.GraphQL.0.0.1\lib\netstandard1.1\Octokit.GraphQL.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="rothko, Version=0.0.3.0, Culture=neutral, PublicKeyToken=9f664c41f503810a, processorArchitecture=MSIL">

--- a/src/GitHub.VisualStudio/Properties/AssemblyInfo.cs
+++ b/src/GitHub.VisualStudio/Properties/AssemblyInfo.cs
@@ -19,6 +19,8 @@ using Microsoft.VisualStudio.Shell;
     OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = AssemblyVersionInformation.Version)]
 
 [assembly: ProvideCodeBase(AssemblyName = "Octokit", CodeBase = @"$PackageFolder$\Octokit.dll")]
+[assembly: ProvideCodeBase(AssemblyName = "Octokit.GraphQL", CodeBase = @"$PackageFolder$\Octokit.GraphQL.dll")]
+[assembly: ProvideCodeBase(AssemblyName = "Octokit.GraphQL.Core", CodeBase = @"$PackageFolder$\Octokit.GraphQL.Core.dll")]
 [assembly: ProvideCodeBase(AssemblyName = "LibGit2Sharp", CodeBase = @"$PackageFolder$\LibGit2Sharp.dll")]
 [assembly: ProvideCodeBase(AssemblyName = "Splat", CodeBase = @"$PackageFolder$\Splat.dll")]
 [assembly: ProvideCodeBase(AssemblyName = "Rothko", CodeBase = @"$PackageFolder$\Rothko.dll")]
@@ -27,3 +29,4 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(AssemblyName = "Serilog.Sinks.File", CodeBase = @"$PackageFolder$\Serilog.Sinks.File.dll")]
 [assembly: ProvideCodeBase(AssemblyName = "Markdig", CodeBase = @"$PackageFolder$\Markdig.dll")]
 [assembly: ProvideCodeBase(AssemblyName = "Markdig.Wpf", CodeBase = @"$PackageFolder$\Markdig.Wpf.dll")]
+[assembly: ProvideCodeBase(AssemblyName = "Newtonsoft.Json", CodeBase = @"$PackageFolder$\Newtonsoft.Json.dll")]

--- a/src/GitHub.VisualStudio/packages.config
+++ b/src/GitHub.VisualStudio/packages.config
@@ -34,7 +34,8 @@
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net461" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.VSSDK.Vsixsigntool" version="14.1.24720" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
+  <package id="Octokit.GraphQL" version="0.0.1" targetFramework="net461" />
   <package id="Rothko" version="0.0.3-ghfvs" targetFramework="net461" />
   <package id="Rx-Core" version="2.2.5-custom" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5-custom" targetFramework="net45" />

--- a/test/UnitTests/GitHub.App/Factories/ModelServiceFactoryTests.cs
+++ b/test/UnitTests/GitHub.App/Factories/ModelServiceFactoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using GitHub.Api;
 using GitHub.Caches;
 using GitHub.Extensions;
 using GitHub.Factories;
@@ -63,12 +64,14 @@ namespace UnitTests.GitHub.App.Factories
             IHostCacheFactory hostCacheFactory = null)
         {
             var apiClientFactory = Substitute.For<IApiClientFactory>();
+            var graphQLClientFactory = Substitute.For<IGraphQLClientFactory>();
             var avatarProvider = Substitute.For<IAvatarProvider>();
 
             hostCacheFactory = hostCacheFactory ?? Substitute.For<IHostCacheFactory>();
 
             return new ModelServiceFactory(
                 apiClientFactory,
+                graphQLClientFactory,
                 hostCacheFactory,
                 avatarProvider);
         }

--- a/test/UnitTests/GitHub.App/Models/AccountModelTests.cs
+++ b/test/UnitTests/GitHub.App/Models/AccountModelTests.cs
@@ -30,7 +30,7 @@ namespace UnitTests.GitHub.App.Models
             const string login = "foo";
             const int initialOwnedPrivateRepositoryCount = 1;
 
-            var initialAccount = new Account(login, true, false, initialOwnedPrivateRepositoryCount, 0, initialBitmapImageSubject);
+            var initialAccount = new Account(login, true, false, initialOwnedPrivateRepositoryCount, 0, null, initialBitmapImageSubject);
 
             //Creating the test collection
             var col = new TrackingCollection<IAccount>(Observable.Empty<IAccount>(), OrderedComparer<IAccount>.OrderByDescending(x => x.Login).Compare);
@@ -78,7 +78,7 @@ namespace UnitTests.GitHub.App.Models
             //Creating an account update
             const int updatedOwnedPrivateRepositoryCount = 2;
             var updatedBitmapImageSubject = new Subject<BitmapImage>();
-            var updatedAccount = new Account(login, true, false, updatedOwnedPrivateRepositoryCount, 0, updatedBitmapImageSubject);
+            var updatedAccount = new Account(login, true, false, updatedOwnedPrivateRepositoryCount, 0, null, updatedBitmapImageSubject);
 
             //Updating the account in the collection
             col.AddItem(updatedAccount);
@@ -119,13 +119,26 @@ namespace UnitTests.GitHub.App.Models
 
         public static byte[] BitmapSourceToBytes(BitmapSource image)
         {
-            var encoder = new BmpBitmapEncoder();
-            encoder.Frames.Add(BitmapFrame.Create(image));
-            using (MemoryStream ms = new MemoryStream())
+            byte[] data = new byte[] { };
+            if (image != null)
             {
-                encoder.Save(ms);
-                return ms.ToArray();
+                try
+                {
+                    var encoder = new BmpBitmapEncoder();
+                    encoder.Frames.Add(BitmapFrame.Create(image));
+                    using (MemoryStream ms = new MemoryStream())
+                    {
+                        encoder.Save(ms);
+                        data = ms.ToArray();
+                    }
+                    return data;
+                }
+                catch (Exception ex)
+                {
+                }
             }
+
+            return data;
         }
     }
 }

--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModelTests.cs
@@ -126,9 +126,9 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
             var pullRequest = new PullRequestModel(
                 1,
                 "PR1",
-                new Account("foo", true, false, 1, 0, bitmapSource),
+                new Account("foo", true, false, 1, 0, null, bitmapSource),
                 DateTimeOffset.MinValue);
-            pullRequest.Assignee = new Account("foo", true, false, 1, 0, bitmapSource);
+            pullRequest.Assignee = new Account("foo", true, false, 1, 0, null, bitmapSource);
 
             var pullRequestCollection = Substitute.For<ITrackingCollection<IPullRequestModel>>();
             pullRequestCollection[0].Returns(pullRequest);

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -158,12 +158,24 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Octokit.GraphQL, Version=0.0.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Octokit.GraphQL.0.0.1\lib\netstandard1.1\Octokit.GraphQL.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Octokit.GraphQL.Core, Version=0.0.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Octokit.GraphQL.0.0.1\lib\netstandard1.1\Octokit.GraphQL.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/test/UnitTests/packages.config
+++ b/test/UnitTests/packages.config
@@ -24,10 +24,12 @@
   <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net461" />
   <package id="NUnit" version="3.9.0" targetFramework="net461" />
   <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net461" />
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net461" />
+  <package id="Octokit.GraphQL" version="0.0.1" targetFramework="net461" />
   <package id="Rothko" version="0.0.3-ghfvs" targetFramework="net461" />
   <package id="Rx-Core" version="2.2.5-custom" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5-custom" targetFramework="net45" />


### PR DESCRIPTION
Ported from #1415.

The REST API filters out pending reviews when reading PR reviews/review comments, making it unusable for the PR reviews feature. This PR updates `ModelService` to take a GraphQL `IConnection` and uses that to read PR review comments from the GraphQL API, and in addition reads the related PR reviews too.

This is integrated a bit hackily into `ModelService`; `ModelService` doesn't really mesh well with GraphQL, and our existing models are a bit of a strange fit for the (more logical) way that GraphQL uses nested models to represent relationships. However, without a lot of refactoring this was the best way to get things up and running, and more importantly I don't really have a good feel yet as to _how_ we should structure things with GraphQL. As we hopefully move more things to GraphQL in the coming months we should start to get a feel for that.

(As a side note, take a look at how much code is required to do nested paging in GraphQL - I think making this work by default in Ocotokit.GraphQL will be a big deal)

Part of #1491