### PR TITLE
Make InUIThread return false on non-UIThread

### DIFF
--- a/src/GitHub.Exports/Helpers/ThreadingHelper.cs
+++ b/src/GitHub.Exports/Helpers/ThreadingHelper.cs
@@ -24,7 +24,7 @@ namespace GitHub.Helpers
 
     public static class ThreadingHelper
     {
-        public static bool InUIThread => (!Guard.InUnitTestRunner && Application.Current.Dispatcher.CheckAccess()) || !(Guard.InUnitTestRunner);
+        public static bool InUIThread => Guard.InUnitTestRunner ? true : Application.Current.Dispatcher.CheckAccess();
 
         /// <summary>
         /// Gets the Dispatcher for the main thread.
@@ -88,7 +88,7 @@ namespace GitHub.Helpers
             {
                 isCompleted = () => true;
                 onCompleted = c => c();
-                getResult = () => {};
+                getResult = () => { };
             }
 
             public AwaiterWrapper(MainThreadAwaiter awaiter)


### PR DESCRIPTION
Was always returning true when not InUnitTestRunner:

```cs
bool InUIThread =>
    (!Guard.InUnitTestRunner && Application.Current.Dispatcher.CheckAccess()) ||
    !(Guard.InUnitTestRunner);
```

Changed to:

```cs
bool InUIThread =>
    Guard.InUnitTestRunner ? true : Application.Current.Dispatcher.CheckAccess();
```