### PR TITLE
Find workaround for SwitchToMainThreadAsync

### DIFF
--- a/src/GitHub.Exports/Helpers/ThreadingHelper.cs
+++ b/src/GitHub.Exports/Helpers/ThreadingHelper.cs
@@ -8,9 +8,6 @@ using System.Windows;
 using static Microsoft.VisualStudio.Threading.JoinableTaskFactory;
 using static Microsoft.VisualStudio.Threading.AwaitExtensions;
 using System.Windows.Threading;
-using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Shell;
-using Task = System.Threading.Tasks.Task;
 
 namespace GitHub.Helpers
 {

--- a/src/GitHub.Exports/Helpers/ThreadingHelper.cs
+++ b/src/GitHub.Exports/Helpers/ThreadingHelper.cs
@@ -59,17 +59,6 @@ namespace GitHub.Helpers
                 new AwaitableWrapper(scheduler ?? TaskScheduler.Default);
         }
 
-        // HACK: This is a workaround because the following doesn't seem to work.
-        //await JoinableTaskFactory
-        //   .WithPriority(VsTaskRunContext.UIThreadNormalPriority)
-        //   .SwitchToMainThreadAsync();
-        public static Task RunOnMainThreadNormalPriority(Action action)
-        {
-            var service = (IVsTaskSchedulerService2)VsTaskLibraryHelper.ServiceInstance;
-            var scheduler = service.GetTaskScheduler((uint)VsTaskRunContext.UIThreadNormalPriority);
-            return Task.Factory.StartNew(action, default(CancellationToken), TaskCreationOptions.HideScheduler, scheduler);
-        }
-
         class AwaitableWrapper : IAwaitable
         {
             Func<IAwaiter> getAwaiter;

--- a/src/GitHub.InlineReviews/InlineReviewsPackage.cs
+++ b/src/GitHub.InlineReviews/InlineReviewsPackage.cs
@@ -30,13 +30,19 @@ namespace GitHub.InlineReviews
 
             // Avoid delays when there is ongoing UI activity.
             // See: https://github.com/github/VisualStudio/issues/1537
-            await JoinableTaskFactory.RunAsync(VsTaskRunContext.UIThreadNormalPriority, async () =>
-            {
-                await JoinableTaskFactory.SwitchToMainThreadAsync();
-                menuService.AddCommands(
-                    exports.GetExportedValue<INextInlineCommentCommand>(),
-                    exports.GetExportedValue<IPreviousInlineCommentCommand>());
-            });
+            await JoinableTaskFactory.RunAsync(VsTaskRunContext.UIThreadNormalPriority, InitializeMenus);
+        }
+
+        async Task InitializeMenus()
+        {
+            var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
+            var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
+            var exports = componentModel.DefaultExportProvider;
+
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
+            menuService.AddCommands(
+                exports.GetExportedValue<INextInlineCommentCommand>(),
+                exports.GetExportedValue<IPreviousInlineCommentCommand>());
         }
     }
 }

--- a/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
+++ b/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
@@ -8,6 +8,7 @@ using GitHub.InlineReviews.Services;
 using Microsoft.VisualStudio.Shell;
 using Serilog;
 using Task = System.Threading.Tasks.Task;
+using GitHub.Helpers;
 
 namespace GitHub.InlineReviews
 {
@@ -27,13 +28,15 @@ namespace GitHub.InlineReviews
             var serviceProvider = (IGitHubServiceProvider)await GetServiceAsync(typeof(IGitHubServiceProvider));
             var barManager = new PullRequestStatusBarManager(usageTracker, serviceProvider);
 
-            log.Information("SwitchToMainThreadAsync");
-            await JoinableTaskFactory
-               .WithPriority(VsTaskRunContext.UIThreadNormalPriority)
-               .SwitchToMainThreadAsync();
+            // Unfortunately this doesn't return until after the GitHub pane has finnished refreshing.
+            //log.Information("SwitchToMainThreadAsync");
+            //await JoinableTaskFactory
+            //   .WithPriority(VsTaskRunContext.UIThreadNormalPriority)
+            //   .SwitchToMainThreadAsync();
 
-            log.Information("StartShowingStatus");
-            barManager.StartShowingStatus();
+            // Posting a task like this seems to work.            
+            await ThreadingHelper.RunOnMainThreadNormalPriority(() => barManager.StartShowingStatus());
         }
+
     }
 }

--- a/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
+++ b/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
@@ -8,7 +8,7 @@ using GitHub.InlineReviews.Services;
 using Microsoft.VisualStudio.Shell;
 using Serilog;
 using Task = System.Threading.Tasks.Task;
-using GitHub.Helpers;
+using Microsoft.VisualStudio.Threading;
 
 namespace GitHub.InlineReviews
 {
@@ -24,18 +24,19 @@ namespace GitHub.InlineReviews
         /// </summary>
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
+            // Avoid delays when there is ongoing UI activity.
+            // See: https://github.com/github/VisualStudio/issues/1537
+            await JoinableTaskFactory.RunAsync(VsTaskRunContext.UIThreadNormalPriority, InitializeStatusBar);
+        }
+
+        async Task InitializeStatusBar()
+        {
             var usageTracker = (IUsageTracker)await GetServiceAsync(typeof(IUsageTracker));
             var serviceProvider = (IGitHubServiceProvider)await GetServiceAsync(typeof(IGitHubServiceProvider));
             var barManager = new PullRequestStatusBarManager(usageTracker, serviceProvider);
 
-            // Avoid delays when there is ongoing UI activity.
-            // See: https://github.com/github/VisualStudio/issues/1537
-            await JoinableTaskFactory.RunAsync(VsTaskRunContext.UIThreadNormalPriority, async () =>
-            {
-                await JoinableTaskFactory.SwitchToMainThreadAsync();
-                barManager.StartShowingStatus();
-            });
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
+            barManager.StartShowingStatus();
         }
-
     }
 }

--- a/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
+++ b/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Threading;
 using System.Runtime.InteropServices;
-using GitHub.Logging;
 using GitHub.Services;
 using GitHub.VisualStudio;
 using GitHub.InlineReviews.Services;
 using Microsoft.VisualStudio.Shell;
-using Serilog;
 using Task = System.Threading.Tasks.Task;
 using Microsoft.VisualStudio.Threading;
 
@@ -17,8 +15,6 @@ namespace GitHub.InlineReviews
     [ProvideAutoLoad(Guids.UIContext_Git, PackageAutoLoadFlags.BackgroundLoad)]
     public class PullRequestStatusBarPackage : AsyncPackage
     {
-        static readonly ILogger log = LogManager.ForContext<PullRequestStatusBarPackage>();
-
         /// <summary>
         /// Initialize the PR status UI on Visual Studio's status bar.
         /// </summary>

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -41,8 +41,9 @@ namespace GitHub.VisualStudio
             await base.InitializeAsync(cancellationToken, progress);
             await GetServiceAsync(typeof(IUsageTracker));
 
-            // This package might be loaded on demand so we must await initialization of menus.
-            await InitializeMenus();
+            // Avoid delays when there is ongoing UI activity.
+            // See: https://github.com/github/VisualStudio/issues/1537
+            await JoinableTaskFactory.RunAsync(VsTaskRunContext.UIThreadNormalPriority, InitializeMenus);
         }
 
         void LogVersionInformation()
@@ -59,21 +60,16 @@ namespace GitHub.VisualStudio
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
             var exports = componentModel.DefaultExportProvider;
 
-            // Avoid delays when there is ongoing UI activity.
-            // See: https://github.com/github/VisualStudio/issues/1537
-            await JoinableTaskFactory.RunAsync(VsTaskRunContext.UIThreadNormalPriority, async () =>
-            {
-                await JoinableTaskFactory.SwitchToMainThreadAsync();
-                menuService.AddCommands(
-                    exports.GetExportedValue<IAddConnectionCommand>(),
-                    exports.GetExportedValue<IBlameLinkCommand>(),
-                    exports.GetExportedValue<ICopyLinkCommand>(),
-                    exports.GetExportedValue<ICreateGistCommand>(),
-                    exports.GetExportedValue<IOpenLinkCommand>(),
-                    exports.GetExportedValue<IOpenPullRequestsCommand>(),
-                    exports.GetExportedValue<IShowCurrentPullRequestCommand>(),
-                    exports.GetExportedValue<IShowGitHubPaneCommand>());
-            });
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
+            menuService.AddCommands(
+                exports.GetExportedValue<IAddConnectionCommand>(),
+                exports.GetExportedValue<IBlameLinkCommand>(),
+                exports.GetExportedValue<ICopyLinkCommand>(),
+                exports.GetExportedValue<ICreateGistCommand>(),
+                exports.GetExportedValue<IOpenLinkCommand>(),
+                exports.GetExportedValue<IOpenPullRequestsCommand>(),
+                exports.GetExportedValue<IShowCurrentPullRequestCommand>(),
+                exports.GetExportedValue<IShowGitHubPaneCommand>());
         }
 
         async Task EnsurePackageLoaded(Guid packageGuid)


### PR DESCRIPTION
#### The problem

When a package has the following attributes:
```cs
    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
    [ProvideAutoLoad(Constants.vsContextNoSolution, PackageAutoLoadFlags.BackgroundLoad)]
```

Its `InitializeAsync` method is executed as a `Background` task. This is fine for initialization code that doesn't require the Main thread. Initialization code that required the Main thread and calls `SwitchToMainThreadAsync` will wait until all `Normal` priority tasks have completed. This can be problematic for code that controls the visibility of UI elements because there can be a long delay before they become visible.

The following can be used to bump the priority up to `Normal` when `SwitchToMainThreadAsync` is awaited:

```cs
protected override async Task InitializeAsync()
{
    // When SwitchToMainThreadAsync is called, use Normal priority (not Background)
    await JoinableTaskFactory.RunAsync(VsTaskRunContext.UIThreadNormalPriority, InitializeMenus);
}

async Task InitializeMenus()
{
    // This doesn't require the Main thread
    var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));

    await JoinableTaskFactory.SwitchToMainThreadAsync();
    // This does require the Main thread
    menuService.AddCommands(...);
}
```

#### What this PR does

This PR adds code similar to the above for `InlineReviewsPackage`, `PullRequestStatusBarPackage` and `GitHubPackage`.

There is still an issue with why the PR list is being refreshed at Normal priority and delays Background tasks for such a long time. This can be fixed in a separate PR.

### Related

- Loading PR list blocks await JoinableTaskFactory.SwitchToMainThreadAsync: #1537

I'm not marking #1537 as fixed because the refreshing PR list will potentially delay other extensions that don't explicitly specify `UIThreadNormalPriority`.