### PR TITLE
Fix deadlock when VS is opended with GitHub pane visible

### DIFF
--- a/src/GitHub.InlineReviews/InlineReviewsPackage.cs
+++ b/src/GitHub.InlineReviews/InlineReviewsPackage.cs
@@ -28,12 +28,10 @@ namespace GitHub.InlineReviews
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
             var exports = componentModel.DefaultExportProvider;
 
-            // await ThreadingHelper.SwitchToMainThreadAsync() won't return until after a solution
-            // has been loaded. We're using the following instead as a workaround.
-            await ThreadingHelper.MainThreadDispatcher.InvokeAsync(() =>
-                menuService.AddCommands(
-                    exports.GetExportedValue<INextInlineCommentCommand>(),
-                    exports.GetExportedValue<IPreviousInlineCommentCommand>()));
+            await ThreadingHelper.SwitchToMainThreadAsync();
+            menuService.AddCommands(
+                exports.GetExportedValue<INextInlineCommentCommand>(),
+                exports.GetExportedValue<IPreviousInlineCommentCommand>());
         }
     }
 }

--- a/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
+++ b/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
@@ -24,9 +24,8 @@ namespace GitHub.InlineReviews
             var serviceProvider = (IGitHubServiceProvider)await GetServiceAsync(typeof(IGitHubServiceProvider));
             var barManager = new PullRequestStatusBarManager(usageTracker, serviceProvider);
 
-            // await ThreadingHelper.SwitchToMainThreadAsync() won't return until after a solution
-            // has been loaded. We're using the following instead as a workaround.
-            await ThreadingHelper.MainThreadDispatcher.InvokeAsync(() => barManager.StartShowingStatus());
+            await ThreadingHelper.SwitchToMainThreadAsync();
+            barManager.StartShowingStatus();
         }
     }
 }

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -59,18 +59,16 @@ namespace GitHub.VisualStudio
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
             var exports = componentModel.DefaultExportProvider;
 
-            // await ThreadingHelper.SwitchToMainThreadAsync() won't return until after a solution
-            // has been loaded. We're using the following instead as a workaround.
-            await ThreadingHelper.MainThreadDispatcher.InvokeAsync(() =>
-                menuService.AddCommands(
-                    exports.GetExportedValue<IAddConnectionCommand>(),
-                    exports.GetExportedValue<IBlameLinkCommand>(),
-                    exports.GetExportedValue<ICopyLinkCommand>(),
-                    exports.GetExportedValue<ICreateGistCommand>(),
-                    exports.GetExportedValue<IOpenLinkCommand>(),
-                    exports.GetExportedValue<IOpenPullRequestsCommand>(),
-                    exports.GetExportedValue<IShowCurrentPullRequestCommand>(),
-                    exports.GetExportedValue<IShowGitHubPaneCommand>()));
+            await ThreadingHelper.SwitchToMainThreadAsync();
+            menuService.AddCommands(
+                exports.GetExportedValue<IAddConnectionCommand>(),
+                exports.GetExportedValue<IBlameLinkCommand>(),
+                exports.GetExportedValue<ICopyLinkCommand>(),
+                exports.GetExportedValue<ICreateGistCommand>(),
+                exports.GetExportedValue<IOpenLinkCommand>(),
+                exports.GetExportedValue<IOpenPullRequestsCommand>(),
+                exports.GetExportedValue<IShowCurrentPullRequestCommand>(),
+                exports.GetExportedValue<IShowGitHubPaneCommand>());
         }
 
         async Task EnsurePackageLoaded(Guid packageGuid)


### PR DESCRIPTION
As a workaround for potential delays before `await ThreadingHelper.SwitchToMainThreadAsync()` returns, we changed to using `await ThreadingHelper.MainThreadDispatcher.InvokeAsync(() => ...)`. Unfortunately rather than simply delays, this workaround can cause deadlock.

This PR:

- Revert back to using `await ThreadingHelper.SwitchToMainThreadAsync()`

These issues happen when Visual Studio is opened with the `GitHub` pane visible. It seems `SwitchToMainThreadAsync` doesn't return until the PR list has finished loading. 😨 

We do need to find out what's causing this, but in a separate issue/PR. For the moment, let's get rid of the deadlock!