### PR TITLE
Update the header for pull request description

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -186,7 +186,7 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <StackPanel Orientation="Horizontal" Grid.Row="0">
+                <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0 -8 0 -4">
                             <ui:GitHubActionLink Margin="0 6" Command="{Binding OpenOnGitHub}">
                                 View on GitHub
                             </ui:GitHubActionLink>
@@ -265,7 +265,7 @@
                     Grid.Row="1">
                     <StackPanel Orientation="Vertical">
                         <!-- View conversation on GitHub -->
-                        <StackPanel Orientation="Horizontal">
+                        <StackPanel Orientation="Horizontal" Margin="0 4 0 0">
                             <controls:AccountAvatar Account="{Binding Model.Author}"
                                                     VerticalAlignment="Bottom"
                                                     Width="16"

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -261,33 +261,38 @@
                 </Grid.RowDefinitions>
 
                 <!-- Author and open time -->
-                <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
-                    <controls:AccountAvatar Account="{Binding Model.Author}"
-                                            VerticalAlignment="Bottom"
-                                            Width="16"
-                                            Height="16" Margin="0,0,0,1"/>
+                <ui:SectionControl Name="descriptionSection"
+                    HeaderText="Description"
+                    IsExpanded="True"
+                    Grid.Row="0">
+                    <StackPanel Orientation="Vertical">
+                        <!-- View conversation on GitHub -->
+                        <ui:GitHubActionLink Margin="0 6" Command="{Binding OpenOnGitHub}">
+                            View conversation on GitHub
+                        </ui:GitHubActionLink>
 
-                    <TextBlock VerticalAlignment="Center" Margin="4 0" TextWrapping="Wrap">
-                        <Run FontWeight="Bold" Text="{Binding Model.Author.Login, Mode=OneWay}" />
-                        <Run Text="wrote" />
-                    </TextBlock>
-                </StackPanel>
+                        <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
+                            <controls:AccountAvatar Account="{Binding Model.Author}"
+                                                    VerticalAlignment="Bottom"
+                                                    Width="16"
+                                                    Height="16" Margin="0,0,0,1"/>
 
-                <!-- PR Body -->
-                <markdig:MarkdownViewer Name="bodyMarkdown"
-                                        Grid.Row="1"
-                                        Margin="2 10 10 6"
-                                        Markdown="{Binding Body}"/>
-
-                <!-- View conversation on GitHub -->
-                <ui:GitHubActionLink Grid.Column="2" Grid.Row="2" Margin="0 6" Command="{Binding OpenOnGitHub}">
-                    View conversation on GitHub
-                </ui:GitHubActionLink>
+                            <TextBlock VerticalAlignment="Center" Margin="4 0" TextWrapping="Wrap">
+                                <Run FontWeight="Bold" Text="{Binding Model.Author.Login, Mode=OneWay}" />
+                                <Run Text="wrote" />
+                            </TextBlock>
+                        </StackPanel>
+                        <!-- PR Body -->
+                        <markdig:MarkdownViewer Name="bodyMarkdown"
+                                                Margin="2 10 10 6"
+                                                Markdown="{Binding Body}"/>
+                    </StackPanel>
+                </ui:SectionControl>
 
                 <ui:SectionControl Name="reviewsSection"
                                    HeaderText="Reviewers"
                                    IsExpanded="True"
-                                   Grid.Row="3">
+                                   Grid.Row="2">
                     <ItemsControl ItemsSource="{Binding Reviews}" Margin="0 4 12 4">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -278,7 +278,7 @@
                         </StackPanel>
                         <!-- PR Body -->
                         <markdig:MarkdownViewer Name="bodyMarkdown"
-                                                Margin="2 10 10 6"
+                                                Margin="2 4 10 6"
                                                 Markdown="{Binding Body}"/>
                     </StackPanel>
                 </ui:SectionControl>
@@ -286,6 +286,7 @@
                 <ui:SectionControl Name="reviewsSection"
                                    HeaderText="Reviewers"
                                    IsExpanded="True"
+                                   Margin="0 8 0 0"
                                    Grid.Row="2">
                     <ItemsControl ItemsSource="{Binding Reviews}" Margin="0 4 12 4">
                         <ItemsControl.ItemTemplate>
@@ -301,7 +302,7 @@
                                    Grid.Row="4"
                                    IsExpanded="True"
                                    HeaderText="{Binding Files.ChangedFilesCount, StringFormat={x:Static prop:Resources.ChangesCountFormat}}"
-                                   Margin="0 5 10 0">
+                                   Margin="0 8 10 0">
                     <local:PullRequestFilesView DataContext="{Binding Files}"/>
                 </ui:SectionControl>
             </Grid>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -186,7 +186,7 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0 -8 0 -4">
+                <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0 -4 0 0">
                             <ui:GitHubActionLink Margin="0 6" Command="{Binding OpenOnGitHub}">
                                 View on GitHub
                             </ui:GitHubActionLink>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -102,10 +102,13 @@
             <StackPanel Grid.Column="0"
                 Grid.Row="1"
                 Orientation="Horizontal">
+
                 <TextBlock FontWeight="Bold"
                            Margin="0 0 4 0"
                            Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
                            Style="{StaticResource StateIndicator}"/>
+
+                <Rectangle Grid.Column="1" Margin="5 0 10 0" Width="1" Height="12" VerticalAlignment="Top" Style="{DynamicResource Separator}" />
 
                 <!-- source and target branches -->
                 <Grid Margin="0 -3" HorizontalAlignment="Left">
@@ -116,18 +119,17 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
-                        <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding SourceBranchDisplayName, Mode=OneWay}" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" />
-                    </Border>
-
-                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5" Text="into" />
-
                     <Border Grid.Column="3" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
                         <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding TargetBranchDisplayName, Mode=OneWay}" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" />
                     </Border>
+
+                    <ui:OcticonImage Grid.Column="2" VerticalAlignment="Center" Margin="5" Icon="arrow_left" />
+
+                    <Border Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                        <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding SourceBranchDisplayName, Mode=OneWay}" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" />
+                    </Border>
                 </Grid>
             </StackPanel>
-
         </Grid>
 
         <!-- Avatar, PR Title, Open/Merged/Closed state and actions area -->

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -148,82 +148,8 @@
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-
-                    <TextBlock Grid.Column="0" Opacity="0.5" VerticalAlignment="Center"
-                               Text="{Binding Model.UpdatedAt, StringFormat={x:Static prop:Resources.UpdatedFormat}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
-
-                    <Rectangle Grid.Column="1" Margin="5" Width="1" Height="12" VerticalAlignment="Top" Style="{DynamicResource Separator}" />
-
-                    <!-- Checkout pull request button -->
-                    <ui:GitHubActionLink Command="{Binding Checkout}"
-                                         Content="{Binding CheckoutState.Caption}"
-                                         Grid.Column="2"
-                                         VerticalAlignment="Center"
-                                         TextTrimming="CharacterEllipsis"
-                                         Visibility="{Binding CheckoutState, Converter={ui:NullToVisibilityConverter}}"
-                                         ToolTip="{Binding CheckoutState.ToolTip}"
-                                         ToolTipService.ShowOnDisabled="True"/>
-
-                    <!-- Pull/push buttons -->
-                    <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center"
-                            Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToInverseVisibilityConverter}}">
-                        <ui:OcticonImage Icon="arrow_down"/>
-                        <TextBlock Text="{Binding UpdateState.CommitsBehind}" VerticalAlignment="Center"/>
-                        <ui:GitHubActionLink Content="Pull"
-                                             Command="{Binding Pull}"
-                                             Margin="4,0"
-                                             ToolTip="{Binding UpdateState.PullToolTip}"
-                                             ToolTipService.ShowOnDisabled="True"
-                                             VerticalAlignment="Center"/>
-                        <ui:OcticonImage Icon="arrow_up"/>
-                        <TextBlock Text="{Binding UpdateState.CommitsAhead}" VerticalAlignment="Center"/>
-                        <ui:GitHubActionLink Content="Push"
-                                             Command="{Binding Push}"
-                                             Margin="4,0"
-                                             ToolTip="{Binding UpdateState.PushToolTip}"
-                                             ToolTipService.ShowOnDisabled="True"
-                                             VerticalAlignment="Center"/>
-                        <!-- Sync submodules -->
-                        <ui:OcticonImage Icon="package"
-                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
-                        <TextBlock  Margin="4 0 0 0" Text="{Binding UpdateState.SubmodulesToSync}" VerticalAlignment="Center"
-                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
-                        <ui:GitHubActionLink Content="Sync"
-                            Command="{Binding SyncSubmodules}"
-                            Margin="4 0"
-                            ToolTip="{Binding UpdateState.SyncSubmodulesToolTip}"
-                            Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
-                    </StackPanel>
-
-                    <!-- Branch checked out and up-to-date -->
-                    <TextBlock Grid.Column="2" VerticalAlignment="Center" TextWrapping="Wrap"
-                           Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutMessage}">
-                                <Setter Property="Visibility" Value="Collapsed"/>
-                                <Style.Triggers>
-                                    <MultiDataTrigger>
-                                        <MultiDataTrigger.Conditions>
-                                            <Condition Binding="{Binding UpdateState.CommitsAhead}" Value="0"/>
-                                            <Condition Binding="{Binding UpdateState.CommitsBehind}" Value="0"/>
-                                        </MultiDataTrigger.Conditions>
-                                        <MultiDataTrigger.Setters>
-                                            <Setter Property="Visibility" Value="Visible"/>
-                                        </MultiDataTrigger.Setters>
-                                    </MultiDataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    <ui:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
-                    <Run Text="{x:Static prop:Resources.LocalBranchUpToDate}"/>
-                    </TextBlock>
-                </Grid>
+                <TextBlock Grid.Column="0" Opacity="0.5" VerticalAlignment="Center"
+                           Text="{Binding Model.UpdatedAt, StringFormat={x:Static prop:Resources.UpdatedFormat}, Converter={ui:DurationToStringConverter}, Mode=OneWay}"/>
             </StackPanel>
 
             <!-- Git operation error message -->
@@ -267,18 +193,86 @@
                     Grid.Row="0">
                     <StackPanel Orientation="Vertical">
                         <!-- View conversation on GitHub -->
-                        <ui:GitHubActionLink Margin="0 6" Command="{Binding OpenOnGitHub}">
-                            View conversation on GitHub
-                        </ui:GitHubActionLink>
+                        <StackPanel Orientation="Horizontal">
+                            <ui:GitHubActionLink Margin="0 6" Command="{Binding OpenOnGitHub}">
+                                View on GitHub
+                            </ui:GitHubActionLink>
 
-                        <StackPanel Margin="0 5 0 0" Orientation="Horizontal">
+                            <Rectangle Margin="5 0" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />
+
+                            <!-- Checkout pull request button -->
+                            <ui:GitHubActionLink Command="{Binding Checkout}"
+                                                 Content="{Binding CheckoutState.Caption}"
+                                                 VerticalAlignment="Center"
+                                                 TextTrimming="CharacterEllipsis"
+                                                 Visibility="{Binding CheckoutState, Converter={ui:NullToVisibilityConverter}}"
+                                                 ToolTip="{Binding CheckoutState.ToolTip}"
+                                                 ToolTipService.ShowOnDisabled="True"/>
+
+                            <!-- Pull/push buttons -->
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center"
+                                    Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToInverseVisibilityConverter}}">
+                                <ui:OcticonImage Icon="arrow_down"/>
+                                <TextBlock Text="{Binding UpdateState.CommitsBehind}" VerticalAlignment="Center"/>
+                                <ui:GitHubActionLink Content="Pull"
+                                                     Command="{Binding Pull}"
+                                                     Margin="4,0"
+                                                     ToolTip="{Binding UpdateState.PullToolTip}"
+                                                     ToolTipService.ShowOnDisabled="True"
+                                                     VerticalAlignment="Center"/>
+                                <ui:OcticonImage Icon="arrow_up"/>
+                                <TextBlock Text="{Binding UpdateState.CommitsAhead}" VerticalAlignment="Center"/>
+                                <ui:GitHubActionLink Content="Push"
+                                                     Command="{Binding Push}"
+                                                     Margin="4,0"
+                                                     ToolTip="{Binding UpdateState.PushToolTip}"
+                                                     ToolTipService.ShowOnDisabled="True"
+                                                     VerticalAlignment="Center"/>
+                                <!-- Sync submodules -->
+                                <ui:OcticonImage Icon="package"
+                                    Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
+                                <TextBlock  Margin="4 0 0 0" Text="{Binding UpdateState.SubmodulesToSync}" VerticalAlignment="Center"
+                                    Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
+                                <ui:GitHubActionLink Content="Sync"
+                                    Command="{Binding SyncSubmodules}"
+                                    Margin="4 0"
+                                    ToolTip="{Binding UpdateState.SyncSubmodulesToolTip}"
+                                    Visibility="{Binding UpdateState.SyncSubmodulesEnabled, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}" />
+                            </StackPanel>
+
+                            <!-- Branch checked out and up-to-date -->
+                            <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
+                                   Visibility="{Binding UpdateState.UpToDate, FallbackValue=Collapsed, Converter={ui:BooleanToVisibilityConverter}}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource CheckoutMessage}">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <MultiDataTrigger>
+                                                <MultiDataTrigger.Conditions>
+                                                    <Condition Binding="{Binding UpdateState.CommitsAhead}" Value="0"/>
+                                                    <Condition Binding="{Binding UpdateState.CommitsBehind}" Value="0"/>
+                                                </MultiDataTrigger.Conditions>
+                                                <MultiDataTrigger.Setters>
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </MultiDataTrigger.Setters>
+                                            </MultiDataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+
+                                <ui:OcticonImage Icon="check" Foreground="#6CC644" Margin="0 0 0 -4"/>
+                                <Run Text="{x:Static prop:Resources.LocalBranchUpToDate}"/>
+                            </TextBlock>
+                        </StackPanel>
+
+                        <StackPanel Orientation="Horizontal">
                             <controls:AccountAvatar Account="{Binding Model.Author}"
                                                     VerticalAlignment="Bottom"
                                                     Width="16"
                                                     Height="16" Margin="0,0,0,1"/>
 
                             <TextBlock VerticalAlignment="Center" Margin="4 0" TextWrapping="Wrap">
-                                <Run FontWeight="Bold" Text="{Binding Model.Author.Login, Mode=OneWay}" />
+                                <Run FontWeight="SemiBold" Text="{Binding Model.Author.Login, Mode=OneWay}" />
                                 <Run Text="wrote" />
                             </TextBlock>
                         </StackPanel>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -186,14 +186,7 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <!-- Author and open time -->
-                <ui:SectionControl Name="descriptionSection"
-                    HeaderText="Description"
-                    IsExpanded="True"
-                    Grid.Row="0">
-                    <StackPanel Orientation="Vertical">
-                        <!-- View conversation on GitHub -->
-                        <StackPanel Orientation="Horizontal">
+                <StackPanel Orientation="Horizontal" Grid.Row="0">
                             <ui:GitHubActionLink Margin="0 6" Command="{Binding OpenOnGitHub}">
                                 View on GitHub
                             </ui:GitHubActionLink>
@@ -265,6 +258,13 @@
                             </TextBlock>
                         </StackPanel>
 
+                <!-- Author and open time -->
+                <ui:SectionControl Name="descriptionSection"
+                    HeaderText="Description"
+                    IsExpanded="True"
+                    Grid.Row="1">
+                    <StackPanel Orientation="Vertical">
+                        <!-- View conversation on GitHub -->
                         <StackPanel Orientation="Horizontal">
                             <controls:AccountAvatar Account="{Binding Model.Author}"
                                                     VerticalAlignment="Bottom"

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -88,15 +88,21 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
             <TextBlock Grid.Column="0"
                        Style="{DynamicResource {x:Static vsui:VsResourceKeys.TextBlockEnvironment122PercentFontSizeStyleKey}}"
                        TextWrapping="Wrap"
                        Margin="0 0 5 3"
                        Text="{Binding Model.Title}"/>
 
-            <TextBlock Grid.Column="1"
+            <TextBlock Grid.Column="0"
+                       Grid.Row="1"
                        FontWeight="Bold"
-                       Margin="10 4 0 0"
+                       Margin="0 0 4 0"
                        Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
                        Style="{StaticResource StateIndicator}"/>
         </Grid>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -120,13 +120,13 @@
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
-                    <Border Grid.Column="3" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                    <Border Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
                         <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding TargetBranchDisplayName, Mode=OneWay}" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" />
                     </Border>
 
                     <ui:OcticonImage Grid.Column="2" VerticalAlignment="Center" Margin="5" Icon="arrow_left" />
 
-                    <Border Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                    <Border Grid.Column="3" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
                         <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding SourceBranchDisplayName, Mode=OneWay}" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" />
                     </Border>
                 </Grid>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -89,7 +89,7 @@
             </Grid.ColumnDefinitions>
 
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
@@ -99,12 +99,35 @@
                        Margin="0 0 5 3"
                        Text="{Binding Model.Title}"/>
 
-            <TextBlock Grid.Column="0"
-                       Grid.Row="1"
-                       FontWeight="Bold"
-                       Margin="0 0 4 0"
-                       Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
-                       Style="{StaticResource StateIndicator}"/>
+            <StackPanel Grid.Column="0"
+                Grid.Row="1"
+                Orientation="Horizontal">
+                <TextBlock FontWeight="Bold"
+                           Margin="0 0 4 0"
+                           Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
+                           Style="{StaticResource StateIndicator}"/>
+
+                <!-- source and target branches -->
+                <Grid Margin="0 -3" HorizontalAlignment="Left">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                        <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding SourceBranchDisplayName, Mode=OneWay}" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" />
+                    </Border>
+
+                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5" Text="into" />
+
+                    <Border Grid.Column="3" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
+                        <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding TargetBranchDisplayName, Mode=OneWay}" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" />
+                    </Border>
+                </Grid>
+            </StackPanel>
+
         </Grid>
 
         <!-- Avatar, PR Title, Open/Merged/Closed state and actions area -->
@@ -122,27 +145,6 @@
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Column="1" Margin="0 0 6 0" Orientation="Vertical">
-                <!-- source and target branches -->
-                <Grid Margin="0 -3" HorizontalAlignment="Left">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-
-                    <ui:OcticonImage Grid.Column="0" VerticalAlignment="Center" Icon="git_branch" Height="15" Opacity="0.5" Margin="0 0 3 0" />
-                    <Border Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
-                        <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding SourceBranchDisplayName, Mode=OneWay}" Text="{Binding SourceBranchDisplayName, Mode=OneWay}" />
-                    </Border>
-
-                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="5" Text="into" />
-
-                    <Border Grid.Column="3" HorizontalAlignment="Left" VerticalAlignment="Center" CornerRadius="2" Padding="5 1" Background="{DynamicResource GitHubBranchNameBackgroundBrush}">
-                        <TextBlock FontFamily="Consolas" TextTrimming="CharacterEllipsis" ToolTip="{Binding TargetBranchDisplayName, Mode=OneWay}" Text="{Binding TargetBranchDisplayName, Mode=OneWay}" />
-                    </Border>
-                </Grid>
-
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -105,10 +105,11 @@
 
                 <TextBlock FontWeight="Bold"
                            Margin="0 0 4 0"
+                           VerticalAlignment="Center"
                            Text="{Binding Model.State, Converter={StaticResource AllCaps}}"
                            Style="{StaticResource StateIndicator}"/>
 
-                <Rectangle Grid.Column="1" Margin="5 0 10 0" Width="1" Height="12" VerticalAlignment="Top" Style="{DynamicResource Separator}" />
+                <Rectangle Grid.Column="1" Margin="5 0 10 0" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />
 
                 <!-- source and target branches -->
                 <Grid Margin="0 -3" HorizontalAlignment="Left">


### PR DESCRIPTION
This is the first of a set of changes to the pull request details view based on discussions in https://github.com/github/VisualStudio/issues/1452:

- Move "View conversation" link to above the description
- Make the description area collapsable
- Move PR Checkout features outside of the header
- Update Base / Target branch UI

**Before**

<img src="https://user-images.githubusercontent.com/1174461/37359723-98aaa9b6-26ab-11e8-8e20-478bb70c13a4.png" width="355" />

**After**

<img width="355" alt="screen shot 2018-03-13 at 9 38 08 am" src="https://user-images.githubusercontent.com/1174461/37359704-8c7e3130-26ab-11e8-8e8c-130afadaf938.png">


