### PR TITLE
Allow VSGitExt to be constructed and subscribed to from background thread

### DIFF
--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -99,10 +99,7 @@ namespace GitHub.VisualStudio.Base
 
         async Task<bool> TryInitialize()
         {
-            // GetService must be called on the Main thread.
-            await ThreadingHelper.SwitchToMainThreadAsync();
-
-            gitService = serviceProvider.GetService<IGitExt>();
+            gitService = await GetServiceAsync<IGitExt>();
             if (gitService != null)
             {
                 gitService.PropertyChanged += (s, e) =>
@@ -123,6 +120,13 @@ namespace GitHub.VisualStudio.Base
 
             log.Error("Couldn't find IGitExt service");
             return false;
+        }
+
+        async Task<T> GetServiceAsync<T>() where T : class
+        {
+            // GetService must be called from the Main thread.
+            await ThreadingHelper.SwitchToMainThreadAsync();
+            return serviceProvider.GetService<T>();
         }
 
         void RefreshActiveRepositories()

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -18,7 +18,7 @@ namespace GitHub.VisualStudio.Base
     /// </summary>
     /// <remarks>
     /// Initialization for this service will be done asynchronously and the <see cref="IGitExt" /> service will be
-    /// retrieved on the Main thread. This means the service to be constructed and subscribed to on a background thread.
+    /// retrieved on the Main thread. This means the service can be constructed and subscribed to on a background thread.
     /// </remarks>
     [Export(typeof(IVSGitExt))]
     [PartCreationPolicy(CreationPolicy.Shared)]

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -16,6 +16,10 @@ namespace GitHub.VisualStudio.Base
     /// <summary>
     /// This service acts as an always available version of <see cref="IGitExt"/>.
     /// </summary>
+    /// <remarks>
+    /// Initialization for this service will be done asynchronously and the <see cref="IGitExt" /> service will be
+    /// retrieved on the Main thread. This means the service to be constructed and subscribed to on a background thread.
+    /// </remarks>
     [Export(typeof(IVSGitExt))]
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class VSGitExt : IVSGitExt

--- a/test/UnitTests/GitHub.TeamFoundation/VSGitExtTests.cs
+++ b/test/UnitTests/GitHub.TeamFoundation/VSGitExtTests.cs
@@ -11,11 +11,10 @@ using NSubstitute;
 using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
 using System.Threading.Tasks;
 using System.Linq;
-using GitHub.TeamFoundation.Services;
 
 public class VSGitExtTests
 {
-    public class TheConstructor
+    public class TheConstructor : TestBaseClass
     {
         [TestCase(true, 1)]
         [TestCase(false, 0)]
@@ -60,7 +59,7 @@ public class VSGitExtTests
         }
     }
 
-    public class TheActiveRepositoriesChangedEvent
+    public class TheActiveRepositoriesChangedEvent : TestBaseClass
     {
         [Test]
         public async Task GitExtPropertyChangedEvent_ActiveRepositoriesChangedIsFired()
@@ -132,7 +131,7 @@ public class VSGitExtTests
         }
     }
 
-    public class TheActiveRepositoriesProperty
+    public class TheActiveRepositoriesProperty : TestBaseClass
     {
         [Test]
         public void SccProviderContextNotActive_IsEmpty()

--- a/test/UnitTests/GitHub.TeamFoundation/VSGitExtTests.cs
+++ b/test/UnitTests/GitHub.TeamFoundation/VSGitExtTests.cs
@@ -63,7 +63,7 @@ public class VSGitExtTests
     public class TheActiveRepositoriesChangedEvent
     {
         [Test]
-        public void GitExtPropertyChangedEvent_ActiveRepositoriesChangedIsFired()
+        public async Task GitExtPropertyChangedEvent_ActiveRepositoriesChangedIsFired()
         {
             var context = CreateVSUIContext(true);
             var gitExt = CreateGitExt();
@@ -75,6 +75,7 @@ public class VSGitExtTests
             var eventArgs = new PropertyChangedEventArgs(nameof(gitExt.ActiveRepositories));
             gitExt.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(gitExt, eventArgs);
 
+            await target.InitializeTask;
             Assert.That(wasFired, Is.True);
         }
 
@@ -188,6 +189,7 @@ public class VSGitExtTests
             var task2 = Task.Run(() => gitExt.ActiveRepositories = activeRepositories2);
 
             await Task.WhenAll(task1, task2);
+            await target.InitializeTask;
 
             Assert.That(target.ActiveRepositories.Single().LocalPath, Is.EqualTo("repo2"));
         }

--- a/test/UnitTests/GitHub.TeamFoundation/VSGitExtTests.cs
+++ b/test/UnitTests/GitHub.TeamFoundation/VSGitExtTests.cs
@@ -75,7 +75,7 @@ public class VSGitExtTests
             var eventArgs = new PropertyChangedEventArgs(nameof(gitExt.ActiveRepositories));
             gitExt.PropertyChanged += Raise.Event<PropertyChangedEventHandler>(gitExt, eventArgs);
 
-            await target.InitializeTask;
+            await target.PendingTasks;
             Assert.That(wasFired, Is.True);
         }
 
@@ -109,7 +109,7 @@ public class VSGitExtTests
 
             var eventArgs = new VSUIContextChangedEventArgs(true);
             context.UIContextChanged += Raise.Event<EventHandler<VSUIContextChangedEventArgs>>(context, eventArgs);
-            target.InitializeTask.Wait();
+            target.PendingTasks.Wait();
 
             Assert.That(wasFired, Is.True);
         }
@@ -126,7 +126,7 @@ public class VSGitExtTests
 
             var eventArgs = new VSUIContextChangedEventArgs(true);
             context.UIContextChanged += Raise.Event<EventHandler<VSUIContextChangedEventArgs>>(context, eventArgs);
-            target.InitializeTask.Wait();
+            target.PendingTasks.Wait();
 
             Assert.That(threadPool, Is.True);
         }
@@ -151,7 +151,7 @@ public class VSGitExtTests
             var context = CreateVSUIContext(true);
             var gitExt = CreateGitExt(new[] { repoPath });
             var target = CreateVSGitExt(context, gitExt, repoFactory: repoFactory);
-            target.InitializeTask.Wait();
+            target.PendingTasks.Wait();
 
             var activeRepositories = target.ActiveRepositories;
 
@@ -168,7 +168,7 @@ public class VSGitExtTests
             var context = CreateVSUIContext(true);
             var gitExt = CreateGitExt(new[] { repoPath });
             var target = CreateVSGitExt(context, gitExt, repoFactory: repoFactory);
-            target.InitializeTask.Wait();
+            target.PendingTasks.Wait();
 
             var activeRepositories = target.ActiveRepositories;
 
@@ -189,7 +189,7 @@ public class VSGitExtTests
             var task2 = Task.Run(() => gitExt.ActiveRepositories = activeRepositories2);
 
             await Task.WhenAll(task1, task2);
-            await target.InitializeTask;
+            await target.PendingTasks;
 
             Assert.That(target.ActiveRepositories.Single().LocalPath, Is.EqualTo("repo2"));
         }
@@ -221,7 +221,7 @@ public class VSGitExtTests
         sp.GetService<IVSUIContextFactory>().Returns(factory);
         sp.GetService<IGitExt>().Returns(gitExt);
         var vsGitExt = new VSGitExt(sp, factory, repoFactory);
-        vsGitExt.InitializeTask.Wait();
+        vsGitExt.PendingTasks.Wait();
         return vsGitExt;
     }
 


### PR DESCRIPTION
This PR allows the `VSGitExt` service to be constructed and subscribed to from background thread. This is necessary to allow the package from `Show current PR on status bar` #1396 to load on a background thread (package option `AllowsBackgroundLoading = true`).

#### Notes on using Task.ContinueWith to guarantee ordering of RefreshActiveRepositories

I wanted to understand what I could have done to keep the ordering of `RefreshActiveRepositories` consistent when I moved it off the main thread to the thread pool. In the `VSGitExt` constructor, it was changed from `RefreshActiveRepositories()` to `Task.Run(() => RefreshActiveRepositories)`.

The body of `RefreshActiveRepositories` can be changed to use `sync`, but this doesn't guarantee the order in which tasks start executing on the thread pool. For example:

```c#
        async Task Lock()
        {
            var refreshLock = new object();
            var writer = new StringWriter();
            var tasks = new List<Task>();

            for (int x = 0; x < 10; x++)
            {
                var y = x;
                tasks.Add(Task.Run(() =>
                {
                    lock (refreshLock)
                    {
                        writer.Write(y + ", ");
                    }
                }));
            }

            await Task.WhenAll(tasks);
            Console.WriteLine(writer);
        }
```

Might output: `0, 3, 4, 5, 6, 7, 8, 9, 1, 2,`

Interestingly the `TaskCreationOptions.PreferFairness` flag doesn't seem to make any difference when starting tasks:

```c#
        async Task PreferFairness()
        {
            var refreshLock = new object();
            var writer = new StringWriter();
            var tasks = new List<Task>();

            for (int x = 0; x < 10; x++)
            {
                var y = x;
                tasks.Add(Task.Factory.StartNew(() =>
                {
                    lock (refreshLock)
                    {
                        writer.Write(y + ", ");
                    }
                }, TaskCreationOptions.PreferFairness));
            }

            await Task.WhenAll(tasks);
            Console.WriteLine(writer);
        }
```

Which outputs: `1, 3, 4, 5, 6, 7, 8, 9, 2, 0,`

An alternative approach is to use `ContinueWith`:

```c#
        async Task ContinueWith()
        {
            var writer = new StringWriter();
            var task = Task.CompletedTask;

            for (int x = 0; x < 10; x++)
            {
                var y = x;
                task = task.ContinueWith(_ => writer.Write(y + ", "), TaskScheduler.Default);
            }

            await task;
            Console.WriteLine(writer);
        }
```

Which consistently outputs: `0, 1, 2, 3, 4, 5, 6, 7, 8, 9,`

I prefer this approach because the intended ordering is explicit when the `ContinueWith` method is used.

What do you think?