### PR TITLE
Clarify what scopes are needed for the personal access token

### DIFF
--- a/docs/getting-started/authenticating-to-github.md
+++ b/docs/getting-started/authenticating-to-github.md
@@ -10,6 +10,10 @@ Before you authenticate, you must already have a GitHub or GitHub Enterprise acc
 **Note:** If your organization is on the [Business plan](https://help.github.com/articles/organization-billing-plans) and has not enabled SAML single sign-on or login with username and passowrd, you must create and authorize a personal access token to access protected content. In addition, SAML single sign-on is not available for GitHub enterprise versions less than 2.12.2.
 
 **Important**: The required scopes for the personal access token are: `user`, `repo`, `gist`, and `write:public_key`. 
+- *user* scope: Grants access to the user profile data. We currently use this to display your avatar and check whether your plans lets you publish private repositories.
+- *repo* scope: Grants read/write access to code, commit statuses, invitations, collaborators, adding team memberships, and deployment statuses for public and private repositories and organizations. This is needed for all git network operations (push, pull, fetch), and for getting information about the repository you're currently working on.
+- *gist* scope: Grants write access to gists. We use this in our gist feature, so you can highlight code and create gists directly from Visual Studio
+- *write:public_key* scope: Grants access to creating, listing, and viewing details for public keys. This will allows us to add ssh support to your repositories, if you are unable to go through https (this feature is not available yet)
 
 For more information on creating personal access tokens, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line). 
 

--- a/docs/getting-started/authenticating-to-github.md
+++ b/docs/getting-started/authenticating-to-github.md
@@ -7,12 +7,13 @@ Before you authenticate, you must already have a GitHub or GitHub Enterprise acc
 - For more information on creating a GitHub account, see "[Signing up for a new GitHub account](https://help.github.com/articles/signing-up-for-a-new-github-account/)".
 - For a GitHub Enterprise account, contact your GitHub Enterprise site administrator.
 
-> **Note:** If your organization is on the [Business plan](https://help.github.com/articles/organization-billing-plans) and has not enabled SAML single sign-on or login with username and passowrd, you must create and authorize a personal access token to access protected content. In addition, SAML single sign-on is not available for GitHub enterprise versions less than 2.12.2.
+**Note:** If your organization is on the [Business plan](https://help.github.com/articles/organization-billing-plans) and has not enabled SAML single sign-on or login with username and passowrd, you must create and authorize a personal access token to access protected content. In addition, SAML single sign-on is not available for GitHub enterprise versions less than 2.12.2.
 
-> For more information on authenticating with SAML single sign-on, see "[About authentication with SAML single sign-on](https://help.github.com/articles/about-authentication-with-saml-single-sign-on)."
+**Important**: The required scopes for the personal access token are: `user`, `repo`, `gist`, and `write:public_key`. 
 
-> For more information on creating personal access tokens, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line). The required scopes for the personal access token are: `user`, `repo`, `gist`, and `write:public_key`. 
+For more information on creating personal access tokens, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line). 
 
+For more information on authenticating with SAML single sign-on, see "[About authentication with SAML single sign-on](https://help.github.com/articles/about-authentication-with-saml-single-sign-on)."
 
 1. In Visual Studio, select **Team Explorer** from the **View** menu.
 ![Team Explorer in the view menu](images/view_team_explorer.png)

--- a/docs/getting-started/authenticating-to-github.md
+++ b/docs/getting-started/authenticating-to-github.md
@@ -7,13 +7,15 @@ Before you authenticate, you must already have a GitHub or GitHub Enterprise acc
 - For more information on creating a GitHub account, see "[Signing up for a new GitHub account](https://help.github.com/articles/signing-up-for-a-new-github-account/)".
 - For a GitHub Enterprise account, contact your GitHub Enterprise site administrator.
 
-**Note:** If your organization is on the [Business plan](https://help.github.com/articles/organization-billing-plans) and has not enabled SAML single sign-on or login with username and passowrd, you must create and authorize a personal access token to access protected content. In addition, SAML single sign-on is not available for GitHub enterprise versions less than 2.12.2.
+**Note:** If your organization is on the [Business plan](https://help.github.com/articles/organization-billing-plans) and has not enabled SAML single sign-on or login with username and password, you must create and authorize a personal access token to access protected content. In addition, SAML single sign-on is not available for GitHub enterprise versions less than 2.12.2.
 
-**Important**: The required scopes for the personal access token are: `user`, `repo`, `gist`, and `write:public_key`. 
+### Scopes for personal access tokens
+
+The scopes for the personal access token are: `user`, `repo`, `gist`, and `write:public_key`. 
 - *user* scope: Grants access to the user profile data. We currently use this to display your avatar and check whether your plans lets you publish private repositories.
 - *repo* scope: Grants read/write access to code, commit statuses, invitations, collaborators, adding team memberships, and deployment statuses for public and private repositories and organizations. This is needed for all git network operations (push, pull, fetch), and for getting information about the repository you're currently working on.
 - *gist* scope: Grants write access to gists. We use this in our gist feature, so you can highlight code and create gists directly from Visual Studio
-- *write:public_key* scope: Grants access to creating, listing, and viewing details for public keys. This will allows us to add ssh support to your repositories, if you are unable to go through https (this feature is not available yet)
+- *write:public_key* scope: Grants access to creating, listing, and viewing details for public keys. This will allows us to add ssh support to your repositories, if you are unable to go through https (this feature is not available yet, this scope is optional)
 
 For more information on creating personal access tokens, see "[Creating a personal access token for the command line](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line). 
 


### PR DESCRIPTION
The information on personal access tokens was in a quote block, which is not very readable. Move the relevant information up and highlight the scopes the personal access token needs.