### PR TITLE
Use custom UIContext to load GitHubPackage / PullRequestStatusBarPackage in context of active repo

### DIFF
--- a/src/GitHub.Exports/Settings/Guids.cs
+++ b/src/GitHub.Exports/Settings/Guids.cs
@@ -21,6 +21,9 @@ namespace GitHub.VisualStudio
         public const string GitSccProviderId = "11B8E6D7-C08B-4385-B321-321078CDD1F8";
         public const string TeamExplorerInstall3rdPartyGitTools = "DF785C7C-8454-4836-9686-D1C4A01D0BB9";
 
+        // UIContexts
+        public const string UIContext_Git = "565515AD-F4C1-4D59-BC14-AE77396DDDD7";
+
         // Guids defined in GitHub.VisualStudio.vsct
         public const string guidGitHubPkgString = "c3d3dc68-c977-411f-b3e8-03b0dccf7dfc";
         public const string guidAssemblyResolverPkgString = "a6424dba-34cb-360d-a4de-1b0b0411e57d";

--- a/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
+++ b/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Runtime.InteropServices;
+using GitHub.Helpers;
 using GitHub.Services;
 using GitHub.VisualStudio;
 using GitHub.InlineReviews.Services;
@@ -11,7 +12,7 @@ namespace GitHub.InlineReviews
 {
     [Guid(Guids.PullRequestStatusPackageId)]
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [ProvideAutoLoad(Guids.GitSccProviderId, PackageAutoLoadFlags.BackgroundLoad)]
+    [ProvideAutoLoad(Guids.UIContext_Git, PackageAutoLoadFlags.BackgroundLoad)]
     public class PullRequestStatusBarPackage : AsyncPackage
     {
         /// <summary>
@@ -21,9 +22,11 @@ namespace GitHub.InlineReviews
         {
             var usageTracker = (IUsageTracker)await GetServiceAsync(typeof(IUsageTracker));
             var serviceProvider = (IGitHubServiceProvider)await GetServiceAsync(typeof(IGitHubServiceProvider));
-            var gitExt = (IVSGitExt)await GetServiceAsync(typeof(IVSGitExt));
+            var barManager = new PullRequestStatusBarManager(usageTracker, serviceProvider);
 
-            new PullRequestStatusBarManager(gitExt, usageTracker, serviceProvider);
+            // await ThreadingHelper.SwitchToMainThreadAsync() won't return until after a solution
+            // has been loaded. We're using the following instead as a workaround.
+            await ThreadingHelper.MainThreadDispatcher.InvokeAsync(() => barManager.StartShowingStatus());
         }
     }
 }

--- a/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
@@ -16,6 +16,9 @@ using ReactiveUI;
 
 namespace GitHub.InlineReviews.Services
 {
+    /// <summary>
+    /// Manage the UI that shows the PR for the current branch.
+    /// </summary>
     public class PullRequestStatusBarManager
     {
         static readonly ILogger log = LogManager.ForContext<PullRequestStatusBarManager>();
@@ -33,11 +36,16 @@ namespace GitHub.InlineReviews.Services
             this.serviceProvider = serviceProvider;
         }
 
+        /// <summary>
+        /// Start showing the PR for the active branch on the status bar.
+        /// </summary>
+        /// <remarks>
+        /// This must be called from the Main thread.
+        /// </remarks>
         public void StartShowingStatus()
         {
             try
             {
-                // Create just in time on Main thread.
                 pullRequestSessionManager = serviceProvider.GetService<IPullRequestSessionManager>();
                 pullRequestSessionManager.WhenAnyValue(x => x.CurrentSession)
                     .Subscribe(x => RefreshCurrentSession());

--- a/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
@@ -21,33 +21,19 @@ namespace GitHub.InlineReviews.Services
         static readonly ILogger log = LogManager.ForContext<PullRequestStatusBarManager>();
         const string StatusBarPartName = "PART_SccStatusBarHost";
 
-        readonly IVSGitExt gitExt;
         readonly IUsageTracker usageTracker;
         readonly IGitHubServiceProvider serviceProvider;
 
         IPullRequestSessionManager pullRequestSessionManager;
 
         [ImportingConstructor]
-        public PullRequestStatusBarManager(IVSGitExt gitExt, IUsageTracker usageTracker, IGitHubServiceProvider serviceProvider)
+        public PullRequestStatusBarManager(IUsageTracker usageTracker, IGitHubServiceProvider serviceProvider)
         {
-            this.gitExt = gitExt;
             this.usageTracker = usageTracker;
             this.serviceProvider = serviceProvider;
-
-            OnActiveRepositoriesChanged();
-            gitExt.ActiveRepositoriesChanged += OnActiveRepositoriesChanged;
         }
 
-        void OnActiveRepositoriesChanged()
-        {
-            if (gitExt.ActiveRepositories.Count > 0)
-            {
-                gitExt.ActiveRepositoriesChanged -= OnActiveRepositoriesChanged;
-                Application.Current.Dispatcher.Invoke(() => StartShowingStatus());
-            }
-        }
-
-        void StartShowingStatus()
+        public void StartShowingStatus()
         {
             try
             {

--- a/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
@@ -3,7 +3,6 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.ComponentModel;
 using System.ComponentModel.Composition;
 using GitHub.InlineReviews.Views;
 using GitHub.InlineReviews.ViewModels;
@@ -13,6 +12,7 @@ using GitHub.Models;
 using GitHub.Logging;
 using GitHub.Extensions;
 using Serilog;
+using ReactiveUI;
 
 namespace GitHub.InlineReviews.Services
 {
@@ -39,21 +39,12 @@ namespace GitHub.InlineReviews.Services
             {
                 // Create just in time on Main thread.
                 pullRequestSessionManager = serviceProvider.GetService<IPullRequestSessionManager>();
-
-                RefreshCurrentSession();
-                pullRequestSessionManager.PropertyChanged += PullRequestSessionManager_PropertyChanged;
+                pullRequestSessionManager.WhenAnyValue(x => x.CurrentSession)
+                    .Subscribe(x => RefreshCurrentSession());
             }
             catch (Exception e)
             {
                 log.Error(e, "Error initializing");
-            }
-        }
-
-        void PullRequestSessionManager_PropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(PullRequestSessionManager.CurrentSession))
-            {
-                RefreshCurrentSession();
             }
         }
 

--- a/src/GitHub.VisualStudio/GitContextPackage.cs
+++ b/src/GitHub.VisualStudio/GitContextPackage.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
+using GitHub.Services;
+using Task = System.Threading.Tasks.Task;
+
+namespace GitHub.VisualStudio
+{
+    /// <summary>
+    /// This package creates a custom UIContext <see cref="Guids.UIContext_Git"/> that is activated when a
+    /// repository is active in <see cref="IVSGitExt"/>.
+    /// </summary>
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    [Guid(Guids.UIContext_Git)]
+    // this is the Git service GUID, so we load whenever it loads
+    [ProvideAutoLoad(Guids.GitSccProviderId, PackageAutoLoadFlags.BackgroundLoad)]
+    public class GitContextPackage : AsyncPackage
+    {
+        protected async override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            var gitExt = (IVSGitExt)await GetServiceAsync(typeof(IVSGitExt));
+            var context = UIContext.FromUIContextGuid(new Guid(Guids.UIContext_Git));
+            RefreshContext(context, gitExt);
+            gitExt.ActiveRepositoriesChanged += () =>
+            {
+                RefreshContext(context, gitExt);
+            };
+        }
+
+        static void RefreshContext(UIContext context, IVSGitExt gitExt)
+        {
+            context.IsActive = gitExt.ActiveRepositories.Count > 0;
+        }
+    }
+}

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -306,6 +306,7 @@
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
     <Compile Include="AssemblyResolverPackage.cs" />
+    <Compile Include="GitContextPackage.cs" />
     <Compile Include="IServiceProviderPackage.cs" />
     <Compile Include="Menus\BlameLink.cs" />
     <Compile Include="Menus\MenuBase.cs" />

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using GitHub.Api;
 using GitHub.Extensions;
-using GitHub.Helpers;
 using GitHub.Info;
 using GitHub.Logging;
 using GitHub.Models;
@@ -56,7 +55,8 @@ namespace GitHub.VisualStudio
 
             await GetServiceAsync(typeof(IUsageTracker));
 
-            InitializeMenus().Forget();
+            // This package might be loaded on demand so we must await initialization of menus.
+            await InitializeMenus();
         }
 
         void LogVersionInformation()
@@ -75,8 +75,6 @@ namespace GitHub.VisualStudio
                 // Ignore if null because Expression Blend doesn't support custom services or menu extensibility.
                 return;
             }
-
-            await ThreadingHelper.SwitchToMainThreadAsync();
 
             foreach (var menu in menus.Menus)
                 serviceProvider.AddCommandHandler(menu.Guid, menu.CmdId, (s, e) => menu.Activate());

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -28,8 +28,8 @@ namespace GitHub.VisualStudio
     [InstalledProductRegistration("#110", "#112", System.AssemblyVersionInformation.Version, IconResourceID = 400)]
     [Guid(Guids.guidGitHubPkgString)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
-    // this is the Git service GUID, so we load whenever it loads
-    [ProvideAutoLoad(Guids.GitSccProviderId)]
+    // Only initialize when we're in the context of a Git repository.
+    [ProvideAutoLoad(Guids.UIContext_Git, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideToolWindow(typeof(GitHubPane), Orientation = ToolWindowOrientation.Right, Style = VsDockStyle.Tabbed, Window = EnvDTE.Constants.vsWindowKindSolutionExplorer)]
     [ProvideOptionPage(typeof(OptionsPage), "GitHub for Visual Studio", "General", 0, 0, supportsAutomation: true)]
     public class GitHubPackage : AsyncPackage


### PR DESCRIPTION
Depends on #1396 

This PR does the following:

- Adds the custom UIContext `Guids.UIContext_Git` which is activated when a repository is active
- Changes `PullRequestStatusBarPackage` to auto-load on `UIContext_Git`
- Changes `GitHubPackage` to auto-load on `UIContext_Git`
- Auto-load using a background thread
- Ensure that `GitHubPackage` completes menu initialization
  - This is necessary when it's loaded on demand before a command executes

Fixes #1511