### PR TITLE
Simplify the VSGitExt service

### DIFF
--- a/src/GitHub.Exports/Services/IVSUIContextFactory.cs
+++ b/src/GitHub.Exports/Services/IVSUIContextFactory.cs
@@ -20,6 +20,6 @@ namespace GitHub.Services
     public interface IVSUIContext
     {
         bool IsActive { get; }
-        event EventHandler<VSUIContextChangedEventArgs> UIContextChanged;
+        void WhenActivated(Action action);
     }
 }

--- a/src/GitHub.TeamFoundation.14/Services/VSUIContextFactory.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSUIContextFactory.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
 using GitHub.Services;
 
@@ -17,8 +15,7 @@ namespace GitHub.TeamFoundation.Services
     class VSUIContext : IVSUIContext
     {
         readonly UIContext context;
-        readonly Dictionary<EventHandler<VSUIContextChangedEventArgs>, EventHandler<UIContextChangedEventArgs>> handlers =
-            new Dictionary<EventHandler<VSUIContextChangedEventArgs>, EventHandler<UIContextChangedEventArgs>>();
+
         public VSUIContext(UIContext context)
         {
             this.context = context;
@@ -26,27 +23,6 @@ namespace GitHub.TeamFoundation.Services
 
         public bool IsActive { get { return context.IsActive; } }
 
-        public event EventHandler<VSUIContextChangedEventArgs> UIContextChanged
-        {
-            add
-            {
-                EventHandler<UIContextChangedEventArgs> handler = null;
-                if (!handlers.TryGetValue(value, out handler))
-                {
-                    handler = (s, e) => value.Invoke(s, new VSUIContextChangedEventArgs(e.Activated));
-                    handlers.Add(value, handler);
-                }
-                context.UIContextChanged += handler;
-            }
-            remove
-            {
-                EventHandler<UIContextChangedEventArgs> handler = null;
-                if (handlers.TryGetValue(value, out handler))
-                {
-                    handlers.Remove(value);
-                    context.UIContextChanged -= handler;
-                }
-            }
-        }
+        public void WhenActivated(Action action) => context.WhenActivated(action);
     }
 }


### PR DESCRIPTION
- Use `UIContext.WhenActivated` instead of UIContext.UIContextChanged event
- Don't use async InitializeAsync now we're initializing on background thread
- No more need to call `RefreshActiveRepositories` using `ContinueWith`