### PR TITLE
Call MenuCommandService.AddCommand on Main thread

### DIFF
--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using GitHub.Api;
 using GitHub.Extensions;
+using GitHub.Helpers;
 using GitHub.Info;
 using GitHub.Logging;
 using GitHub.Models;
@@ -75,6 +76,9 @@ namespace GitHub.VisualStudio
                 // Ignore if null because Expression Blend doesn't support custom services or menu extensibility.
                 return;
             }
+
+            // IMenuCommandService.AddCommand uses IServiceProvider.GetService and must be called on Main thread.
+            await ThreadingHelper.SwitchToMainThreadAsync();
 
             foreach (var menu in menus.Menus)
                 serviceProvider.AddCommandHandler(menu.Guid, menu.CmdId, (s, e) => menu.Activate());


### PR DESCRIPTION
We now use the following attribute on `GitHubPackage`:
```
    [ProvideAutoLoad(Guids.UIContext_Git, PackageAutoLoadFlags.BackgroundLoad)]
```

It appears the `PackageAutoLoadFlags.BackgroundLoad` flag is only honored on Visual Studio 2017. This caused the menu initialization to only execute on a background thread when using Visual Studio 2017. This would cause a deadlock. 😭 

Fixes #1520