### PR TITLE
Cleanup GitHubPackage.cs

### DIFF
--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -253,7 +253,6 @@ namespace GitHub.VisualStudio
             }
             else if (serviceType == typeof(IUsageTracker))
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var usageService = await GetServiceAsync(typeof(IUsageService)) as IUsageService;
                 var serviceProvider = await GetServiceAsync(typeof(IGitHubServiceProvider)) as IGitHubServiceProvider;
                 return new UsageTracker(serviceProvider, usageService);

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,7 +23,7 @@ using Task = System.Threading.Tasks.Task;
 namespace GitHub.VisualStudio
 {
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [InstalledProductRegistration("#110", "#112", System.AssemblyVersionInformation.Version, IconResourceID = 400)]
+    [InstalledProductRegistration("#110", "#112", AssemblyVersionInformation.Version, IconResourceID = 400)]
     [Guid(Guids.guidGitHubPkgString)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     // Only initialize when we're in the context of a Git repository.
@@ -35,7 +34,6 @@ namespace GitHub.VisualStudio
     {
         static readonly ILogger log = LogManager.ForContext<GitHubPackage>();
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields")]
         readonly IServiceProvider serviceProvider;
 
         public GitHubPackage()
@@ -116,34 +114,7 @@ namespace GitHub.VisualStudio
     public sealed class ServiceProviderPackage : AsyncPackage, IServiceProviderPackage, IGitHubToolWindowManager
     {
         public const string ServiceProviderPackageId = "D5CE1488-DEDE-426D-9E5B-BFCCFBE33E53";
-        const string StartPagePreview4PackageId = "3b764d23-faf7-486f-94c7-b3accc44a70d";
-        const string StartPagePreview5PackageId = "3b764d23-faf7-486f-94c7-b3accc44a70e";
         static readonly ILogger log = LogManager.ForContext<ServiceProviderPackage>();
-
-        Version vsversion;
-        Version VSVersion
-        {
-            get
-            {
-                if (vsversion == null)
-                {
-                    var asm = typeof(ITaskList).Assembly;
-                    try
-                    {
-                        // this will return Microsoft.VisualStudio.Shell.Immutable.14.0 in VS15
-                        // but Microsoft.VisualStudio.Shell.Framework in Dev15
-                        var vinfo = FileVersionInfo.GetVersionInfo(asm.Location);
-                        vsversion = new Version(vinfo.FileMajorPart, vinfo.FileMinorPart, vinfo.FileBuildPart, vinfo.FilePrivatePart);
-                    }
-                    catch
-                    {
-                        // something wrong, fallback to assembly version
-                        vsversion = asm.GetName().Version;
-                    }
-                }
-                return vsversion;
-            }
-        }
 
         protected override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel.Composition;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,7 +7,6 @@ using GitHub.Api;
 using GitHub.Extensions;
 using GitHub.Info;
 using GitHub.Logging;
-using GitHub.Models;
 using GitHub.Services;
 using GitHub.ViewModels.GitHubPane;
 using GitHub.VisualStudio.Menus;
@@ -16,7 +14,6 @@ using GitHub.VisualStudio.UI;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Octokit;
 using Serilog;
 using Task = System.Threading.Tasks.Task;
 
@@ -89,16 +86,6 @@ namespace GitHub.VisualStudio
                 IVsPackage vsPackage;
                 ErrorHandler.ThrowOnFailure(shell.LoadPackage(ref packageGuid, out vsPackage));
             }
-        }
-    }
-
-    [Export(typeof(IGitHubClient))]
-    public class GHClient : GitHubClient
-    {
-        [ImportingConstructor]
-        public GHClient(IProgram program)
-            : base(program.ProductHeader)
-        {
         }
     }
 


### PR DESCRIPTION
Clean up a few things I noticed when working on another PR

- Don't `SwitchToMainThreadAsync` when returning `UsageTracker` service
- Remove a bunch of dead code
- Removed unused export for `GitHubHClient`
   - No errors in MEF log when removed
   - Checked for dynamic loading using `typeof(IGitHubClient)` or `<IGitHubClient>`
