### PR TITLE
Display Pull Request Reviews for a User.

### DIFF
--- a/src/GitHub.App/Api/ApiClient.cs
+++ b/src/GitHub.App/Api/ApiClient.cs
@@ -88,6 +88,11 @@ namespace GitHub.Api
             return gitHubClient.User.Current();
         }
 
+        public IObservable<User> GetUser(string login)
+        {
+            return gitHubClient.User.Get(login);
+        }
+
         public IObservable<Organization> GetOrganizations()
         {
             // Organization.GetAllForCurrent doesn't return all of the information we need (we 

--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -212,6 +212,9 @@
     <Compile Include="Models\PullRequestDetailArgument.cs" />
     <Compile Include="Models\PullRequestReviewModel.cs" />
     <Compile Include="SampleData\PullRequestFilesViewModelDesigner.cs" />
+    <Compile Include="SampleData\PullRequestReviewFileCommentViewModelDesigner.cs" />
+    <Compile Include="SampleData\PullRequestReviewViewModelDesigner.cs" />
+    <Compile Include="SampleData\PullRequestUserReviewsViewModelDesigner.cs" />
     <Compile Include="Services\EnterpriseCapabilitiesService.cs" />
     <Compile Include="Services\GlobalConnection.cs" />
     <Compile Include="Services\PullRequestEditorService.cs" />
@@ -240,7 +243,10 @@
     <Compile Include="ViewModels\GitHubPane\PullRequestCreationViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\NotAGitHubRepositoryViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\NotAGitRepositoryViewModel.cs" />
+    <Compile Include="ViewModels\GitHubPane\PullRequestReviewFileCommentViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\PullRequestReviewSummaryViewModel.cs" />
+    <Compile Include="ViewModels\GitHubPane\PullRequestReviewViewModel.cs" />
+    <Compile Include="ViewModels\GitHubPane\PullRequestUserReviewsViewModel.cs" />
     <Compile Include="ViewModels\RepositoryFormViewModel.cs" />
     <Compile Include="ViewModels\TeamExplorer\RepositoryPublishViewModel.cs" />
     <Compile Include="Caches\CacheIndex.cs" />

--- a/src/GitHub.App/Models/PullRequestReviewModel.cs
+++ b/src/GitHub.App/Models/PullRequestReviewModel.cs
@@ -10,5 +10,6 @@ namespace GitHub.Models
         public string Body { get; set; }
         public PullRequestReviewState State { get; set; }
         public string CommitId { get; set; }
+        public DateTimeOffset? SubmittedAt { get; set; }
     }
 }

--- a/src/GitHub.App/SampleData/PullRequestReviewFileCommentViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestReviewFileCommentViewModelDesigner.cs
@@ -1,0 +1,13 @@
+﻿using System.Reactive;
+using GitHub.ViewModels.GitHubPane;
+using ReactiveUI;
+
+namespace GitHub.SampleData
+{
+    public class PullRequestReviewFileCommentViewModelDesigner : IPullRequestReviewFileCommentViewModel
+    {
+        public string Body { get; set; }
+        public string RelativePath { get; set; }
+        public ReactiveCommand<Unit> Open { get; }
+    }
+}

--- a/src/GitHub.App/SampleData/PullRequestReviewViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestReviewViewModelDesigner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using GitHub.Models;
 using GitHub.ViewModels.GitHubPane;
@@ -7,6 +8,7 @@ using ReactiveUI;
 
 namespace GitHub.SampleData
 {
+    [ExcludeFromCodeCoverage]
     public class PullRequestReviewViewModelDesigner : PanePageViewModelBase, IPullRequestReviewViewModel
     {
         public PullRequestReviewViewModelDesigner()
@@ -67,19 +69,5 @@ However, if you're two-way binding these properties to a UI, then ignore the rea
         public IPullRequestModel PullRequestModel { get; set; }
         public string RemoteRepositoryOwner { get; set; }
         public string StateDisplay { get; set; }
-
-        public Task InitializeAsync(
-            ILocalRepositoryModel localRepository,
-            string owner,
-            IPullRequestModel pullRequest,
-            long pullRequestReviewId)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task Load(IPullRequestModel pullRequest)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/GitHub.App/SampleData/PullRequestReviewViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestReviewViewModelDesigner.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GitHub.Models;
+using GitHub.ViewModels.GitHubPane;
+using ReactiveUI;
+
+namespace GitHub.SampleData
+{
+    public class PullRequestReviewViewModelDesigner : PanePageViewModelBase, IPullRequestReviewViewModel
+    {
+        public PullRequestReviewViewModelDesigner()
+        {
+            PullRequestModel = new PullRequestModel(
+                419,
+                "Fix a ton of potential crashers, odd code and redundant calls in ModelService",
+                new AccountDesigner { Login = "Haacked", IsUser = true },
+                DateTimeOffset.Now - TimeSpan.FromDays(2));
+
+            Model = new PullRequestReviewModel
+            {
+                
+                SubmittedAt = DateTimeOffset.Now - TimeSpan.FromDays(1),
+                User = new AccountDesigner { Login = "Haacked", IsUser = true },
+            };
+
+            Body = @"Just a few comments. I don't feel too strongly about them though.
+
+Otherwise, very nice work here! ✨";
+
+            StateDisplay = "approved";
+
+            FileComments = new[]
+            {
+                new PullRequestReviewFileCommentViewModelDesigner
+                {
+                    Body = @"These should probably be properties. Most likely they should be readonly properties. I know that makes creating instances of these not look as nice as using property initializers when constructing an instance, but if these properties should never be mutated after construction, then it guides future consumers to the right behavior.
+
+However, if you're two-way binding these properties to a UI, then ignore the readonly part and make them properties. But in that case they should probably be reactive properties (or implement INPC).",
+                    RelativePath = "src/GitHub.Exports.Reactive/ViewModels/IPullRequestListViewModel.cs",
+                },
+                new PullRequestReviewFileCommentViewModelDesigner
+                {
+                    Body = "While I have no problems with naming a variable ass I think we should probably avoid swear words in case Microsoft runs their Policheck tool against this code.",
+                    RelativePath = "src/GitHub.App/ViewModels/PullRequestListViewModel.cs",
+                },
+            };
+
+            OutdatedFileComments = new[]
+            {
+                new PullRequestReviewFileCommentViewModelDesigner
+                {
+                    Body = @"So this is just casting a mutable list to an IReadOnlyList which can be cast back to List. I know we probably won't do that, but I'm thinking of the next person to come along. The safe thing to do is to wrap List with a ReadOnlyList. We have an extension method ToReadOnlyList for observables. Wouldn't be hard to write one for IEnumerable.",
+                    RelativePath = "src/GitHub.Exports.Reactive/ViewModels/IPullRequestListViewModel.cs",
+                },
+            };
+        }
+
+        public string Body { get; }
+        public IReadOnlyList<IPullRequestReviewFileCommentViewModel> FileComments { get; set; }
+        public bool IsExpanded { get; set; }
+        public bool HasDetails { get; set; }
+        public ILocalRepositoryModel LocalRepository { get; set; }
+        public IPullRequestReviewModel Model { get; set; }
+        public ReactiveCommand<object> NavigateToPullRequest { get; }
+        public IReadOnlyList<IPullRequestReviewFileCommentViewModel> OutdatedFileComments { get; set; }
+        public IPullRequestModel PullRequestModel { get; set; }
+        public string RemoteRepositoryOwner { get; set; }
+        public string StateDisplay { get; set; }
+
+        public Task InitializeAsync(
+            ILocalRepositoryModel localRepository,
+            string owner,
+            IPullRequestModel pullRequest,
+            long pullRequestReviewId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Load(IPullRequestModel pullRequest)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/GitHub.App/SampleData/PullRequestUserReviewsViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestUserReviewsViewModelDesigner.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GitHub.Models;
+using GitHub.ViewModels.GitHubPane;
+using ReactiveUI;
+
+namespace GitHub.SampleData
+{
+    public class PullRequestUserReviewsViewModelDesigner : PanePageViewModelBase, IPullRequestUserReviewsViewModel
+    {
+        public PullRequestUserReviewsViewModelDesigner()
+        {
+            User = new AccountDesigner { Login = "Haacked", IsUser = true };
+            PullRequestNumber = 123;
+            PullRequestTitle = "Error handling/bubbling from viewmodels to views to viewhosts";
+            Reviews = new[]
+            {
+                new PullRequestReviewViewModelDesigner()
+                {
+                    IsExpanded = true,
+                    HasDetails = true,
+                    FileComments = new PullRequestReviewFileCommentViewModel[0],
+                    StateDisplay = "approved",
+                    Model = new PullRequestReviewModel
+                    {
+                        State = PullRequestReviewState.Approved,
+                        SubmittedAt = DateTimeOffset.Now - TimeSpan.FromDays(1),
+                        User = User,
+                    },
+                },
+                new PullRequestReviewViewModelDesigner()
+                {
+                    IsExpanded = true,
+                    HasDetails = true,
+                    StateDisplay = "requested changes",
+                    Model = new PullRequestReviewModel
+                    {
+                        State = PullRequestReviewState.ChangesRequested,
+                        SubmittedAt = DateTimeOffset.Now - TimeSpan.FromDays(2),
+                        User = User,
+                    },
+                },
+                new PullRequestReviewViewModelDesigner()
+                {
+                    IsExpanded = false,
+                    HasDetails = false,
+                    StateDisplay = "commented",
+                    Model = new PullRequestReviewModel
+                    {
+                        State = PullRequestReviewState.Commented,
+                        SubmittedAt = DateTimeOffset.Now - TimeSpan.FromDays(2),
+                        User = User,
+                    },
+                }
+            };
+        }
+
+        public ILocalRepositoryModel LocalRepository { get; set; }
+        public string RemoteRepositoryOwner { get; set; }
+        public int PullRequestNumber { get; set; }
+        public IAccount User { get; set; }
+        public IReadOnlyList<IPullRequestReviewViewModel> Reviews { get; set; }
+        public string PullRequestTitle { get; set; }
+        public ReactiveCommand<object> NavigateToPullRequest { get; }
+
+        public Task InitializeAsync(ILocalRepositoryModel localRepository, IConnection connection, string owner, string repo, int pullRequestNumber, string login)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task Load(IAccount user, IPullRequestModel pullRequest)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/GitHub.App/SampleData/PullRequestUserReviewsViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestUserReviewsViewModelDesigner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using GitHub.Models;
 using GitHub.ViewModels.GitHubPane;
@@ -7,6 +8,7 @@ using ReactiveUI;
 
 namespace GitHub.SampleData
 {
+    [ExcludeFromCodeCoverage]
     public class PullRequestUserReviewsViewModelDesigner : PanePageViewModelBase, IPullRequestUserReviewsViewModel
     {
         public PullRequestUserReviewsViewModelDesigner()
@@ -65,11 +67,6 @@ namespace GitHub.SampleData
         public ReactiveCommand<object> NavigateToPullRequest { get; }
 
         public Task InitializeAsync(ILocalRepositoryModel localRepository, IConnection connection, string owner, string repo, int pullRequestNumber, string login)
-        {
-            return Task.CompletedTask;
-        }
-
-        public Task Load(IAccount user, IPullRequestModel pullRequest)
         {
             return Task.CompletedTask;
         }

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -405,6 +405,7 @@ namespace GitHub.Services
                             Body = y.Body,
                             CommitId = y.Commit.Oid,
                             State = FromGraphQL(y.State),
+                            SubmittedAt = y.SubmittedAt,
                             User = Create(y.Author.Login, y.Author.AvatarUrl(null))
                         }).ToList()
                     });
@@ -630,6 +631,7 @@ namespace GitHub.Services
                         Body = x.Body,
                         State = x.State,
                         CommitId = x.CommitId,
+                        SubmittedAt = x.SubmittedAt,
                     }).ToList(),
                 ReviewComments = prCacheItem.ReviewComments.Select(x =>
                     (IPullRequestReviewCommentModel)new PullRequestReviewCommentModel
@@ -899,6 +901,7 @@ namespace GitHub.Services
                 };
                 Body = review.Body;
                 State = review.State;
+                SubmittedAt = review.SubmittedAt;
             }
 
             public long Id { get; set; }
@@ -907,6 +910,7 @@ namespace GitHub.Services
             public string Body { get; set; }
             public GitHub.Models.PullRequestReviewState State { get; set; }
             public string CommitId { get; set; }
+            public DateTimeOffset? SubmittedAt { get; set; }
         }
 
         public class PullRequestReviewCommentCacheItem

--- a/src/GitHub.App/Services/ModelService.cs
+++ b/src/GitHub.App/Services/ModelService.cs
@@ -57,6 +57,13 @@ namespace GitHub.Services
             return GetUserFromCache().Select(Create);
         }
 
+        public IObservable<IAccount> GetUser(string login)
+        {
+            return hostCache.GetAndRefreshObject("user|" + login,
+                () => ApiClient.GetUser(login).Select(AccountCacheItem.Create), TimeSpan.FromMinutes(5), TimeSpan.FromDays(7))
+                .Select(Create);
+        }
+
         public IObservable<GitIgnoreItem> GetGitIgnoreTemplates()
         {
             return Observable.Defer(() =>

--- a/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
@@ -33,6 +33,7 @@ namespace GitHub.ViewModels.GitHubPane
     {
         static readonly ILogger log = LogManager.ForContext<GitHubPaneViewModel>();
         static readonly Regex pullUri = CreateRoute("/:owner/:repo/pull/:number");
+        static readonly Regex pullUserReviewsUri = CreateRoute("/:owner/:repo/pull/:number/reviews/:login");
 
         readonly IViewViewModelFactory viewModelFactory;
         readonly ISimpleApiClientFactory apiClientFactory;
@@ -243,6 +244,14 @@ namespace GitHub.ViewModels.GitHubPane
                 var number = int.Parse(match.Groups["number"].Value);
                 await ShowPullRequest(owner, repo, number);
             }
+            else if ((match = pullUserReviewsUri.Match(uri.AbsolutePath))?.Success == true)
+            {
+                var owner = match.Groups["owner"].Value;
+                var repo = match.Groups["repo"].Value;
+                var number = int.Parse(match.Groups["number"].Value);
+                var login = match.Groups["login"].Value;
+                await ShowPullRequestReviews(owner, repo, number, login);
+            }
             else
             {
                 throw new NotSupportedException("Unrecognised GitHub pane URL: " + uri.AbsolutePath);
@@ -280,6 +289,20 @@ namespace GitHub.ViewModels.GitHubPane
             return NavigateTo<IPullRequestDetailViewModel>(
                 x => x.InitializeAsync(LocalRepository, Connection, owner, repo, number),
                 x => x.RemoteRepositoryOwner == owner && x.LocalRepository.Name == repo && x.Number == number);
+        }
+
+        /// <inheritdoc/>
+        public Task ShowPullRequestReviews(string owner, string repo, int number, string login)
+        {
+            Guard.ArgumentNotNull(owner, nameof(owner));
+            Guard.ArgumentNotNull(repo, nameof(repo));
+
+            return NavigateTo<IPullRequestUserReviewsViewModel>(
+                x => x.InitializeAsync(LocalRepository, Connection, owner, repo, number, login),
+                x => x.RemoteRepositoryOwner == owner &&
+                     x.LocalRepository.Name == repo &&
+                     x.PullRequestNumber == number &&
+                     x.User.Login == login);
         }
 
         async Task CreateInitializeTask(IServiceProvider paneServiceProvider)

--- a/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
@@ -408,7 +408,7 @@ namespace GitHub.ViewModels.GitHubPane
         static Regex CreateRoute(string route)
         {
             // Build RegEx from route (:foo to named group (?<foo>[\w_.-]+)).
-            var routeFormat = new Regex("(:([a-z]+))\\b").Replace(route, @"(?<$2>[\w_.-]+)");
+            var routeFormat = "^" + new Regex("(:([a-z]+))\\b").Replace(route, @"(?<$2>[\w_.-]+)") + "$";
             return new Regex(routeFormat, RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
         }
     }

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
@@ -18,6 +18,7 @@ using GitHub.Services;
 using LibGit2Sharp;
 using ReactiveUI;
 using Serilog;
+using static System.FormattableString;
 
 namespace GitHub.ViewModels.GitHubPane
 {
@@ -636,7 +637,16 @@ namespace GitHub.ViewModels.GitHubPane
 
         void DoShowReview(object item)
         {
-            // TODO
+            var review = (PullRequestReviewSummaryViewModel)item;
+
+            if (review.State == PullRequestReviewState.Pending)
+            {
+                throw new NotImplementedException();
+            }
+            else
+            {
+                NavigateTo(Invariant($"{RemoteRepositoryOwner}/{LocalRepository.Name}/pull/{Number}/reviews/{review.User.Login}"));
+            }
         }
 
         class CheckoutCommandState : IPullRequestCheckoutState

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewFileCommentViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewFileCommentViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 using GitHub.Extensions;
 using GitHub.Models;
@@ -12,7 +13,9 @@ namespace GitHub.ViewModels.GitHubPane
     /// </summary>
     public class PullRequestReviewFileCommentViewModel : IPullRequestReviewFileCommentViewModel
     {
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "This will be used in a later PR")]
         readonly IPullRequestEditorService editorService;
+        [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "This will be used in a later PR")]
         readonly IPullRequestSession session;
         readonly IPullRequestReviewCommentModel model;
 

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewFileCommentViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewFileCommentViewModel.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Reactive;
+using GitHub.Extensions;
+using GitHub.Models;
+using GitHub.Services;
+using ReactiveUI;
+
+namespace GitHub.ViewModels.GitHubPane
+{
+    /// <summary>
+    /// A view model for a file comment in a <see cref="PullRequestReviewViewModel"/>.
+    /// </summary>
+    public class PullRequestReviewFileCommentViewModel : IPullRequestReviewFileCommentViewModel
+    {
+        readonly IPullRequestEditorService editorService;
+        readonly IPullRequestSession session;
+        readonly IPullRequestReviewCommentModel model;
+
+        public PullRequestReviewFileCommentViewModel(
+            IPullRequestEditorService editorService,
+            IPullRequestSession session,
+            IPullRequestReviewCommentModel model)
+        {
+            Guard.ArgumentNotNull(editorService, nameof(editorService));
+            Guard.ArgumentNotNull(session, nameof(session));
+            Guard.ArgumentNotNull(model, nameof(model));
+
+            this.editorService = editorService;
+            this.session = session;
+            this.model = model;
+        }
+
+        /// <inheritdoc/>
+        public string Body => model.Body;
+
+        /// <inheritdoc/>
+        public string RelativePath => model.Path;
+
+        /// <inheritdoc/>
+        public ReactiveCommand<Unit> Open { get; }
+    }
+}

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewViewModel.cs
@@ -14,10 +14,6 @@ namespace GitHub.ViewModels.GitHubPane
     /// </summary>
     public class PullRequestReviewViewModel : ViewModelBase, IPullRequestReviewViewModel
     {
-        static readonly ILogger log = LogManager.ForContext<PullRequestReviewViewModel>();
-
-        readonly IPullRequestEditorService editorService;
-        readonly IPullRequestSession session;
         bool isExpanded;
 
         /// <summary>
@@ -36,9 +32,6 @@ namespace GitHub.ViewModels.GitHubPane
             Guard.ArgumentNotNull(editorService, nameof(editorService));
             Guard.ArgumentNotNull(session, nameof(session));
             Guard.ArgumentNotNull(model, nameof(model));
-
-            this.editorService = editorService;
-            this.session = session;
 
             Model = model;
             Body = string.IsNullOrWhiteSpace(Model.Body) ? null : Model.Body;

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewViewModel.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using GitHub.Extensions;
+using GitHub.Logging;
+using GitHub.Models;
+using GitHub.Services;
+using Serilog;
+
+namespace GitHub.ViewModels.GitHubPane
+{
+    /// <summary>
+    /// View model for displaying details of a pull request review.
+    /// </summary>
+    public class PullRequestReviewViewModel : ViewModelBase, IPullRequestReviewViewModel
+    {
+        static readonly ILogger log = LogManager.ForContext<PullRequestReviewViewModel>();
+
+        readonly IPullRequestEditorService editorService;
+        readonly IPullRequestSession session;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PullRequestReviewViewModel"/> class.
+        /// </summary>
+        /// <param name="localRepository">The local repository.</param>
+        /// <param name="owner">The pull request's repository owner.</param>
+        /// <param name="pullRequest">The pull request model.</param>
+        /// <param name="pullRequestReviewId">The pull request review ID.</param>
+        public PullRequestReviewViewModel(
+            IPullRequestEditorService editorService,
+            IPullRequestSession session,
+            ILocalRepositoryModel localRepository,
+            string owner,
+            IPullRequestModel pullRequest,
+            long pullRequestReviewId)
+        {
+            Guard.ArgumentNotNull(editorService, nameof(editorService));
+            Guard.ArgumentNotNull(session, nameof(session));
+            Guard.ArgumentNotNull(localRepository, nameof(localRepository));
+            Guard.ArgumentNotNull(owner, nameof(owner));
+            Guard.ArgumentNotNull(pullRequest, nameof(pullRequest));
+
+            this.editorService = editorService;
+            this.session = session;
+
+            LocalRepository = localRepository;
+            RemoteRepositoryOwner = owner;
+            Model = GetModel(pullRequest, pullRequestReviewId);
+            PullRequestModel = pullRequest;
+            Body = string.IsNullOrWhiteSpace(Model.Body) ? null : Model.Body;
+            StateDisplay = ToString(Model.State);
+
+            var comments = new List<IPullRequestReviewFileCommentViewModel>();
+            var outdated = new List<IPullRequestReviewFileCommentViewModel>();
+
+            foreach (var comment in PullRequestModel.ReviewComments)
+            {
+                if (comment.PullRequestReviewId == pullRequestReviewId)
+                {
+                    var vm = new PullRequestReviewFileCommentViewModel(
+                        editorService,
+                        session,
+                        comment);
+
+                    if (comment.Position.HasValue)
+                        comments.Add(vm);
+                    else
+                        outdated.Add(vm);
+                }
+            }
+
+            FileComments = comments;
+            OutdatedFileComments = outdated;
+
+            HasDetails = Body != null ||
+                FileComments.Count > 0 ||
+                OutdatedFileComments.Count > 0;
+            IsExpanded = HasDetails && CalculateIsLatest(pullRequest, Model);
+        }
+
+        /// <inheritdoc/>
+        public ILocalRepositoryModel LocalRepository { get; private set; }
+
+        /// <inheritdoc/>
+        public string RemoteRepositoryOwner { get; private set; }
+
+        /// <inheritdoc/>
+        public IPullRequestReviewModel Model { get; }
+
+        /// <inheritdoc/>
+        public IPullRequestModel PullRequestModel { get; }
+
+        /// <inheritdoc/>
+        public string Body { get; }
+
+        /// <inheritdoc/>
+        public string StateDisplay { get; }
+
+        /// <inheritdoc/>
+        public bool IsExpanded { get; }
+
+        /// <inheritdoc/>
+        public bool HasDetails { get; }
+
+        /// <inheritdoc/>
+        public IReadOnlyList<IPullRequestReviewFileCommentViewModel> FileComments { get; }
+
+        /// <inheritdoc/>
+        public IReadOnlyList<IPullRequestReviewFileCommentViewModel> OutdatedFileComments { get; }
+
+        static bool CalculateIsLatest(IPullRequestModel pullRequest, IPullRequestReviewModel model)
+        {
+            return !pullRequest.Reviews.Any(x =>
+                x.User.Login == model.User.Login &&
+                x.SubmittedAt > model.SubmittedAt);
+        }
+
+        static IPullRequestReviewModel GetModel(IPullRequestModel pullRequest, long pullRequestReviewId)
+        {
+            var result = pullRequest.Reviews.FirstOrDefault(x => x.Id == pullRequestReviewId);
+
+            if (result == null)
+            {
+                throw new KeyNotFoundException(
+                    $"Unable to find review {pullRequestReviewId} in pull request #{pullRequest.Number}");
+            }
+
+            return result;
+        }
+
+        static string ToString(PullRequestReviewState state)
+        {
+            switch (state)
+            {
+                case PullRequestReviewState.Approved:
+                    return "approved";
+                case PullRequestReviewState.ChangesRequested:
+                    return "requested changes";
+                case PullRequestReviewState.Commented:
+                case PullRequestReviewState.Dismissed:
+                    return "commented";
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestUserReviewsViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestUserReviewsViewModel.cs
@@ -139,8 +139,10 @@ namespace GitHub.ViewModels.GitHubPane
         }
 
         /// <inheritdoc/>
-        public async Task Load(IAccount user, IPullRequestModel pullRequest)
+        async Task Load(IAccount user, IPullRequestModel pullRequest)
         {
+            IsBusy = true;
+
             try
             {
                 session = await sessionManager.GetSession(pullRequest);
@@ -148,19 +150,17 @@ namespace GitHub.ViewModels.GitHubPane
                 PullRequestTitle = pullRequest.Title;
 
                 var reviews = new List<IPullRequestReviewViewModel>();
+                var isFirst = true;
 
                 foreach (var review in pullRequest.Reviews.OrderByDescending(x => x.SubmittedAt))
                 {
-                    if (review.User.Login == user.Login)
+                    if (review.User.Login == user.Login &&
+                        review.State != PullRequestReviewState.Pending)
                     {
-                        var vm = new PullRequestReviewViewModel(
-                            editorService,
-                            session,
-                            LocalRepository,
-                            RemoteRepositoryOwner,
-                            pullRequest,
-                            review.Id);
+                        var vm = new PullRequestReviewViewModel(editorService, session, pullRequest, review);
+                        vm.IsExpanded = isFirst;
                         reviews.Add(vm);
+                        isFirst = false;
                     }
                 }
 

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestUserReviewsViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestUserReviewsViewModel.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using GitHub.Extensions;
+using GitHub.Factories;
+using GitHub.Logging;
+using GitHub.Models;
+using GitHub.Services;
+using ReactiveUI;
+using Serilog;
+using static System.FormattableString;
+
+namespace GitHub.ViewModels.GitHubPane
+{
+    /// <summary>
+    /// Displays all reviews made by a user on a pull request.
+    /// </summary>
+    [Export(typeof(IPullRequestUserReviewsViewModel))]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public class PullRequestUserReviewsViewModel : PanePageViewModelBase, IPullRequestUserReviewsViewModel
+    {
+        static readonly ILogger log = LogManager.ForContext<PullRequestReviewViewModel>();
+
+        readonly IPullRequestEditorService editorService;
+        readonly IPullRequestSessionManager sessionManager;
+        readonly IModelServiceFactory modelServiceFactory;
+        IModelService modelService;
+        IPullRequestSession session;
+        IAccount user;
+        string title;
+        IReadOnlyList<IPullRequestReviewViewModel> reviews;
+
+        [ImportingConstructor]
+        public PullRequestUserReviewsViewModel(
+            IPullRequestEditorService editorService,
+            IPullRequestSessionManager sessionManager,
+            IModelServiceFactory modelServiceFactory)
+        {
+            Guard.ArgumentNotNull(editorService, nameof(editorService));
+            Guard.ArgumentNotNull(sessionManager, nameof(sessionManager));
+            Guard.ArgumentNotNull(modelServiceFactory, nameof(modelServiceFactory));
+
+            this.editorService = editorService;
+            this.sessionManager = sessionManager;
+            this.modelServiceFactory = modelServiceFactory;
+
+            NavigateToPullRequest = ReactiveCommand.Create().OnExecuteCompleted(_ =>
+                NavigateTo(Invariant($"{LocalRepository.Owner}/{LocalRepository.Name}/pull/{PullRequestNumber}")));
+        }
+
+        /// <inheritdoc/>
+        public ILocalRepositoryModel LocalRepository { get; private set; }
+
+        /// <inheritdoc/>
+        public string RemoteRepositoryOwner { get; private set; }
+
+        /// <inheritdoc/>
+        public int PullRequestNumber { get; private set; }
+
+        public IAccount User
+        {
+            get { return user; }
+            private set { this.RaiseAndSetIfChanged(ref user, value); }
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyList<IPullRequestReviewViewModel> Reviews
+        {
+            get { return reviews; }
+            private set { this.RaiseAndSetIfChanged(ref reviews, value); }
+        }
+
+        /// <inheritdoc/>
+        public string PullRequestTitle
+        {
+            get { return title; }
+            private set { this.RaiseAndSetIfChanged(ref title, value); }
+        }
+
+        /// <inheritdoc/>
+        public ReactiveCommand<object> NavigateToPullRequest { get; }
+
+        /// <inheritdoc/>
+        public async Task InitializeAsync(
+            ILocalRepositoryModel localRepository,
+            IConnection connection,
+            string owner,
+            string repo,
+            int pullRequestNumber,
+            string login)
+        {
+            if (repo != localRepository.Name)
+            {
+                throw new NotSupportedException();
+            }
+
+            IsLoading = true;
+
+            try
+            {
+                LocalRepository = localRepository;
+                RemoteRepositoryOwner = owner;
+                PullRequestNumber = pullRequestNumber;
+                modelService = await modelServiceFactory.CreateAsync(connection);
+                User = await modelService.GetUser(login);
+                await Refresh();
+            }
+            finally
+            {
+                IsLoading = false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override async Task Refresh()
+        {
+            try
+            {
+                Error = null;
+                IsBusy = true;
+                var pullRequest = await modelService.GetPullRequest(RemoteRepositoryOwner, LocalRepository.Name, PullRequestNumber);
+                await Load(User, pullRequest);
+            }
+            catch (Exception ex)
+            {
+                log.Error(
+                    ex,
+                    "Error loading pull request reviews {Owner}/{Repo}/{Number} from {Address}",
+                    RemoteRepositoryOwner,
+                    LocalRepository.Name,
+                    PullRequestNumber,
+                    modelService.ApiClient.HostAddress.Title);
+                Error = ex;
+                IsBusy = false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task Load(IAccount user, IPullRequestModel pullRequest)
+        {
+            try
+            {
+                session = await sessionManager.GetSession(pullRequest);
+                User = user;
+                PullRequestTitle = pullRequest.Title;
+
+                var reviews = new List<IPullRequestReviewViewModel>();
+
+                foreach (var review in pullRequest.Reviews.OrderByDescending(x => x.SubmittedAt))
+                {
+                    if (review.User.Login == user.Login)
+                    {
+                        var vm = new PullRequestReviewViewModel(
+                            editorService,
+                            session,
+                            LocalRepository,
+                            RemoteRepositoryOwner,
+                            pullRequest,
+                            review.Id);
+                        reviews.Add(vm);
+                    }
+                }
+
+                Reviews = reviews;
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+    }
+}

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestUserReviewsViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestUserReviewsViewModel.cs
@@ -139,14 +139,14 @@ namespace GitHub.ViewModels.GitHubPane
         }
 
         /// <inheritdoc/>
-        async Task Load(IAccount user, IPullRequestModel pullRequest)
+        async Task Load(IAccount author, IPullRequestModel pullRequest)
         {
             IsBusy = true;
 
             try
             {
                 session = await sessionManager.GetSession(pullRequest);
-                User = user;
+                User = author;
                 PullRequestTitle = pullRequest.Title;
 
                 var reviews = new List<IPullRequestReviewViewModel>();
@@ -154,7 +154,7 @@ namespace GitHub.ViewModels.GitHubPane
 
                 foreach (var review in pullRequest.Reviews.OrderByDescending(x => x.SubmittedAt))
                 {
-                    if (review.User.Login == user.Login &&
+                    if (review.User.Login == author.Login &&
                         review.State != PullRequestReviewState.Pending)
                     {
                         var vm = new PullRequestReviewViewModel(editorService, session, pullRequest, review);

--- a/src/GitHub.Exports.Reactive/Api/IApiClient.cs
+++ b/src/GitHub.Exports.Reactive/Api/IApiClient.cs
@@ -16,6 +16,7 @@ namespace GitHub.Api
         IObservable<Repository> CreateRepository(NewRepository repository, string login, bool isUser);
         IObservable<Gist> CreateGist(NewGist newGist);
         IObservable<User> GetUser();
+        IObservable<User> GetUser(string login);
         IObservable<Organization> GetOrganizations();
         /// <summary>
         /// Retrieves all repositories that belong to this user.

--- a/src/GitHub.Exports.Reactive/GitHub.Exports.Reactive.csproj
+++ b/src/GitHub.Exports.Reactive/GitHub.Exports.Reactive.csproj
@@ -197,7 +197,10 @@
     <Compile Include="ViewModels\GitHubPane\IPanePageViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\IPullRequestFilesViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\IPullRequestListViewModel.cs" />
+    <Compile Include="ViewModels\GitHubPane\IPullRequestReviewFileCommentViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\IPullRequestReviewSummaryViewModel.cs" />
+    <Compile Include="ViewModels\GitHubPane\IPullRequestReviewViewModel.cs" />
+    <Compile Include="ViewModels\GitHubPane\IPullRequestUserReviewsViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\ISearchablePageViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\IPullRequestCreationViewModel.cs" />
     <Compile Include="ViewModels\GitHubPane\IPullRequestDetailViewModel.cs" />

--- a/src/GitHub.Exports.Reactive/Services/IModelService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IModelService.cs
@@ -17,6 +17,7 @@ namespace GitHub.Services
         IApiClient ApiClient { get; }
 
         IObservable<IAccount> GetCurrentUser();
+        IObservable<IAccount> GetUser(string login);
         IObservable<Unit> InsertUser(AccountCacheItem user);
         IObservable<IReadOnlyList<IAccount>> GetAccounts();
         IObservable<IRemoteRepositoryModel> GetRepository(string owner, string repo);

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewFileCommentViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewFileCommentViewModel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Reactive;
+using ReactiveUI;
+
+namespace GitHub.ViewModels.GitHubPane
+{
+    /// <summary>
+    /// Represents a view model for a file comment in an <see cref="IPullRequestReviewViewModel"/>.
+    /// </summary>
+    public interface IPullRequestReviewFileCommentViewModel
+    {
+        /// <summary>
+        /// Gets the body of the comment.
+        /// </summary>
+        string Body { get; }
+
+        /// <summary>
+        /// Gets the path to the file, relative to the root of the repository.
+        /// </summary>
+        string RelativePath { get; }
+
+        /// <summary>
+        /// Gets a comment which opens the comment in a diff view.
+        /// </summary>
+        ReactiveCommand<Unit> Open { get; }
+    }
+}

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewFileCommentViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewFileCommentViewModel.cs
@@ -20,7 +20,7 @@ namespace GitHub.ViewModels.GitHubPane
         string RelativePath { get; }
 
         /// <summary>
-        /// Gets a comment which opens the comment in a diff view.
+        /// Gets a command which opens the comment in a diff view.
         /// </summary>
         ReactiveCommand<Unit> Open { get; }
     }

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewViewModel.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using GitHub.Models;
+
+namespace GitHub.ViewModels.GitHubPane
+{
+    /// <summary>
+    /// Represents a view model that displays a pull request review.
+    /// </summary>
+    public interface IPullRequestReviewViewModel : IViewModel
+    {
+        /// <summary>
+        /// Gets the local repository.
+        /// </summary>
+        ILocalRepositoryModel LocalRepository { get; }
+
+        /// <summary>
+        /// Gets the owner of the remote repository that contains the pull request.
+        /// </summary>
+        /// <remarks>
+        /// The remote repository may be different from the local repository if the local
+        /// repository is a fork and the user is viewing pull requests from the parent repository.
+        /// </remarks>
+        string RemoteRepositoryOwner { get; }
+
+        /// <summary>
+        /// Gets the underlying pull request review model.
+        /// </summary>
+        IPullRequestReviewModel Model { get; }
+
+        /// <summary>
+        /// Gets the underlying pull request model.
+        /// </summary>
+        IPullRequestModel PullRequestModel { get; }
+
+        /// <summary>
+        /// Gets the body of the review.
+        /// </summary>
+        string Body { get; }
+
+        /// <summary>
+        /// Gets the state of the pull request review as a string.
+        /// </summary>
+        string StateDisplay { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the pull request review should initially be expanded.
+        /// </summary>
+        bool IsExpanded { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the pull request review has a body or file comments.
+        /// </summary>
+        bool HasDetails { get; }
+
+        /// <summary>
+        /// Gets a list of the file comments in the review.
+        /// </summary>
+        IReadOnlyList<IPullRequestReviewFileCommentViewModel> FileComments { get; }
+
+        /// <summary>
+        /// Gets a list of outdated file comments in the review.
+        /// </summary>
+        IReadOnlyList<IPullRequestReviewFileCommentViewModel> OutdatedFileComments { get; }
+    }
+}

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewViewModel.cs
@@ -10,28 +10,9 @@ namespace GitHub.ViewModels.GitHubPane
     public interface IPullRequestReviewViewModel : IViewModel
     {
         /// <summary>
-        /// Gets the local repository.
-        /// </summary>
-        ILocalRepositoryModel LocalRepository { get; }
-
-        /// <summary>
-        /// Gets the owner of the remote repository that contains the pull request.
-        /// </summary>
-        /// <remarks>
-        /// The remote repository may be different from the local repository if the local
-        /// repository is a fork and the user is viewing pull requests from the parent repository.
-        /// </remarks>
-        string RemoteRepositoryOwner { get; }
-
-        /// <summary>
         /// Gets the underlying pull request review model.
         /// </summary>
         IPullRequestReviewModel Model { get; }
-
-        /// <summary>
-        /// Gets the underlying pull request model.
-        /// </summary>
-        IPullRequestModel PullRequestModel { get; }
 
         /// <summary>
         /// Gets the body of the review.

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestUserReviewsViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestUserReviewsViewModel.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using GitHub.Models;
+using ReactiveUI;
+
+namespace GitHub.ViewModels.GitHubPane
+{
+    /// <summary>
+    /// Displays all reviews made by a user on a pull request.
+    /// </summary>
+    public interface IPullRequestUserReviewsViewModel : IPanePageViewModel
+    {
+        /// <summary>
+        /// Gets the local repository.
+        /// </summary>
+        ILocalRepositoryModel LocalRepository { get; }
+
+        /// <summary>
+        /// Gets the owner of the remote repository that contains the pull request.
+        /// </summary>
+        /// <remarks>
+        /// The remote repository may be different from the local repository if the local
+        /// repository is a fork and the user is viewing pull requests from the parent repository.
+        /// </remarks>
+        string RemoteRepositoryOwner { get; }
+
+        /// <summary>
+        /// Gets the number of the pull request.
+        /// </summary>
+        int PullRequestNumber { get; }
+
+        /// <summary>
+        /// Gets the reviews made by the <see cref="User"/>.
+        /// </summary>
+        IReadOnlyList<IPullRequestReviewViewModel> Reviews { get; }
+
+        /// <summary>
+        /// Gets the title of the pull request.
+        /// </summary>
+        string PullRequestTitle { get; }
+
+        /// <summary>
+        /// Gets the user whose reviews are being shown.
+        /// </summary>
+        IAccount User { get; }
+
+        /// <summary>
+        /// Gets a command that navigates to the parent pull request in the GitHub pane.
+        /// </summary>
+        ReactiveCommand<object> NavigateToPullRequest { get; }
+
+        /// <summary>
+        /// Initializes the view model, loading data from the API.
+        /// </summary>
+        /// <param name="localRepository">The local repository.</param>
+        /// <param name="connection">The connection to the repository host.</param>
+        /// <param name="owner">The pull request's repository owner.</param>
+        /// <param name="repo">The pull request's repository name.</param>
+        /// <param name="pullRequestNumber">The pull request number.</param>
+        /// <param name="login">The user's login.</param>
+        Task InitializeAsync(
+            ILocalRepositoryModel localRepository,
+            IConnection connection,
+            string owner,
+            string repo,
+            int pullRequestNumber,
+            string login);
+
+        /// <summary>
+        /// Loads the view model from pre-loaded models.
+        /// </summary>
+        /// <param name="user">The user model.</param>
+        /// <param name="pullRequest">The pull request model.</param>
+        /// <returns></returns>
+        Task Load(IAccount user, IPullRequestModel pullRequest);
+    }
+}

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestUserReviewsViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestUserReviewsViewModel.cs
@@ -65,13 +65,5 @@ namespace GitHub.ViewModels.GitHubPane
             string repo,
             int pullRequestNumber,
             string login);
-
-        /// <summary>
-        /// Loads the view model from pre-loaded models.
-        /// </summary>
-        /// <param name="user">The user model.</param>
-        /// <param name="pullRequest">The pull request model.</param>
-        /// <returns></returns>
-        Task Load(IAccount user, IPullRequestModel pullRequest);
     }
 }

--- a/src/GitHub.Exports/Models/IPullRequestReviewModel.cs
+++ b/src/GitHub.Exports/Models/IPullRequestReviewModel.cs
@@ -67,5 +67,10 @@ namespace GitHub.Models
         /// Gets the SHA of the commit that the review was submitted on.
         /// </summary>
         string CommitId { get; }
+
+        /// <summary>
+        /// Gets the date/time that the review was submitted.
+        /// </summary>
+        DateTimeOffset? SubmittedAt { get; }
     }
 }

--- a/src/GitHub.Exports/ViewModels/GitHubPane/IGitHubPaneViewModel.cs
+++ b/src/GitHub.Exports/ViewModels/GitHubPane/IGitHubPaneViewModel.cs
@@ -90,5 +90,14 @@ namespace GitHub.ViewModels.GitHubPane
         /// <param name="repo">The repository name.</param>
         /// <param name="number">The pull rqeuest number.</param>
         Task ShowPullRequest(string owner, string repo, int number);
+
+        /// <summary>
+        /// Shows the pull requests reviews authored by a user.
+        /// </summary>
+        /// <param name="owner">The repository owner.</param>
+        /// <param name="repo">The repository name.</param>
+        /// <param name="number">The pull rqeuest number.</param>
+        /// <param name="login">The user login.</param>
+        Task ShowPullRequestReviews(string owner, string repo, int number, string login);
     }
 }

--- a/src/GitHub.UI/Assets/Controls.xaml
+++ b/src/GitHub.UI/Assets/Controls.xaml
@@ -419,7 +419,121 @@
             </Setter.Value>
         </Setter>
     </Style>
+    
     <!-- End ProgressBar -->
+    <!-- Expander -->
+
+    <!-- 
+         A toggle button that displays a triangle expander icon for use in an Expander.
+         Note that when the button is disabled, the triangle expander is hidden.  This is because
+         this is the behavior we want in the only place where we use disabled expanders currently 
+         (PullRequestUserReviewsView).
+    -->
+    <Style x:Key="TriangleToggleButton" TargetType="{x:Type ToggleButton}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Border Background="{TemplateBinding Background}"
+                            Padding="{TemplateBinding Padding}">
+                        <DockPanel>
+                            <ui:OcticonImage x:Name="arrow"
+                                DockPanel.Dock="Left"
+                                Height="10"
+                                Margin="5,0,0,0"
+                                Icon="triangle_right"
+                                Foreground="{TemplateBinding Foreground}"
+                                Visibility="{TemplateBinding IsEnabled, Converter={ui:BooleanToHiddenVisibilityConverter}}"/>
+                            <ContentPresenter Margin="0"
+                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                RecognizesAccessKey="True"
+                                SnapsToDevicePixels="True" />
+                        </DockPanel>
+                    </Border>
+
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="arrow" Property="Icon" Value="triangle_down" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ExpanderHeaderFocusVisual">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border>
+                        <Rectangle Margin="0"
+                            SnapsToDevicePixels="true"
+                            Stroke="Black"
+                            StrokeDashArray="1 2"
+                            StrokeThickness="1" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type Expander}">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Foreground" Value="{DynamicResource GitHubVsToolWindowText}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Expander}">
+                    <Border SnapsToDevicePixels="true">
+                        <DockPanel>
+                            <ToggleButton x:Name="HeaderSite"
+                                MinWidth="0"
+                                MinHeight="0"
+                                Margin="0"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding Header}"
+                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                DockPanel.Dock="Top"
+                                FocusVisualStyle="{StaticResource ExpanderHeaderFocusVisual}"
+                                FontFamily="{TemplateBinding FontFamily}"
+                                FontSize="{TemplateBinding FontSize}"
+                                FontStretch="{TemplateBinding FontStretch}"
+                                FontStyle="{TemplateBinding FontStyle}"
+                                FontWeight="{TemplateBinding FontWeight}"
+                                Foreground="{TemplateBinding Foreground}"
+                                IsEnabled="{TemplateBinding IsEnabled}"
+                                IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                Padding="{TemplateBinding Padding}"
+                                Style="{StaticResource TriangleToggleButton}" />
+                            <ContentPresenter x:Name="ExpandSite"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    DockPanel.Dock="Bottom"
+                                    Focusable="false"
+                                    Visibility="Collapsed" />
+                        </DockPanel>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsExpanded" Value="true">
+                            <Setter TargetName="ExpandSite" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <!-- End Expander -->
 
     <ControlTemplate x:Key="ValidationAdorner">
         <Grid>

--- a/src/GitHub.UI/Assets/Controls.xaml
+++ b/src/GitHub.UI/Assets/Controls.xaml
@@ -424,10 +424,10 @@
     <!-- Expander -->
 
     <!-- 
-         A toggle button that displays a triangle expander icon for use in an Expander.
-         Note that when the button is disabled, the triangle expander is hidden.  This is because
-         this is the behavior we want in the only place where we use disabled expanders currently 
-         (PullRequestUserReviewsView).
+         A toggle button that displays a triangle expander for use in an Expander. Note that when 
+         the button is disabled, the triangle expander is hidden.  This is because this is the
+         behavior we want in the only place where we use disabled expanders currently (in 
+         PullRequestUserReviewsView).
     -->
     <Style x:Key="TriangleToggleButton" TargetType="{x:Type ToggleButton}">
         <Setter Property="Template">
@@ -436,13 +436,18 @@
                     <Border Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}">
                         <DockPanel>
-                            <ui:OcticonImage x:Name="arrow"
-                                DockPanel.Dock="Left"
-                                Height="10"
-                                Margin="5,0,0,0"
-                                Icon="triangle_right"
-                                Foreground="{TemplateBinding Foreground}"
-                                Visibility="{TemplateBinding IsEnabled, Converter={ui:BooleanToHiddenVisibilityConverter}}"/>
+                            <Border Background="Transparent" Width="10" Margin="5,0">
+                                <Path Name="arrow"
+                                      DockPanel.Dock="Left"
+                                      Fill="{TemplateBinding Foreground}"
+                                      Height="7"
+                                      Width="7"
+                                      VerticalAlignment="Center"
+                                      HorizontalAlignment="Center"
+                                      Stretch="UniformToFill"
+                                      Data="M7 1l-.025 5H2z"
+                                      Visibility="{TemplateBinding IsEnabled, Converter={ui:BooleanToHiddenVisibilityConverter}}"/>
+                            </Border>
                             <ContentPresenter Margin="0"
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -452,8 +457,12 @@
                     </Border>
 
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="arrow" Property="Icon" Value="triangle_down" />
+                        <Trigger Property="IsChecked" Value="False">
+                            <Setter TargetName="arrow" Property="LayoutTransform">
+                                <Setter.Value>
+                                    <RotateTransform Angle="-45" />
+                                </Setter.Value>
+                            </Setter>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/GitHub.UI/Controls/TrimmedPathTextBlock.cs
+++ b/src/GitHub.UI/Controls/TrimmedPathTextBlock.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace GitHub.UI
+{
+    /// <summary>
+    /// TextBlock that displays a path and intelligently trims with ellipsis when the path doesn't
+    /// fit in the allocated size.
+    /// </summary>
+    /// <remarks>
+    /// When displaying a path that is too long for its allocated space, we need to trim the path
+    /// with ellipses intelligently instead of simply trimming the end (as this is the filename
+    /// which is the most important part!). This control trims a path in the following manner with
+    /// decreasing allocated space:
+    /// 
+    /// - VisualStudio\src\GitHub.UI\Controls\TrimmedPathTextBlock.cs
+    /// - VisualStudio\...\GitHub.UI\Controls\TrimmedPathTextBlock.cs
+    /// - VisualStudio\...\...\Controls\TrimmedPathTextBlock.cs
+    /// - VisualStudio\...\...\...\TrimmedPathTextBlock.cs
+    /// - ...\...\...\...\TrimmedPathTextBlock.cs
+    /// </remarks>
+    public class TrimmedPathTextBlock : FrameworkElement
+    {
+        public static readonly DependencyProperty FontFamilyProperty =
+            TextBlock.FontFamilyProperty.AddOwner(typeof(TrimmedPathTextBlock));
+        public static readonly DependencyProperty FontSizeProperty =
+            TextBlock.FontSizeProperty.AddOwner(typeof(TrimmedPathTextBlock));
+        public static readonly DependencyProperty FontStretchProperty =
+            TextBlock.FontStretchProperty.AddOwner(typeof(TrimmedPathTextBlock));
+        public static readonly DependencyProperty FontStyleProperty =
+            TextBlock.FontStyleProperty.AddOwner(typeof(TrimmedPathTextBlock));
+        public static readonly DependencyProperty FontWeightProperty =
+            TextBlock.FontWeightProperty.AddOwner(typeof(TrimmedPathTextBlock));
+        public static readonly DependencyProperty ForegroundProperty =
+            TextBlock.ForegroundProperty.AddOwner(typeof(TrimmedPathTextBlock));
+        public static readonly DependencyProperty TextProperty =
+            TextBlock.TextProperty.AddOwner(
+                typeof(TrimmedPathTextBlock),
+                new FrameworkPropertyMetadata(
+                    null,
+                    FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender,
+                    TextChanged));
+
+        FormattedText formattedText;
+        FormattedText renderText;
+
+        public FontFamily FontFamily
+        {
+            get { return (FontFamily)GetValue(FontFamilyProperty); }
+            set { SetValue(FontFamilyProperty, value); }
+        }
+
+        public double FontSize
+        {
+            get { return (double)GetValue(FontSizeProperty); }
+            set { SetValue(FontSizeProperty, value); }
+        }
+
+        public FontStretch FontStretch
+        {
+            get { return (FontStretch)GetValue(FontStretchProperty); }
+            set { SetValue(FontStretchProperty, value); }
+        }
+
+        public FontStyle FontStyle
+        {
+            get { return (FontStyle)GetValue(FontStyleProperty); }
+            set { SetValue(FontStyleProperty, value); }
+        }
+
+        public FontWeight FontWeight
+        {
+            get { return (FontWeight)GetValue(FontWeightProperty); }
+            set { SetValue(FontWeightProperty, value); }
+        }
+
+        public Brush Foreground
+        {
+            get { return (Brush)GetValue(ForegroundProperty); }
+            set { SetValue(ForegroundProperty, value); }
+        }
+
+        public string Text
+        {
+            get { return (string)GetValue(TextProperty); }
+            set { SetValue(TextProperty, value); }
+        }
+
+        protected FormattedText FormattedText
+        {
+            get
+            {
+                if (formattedText == null && Text != null)
+                {
+                    formattedText = CreateFormattedText(Text);
+                }
+
+                return formattedText;
+            }
+        }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            var parts = Text
+                .Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar })
+                .ToList();
+            var nextPart = Math.Min(1, parts.Count - 1);
+
+            while (true)
+            {
+                renderText = CreateFormattedText(string.Join(Path.DirectorySeparatorChar.ToString(), parts));
+
+                if (renderText.Width <= availableSize.Width || nextPart == -1)
+                    break;
+
+                parts[nextPart] = "\u2026";
+
+                if (nextPart == 0)
+                    nextPart = -1;
+                else if (nextPart == parts.Count - 2)
+                    nextPart = 0;
+                else
+                    nextPart++;
+            };
+
+            return new Size(renderText.Width, renderText.Height);
+        }
+
+        protected override void OnRender(DrawingContext drawingContext)
+        {
+            drawingContext.DrawText(renderText, new Point());
+        }
+
+        FormattedText CreateFormattedText(string text)
+        {
+            return new FormattedText(
+                text,
+                CultureInfo.CurrentCulture,
+                FlowDirection.LeftToRight,
+                new Typeface(FontFamily, FontStyle, FontWeight, FontStretch),
+                FontSize,
+                Foreground);
+        }
+
+        static void TextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            var textBlock = sender as TrimmedPathTextBlock;
+
+            if (textBlock != null)
+            {
+                textBlock.formattedText = null;
+                textBlock.renderText = null;
+            }
+        }
+    }
+}

--- a/src/GitHub.UI/Converters/TrimNewlinesConverter.cs
+++ b/src/GitHub.UI/Converters/TrimNewlinesConverter.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 namespace GitHub.UI
 {
     /// <summary>
-    /// An <see cref="IValueConverter"/> that trims newlines from a string and replaces them
+    /// An <see cref="IValueConverter"/> that trims newlines and tabs from a string and replaces them
     /// with spaces.
     /// </summary>
     public class TrimNewlinesConverter : ValueConverterMarkupExtension<TrimNewlinesConverter>

--- a/src/GitHub.UI/Converters/TrimNewlinesConverter.cs
+++ b/src/GitHub.UI/Converters/TrimNewlinesConverter.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace GitHub.UI
+{
+    /// <summary>
+    /// An <see cref="IValueConverter"/> that trims newlines from a string and replaces them
+    /// with spaces.
+    /// </summary>
+    public class TrimNewlinesConverter : ValueConverterMarkupExtension<TrimNewlinesConverter>
+    {
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var text = value as string;
+            if (String.IsNullOrEmpty(text)) return null;
+            return Regex.Replace(text, @"\t|\n|\r", " ");
+        }
+    }
+}

--- a/src/GitHub.UI/GitHub.UI.csproj
+++ b/src/GitHub.UI/GitHub.UI.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Controls\Spinner.xaml.cs">
       <DependentUpon>Spinner.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\TrimmedPathTextBlock.cs" />
     <Compile Include="Converters\AllCapsConverter.cs" />
     <Compile Include="Converters\EqualityConverter.cs" />
     <Compile Include="Converters\EqualsToVisibilityConverter.cs" />

--- a/src/GitHub.UI/GitHub.UI.csproj
+++ b/src/GitHub.UI/GitHub.UI.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Converters\CountToVisibilityConverter.cs" />
     <Compile Include="Converters\DefaultValueConverter.cs" />
     <Compile Include="Converters\StickieListItemConverter.cs" />
+    <Compile Include="Converters\TrimNewlinesConverter.cs" />
     <Compile Include="Helpers\LoadingResourceDictionary.cs" />
     <Compile Include="Helpers\ScrollViewerUtilities.cs" />
     <Compile Include="Helpers\SharedDictionaryManager.cs" />

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeBlue.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeBlue.xaml
@@ -64,5 +64,6 @@
 
   <SolidColorBrush x:Key="GitHubPeekViewBackground" Color="#F5F5F5" />
   <SolidColorBrush x:Key="GitHubPendingReviewBackground" Color="#FFF8C7" />
-  <SolidColorBrush x:Key="GitHubMultilineListItemActiveBrush" Color="#FFCCCEDB"/>
+  <SolidColorBrush x:Key="GitHubMultilineListItemActiveBrush" Color="#FFCCCEDB" />
+  <SolidColorBrush x:Key="GitHubFileExpanderHeaderBackgroundBrush" Color="#FFD6DBE9" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeDark.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeDark.xaml
@@ -65,4 +65,5 @@
   <SolidColorBrush x:Key="GitHubPeekViewBackground" Color="#252526" />
   <SolidColorBrush x:Key="GitHubPendingReviewBackground" Color="#26384D" />
   <SolidColorBrush x:Key="GitHubMultilineListItemActiveBrush" Color="#FF3F3F46"/>
+  <SolidColorBrush x:Key="GitHubFileExpanderHeaderBackgroundBrush" Color="#FF2D2D30" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeLight.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeLight.xaml
@@ -65,4 +65,5 @@
   <SolidColorBrush x:Key="GitHubPeekViewBackground" Color="#F5F5F5" />
   <SolidColorBrush x:Key="GitHubPendingReviewBackground" Color="#FFF8C7" />
   <SolidColorBrush x:Key="GitHubMultilineListItemActiveBrush" Color="#FFCCCEDB"/>
+  <SolidColorBrush x:Key="GitHubFileExpanderHeaderBackgroundBrush" Color="#FFEEEEF2" />
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -382,6 +382,9 @@
     <Compile Include="Views\GitHubPane\GitHubPaneView.xaml.cs">
       <DependentUpon>GitHubPaneView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\GitHubPane\PullRequestFileCommentsView.xaml.cs">
+      <DependentUpon>PullRequestFileCommentsView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\GitHubPane\PullRequestReviewSummaryView.xaml.cs">
       <DependentUpon>PullRequestReviewSummaryView.xaml</DependentUpon>
     </Compile>
@@ -402,6 +405,9 @@
     </Compile>
     <Compile Include="Views\GitHubPane\NotAGitRepositoryView.xaml.cs">
       <DependentUpon>NotAGitRepositoryView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\GitHubPane\PullRequestUserReviewsView.xaml.cs">
+      <DependentUpon>PullRequestUserReviewsView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\TeamExplorer\RepositoryPublishView.xaml.cs">
       <DependentUpon>RepositoryPublishView.xaml</DependentUpon>
@@ -540,6 +546,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Views\GitHubPane\PullRequestFileCommentsView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Views\GitHubPane\PullRequestReviewSummaryView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -569,6 +579,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\GitHubPane\PullRequestListItem.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\GitHubPane\PullRequestUserReviewsView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFileCommentsView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFileCommentsView.xaml
@@ -42,8 +42,8 @@
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate TargetType="{x:Type GroupItem}">
-                                    <Expander Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
-                                              Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                                    <Expander Background="{DynamicResource GitHubFileExpanderHeaderBackgroundBrush}"
+                                              Foreground="{DynamicResource VsBrush.WindowText}"
                                               IsExpanded="True"
                                               Padding="0 4 4 4">
                                         <Expander.Header>
@@ -53,6 +53,7 @@
                                                 <ghfvs:OcticonImage DockPanel.Dock="Right" Icon="comment" Margin="2 0 2 -2"/>
                                                 <ghfvs:TrimmedPathTextBlock Grid.Column="1"
                                                                             FontWeight="SemiBold"
+                                                                            Foreground="{DynamicResource VsBrush.WindowText}"
                                                                             Text="{Binding Name}"
                                                                             ToolTip="{Binding Name}"/>
                                             </DockPanel>
@@ -61,7 +62,7 @@
                                                       Grid.IsSharedSizeScope="True">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <Border BorderBrush="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+                                                    <Border BorderBrush="{DynamicResource GitHubFileExpanderHeaderBackgroundBrush}"
                                                             BorderThickness="1 0 1 1">
                                                         <ghfvs:GitHubActionLink Command="{Binding Open}"
                                                                                 Content="{Binding Body, Converter={ghfvs:TrimNewlinesConverter}, Mode=OneWay}"

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFileCommentsView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFileCommentsView.xaml
@@ -1,0 +1,84 @@
+﻿<UserControl x:Class="GitHub.VisualStudio.Views.GitHubPane.PullRequestFileCommentsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:ghfvs="https://github.com/github/VisualStudio"
+             xmlns:local="clr-namespace:GitHub.VisualStudio.Views.GitHubPane"
+             mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300">
+
+    <d:DesignData.DataContext>
+        <Binding Path="FileComments">
+            <Binding.Source>
+                <ghfvs:PullRequestReviewViewModelDesigner/>
+            </Binding.Source>
+        </Binding>
+    </d:DesignData.DataContext>
+    
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/Assets/Markdown.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <CollectionViewSource x:Key="FileComments" Source="{Binding}">
+                <CollectionViewSource.GroupDescriptions>
+                    <PropertyGroupDescription PropertyName="RelativePath"/>
+                </CollectionViewSource.GroupDescriptions>
+            </CollectionViewSource>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <ListBox ItemsSource="{Binding Source={StaticResource FileComments}}"
+             Background="Transparent"
+             BorderThickness="0"
+             ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+        <ListBox.GroupStyle>
+            <GroupStyle>
+                <GroupStyle.ContainerStyle>
+                    <Style TargetType="{x:Type GroupItem}">
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type GroupItem}">
+                                    <Expander Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+                                              Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                                              IsExpanded="True"
+                                              Padding="0 4 4 4">
+                                        <Expander.Header>
+                                            <DockPanel>
+                                                <ghfvs:OcticonImage DockPanel.Dock="Left" Icon="file_text" Margin="2 0"/>
+                                                <TextBlock DockPanel.Dock="Right" Text="{Binding Items.Count, Mode=OneWay}"/>
+                                                <ghfvs:OcticonImage DockPanel.Dock="Right" Icon="comment" Margin="2 0 2 -2"/>
+                                                <ghfvs:TrimmedPathTextBlock Grid.Column="1"
+                                                                            FontWeight="SemiBold"
+                                                                            Text="{Binding Name}"
+                                                                            ToolTip="{Binding Name}"/>
+                                            </DockPanel>
+                                        </Expander.Header>
+                                        <ItemsControl ItemsSource="{Binding Items}"
+                                                      Grid.IsSharedSizeScope="True">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Border BorderBrush="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+                                                            BorderThickness="1 0 1 1">
+                                                        <ghfvs:GitHubActionLink Command="{Binding Open}"
+                                                                                Content="{Binding Body, Converter={ghfvs:TrimNewlinesConverter}, Mode=OneWay}"
+                                                                                Foreground="{DynamicResource GitHubVsToolWindowText}"
+                                                                                Margin="4"
+                                                                                TextTrimming="CharacterEllipsis"/>
+                                                    </Border>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </Expander>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </GroupStyle.ContainerStyle>
+            </GroupStyle>
+        </ListBox.GroupStyle>
+    </ListBox>
+</UserControl>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFileCommentsView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFileCommentsView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace GitHub.VisualStudio.Views.GitHubPane
+{
+    /// <summary>
+    /// Interaction logic for PullRequestFileCommentsView.xaml
+    /// </summary>
+    public partial class PullRequestFileCommentsView : UserControl
+    {
+        public PullRequestFileCommentsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestUserReviewsView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestUserReviewsView.xaml
@@ -69,7 +69,8 @@
                                         </TextBlock>
                                     </StackPanel>
                                 </Expander.Header>
-                                <StackPanel Margin="16 4 0 4">
+                                <StackPanel Margin="16 4 0 4"
+                                            Visibility="{Binding HasDetails, Converter={ghfvs:BooleanToVisibilityConverter}}">
                                     <Expander Foreground="{DynamicResource GitHubVsToolWindowText}"
                                               IsExpanded="True"
                                               Margin="0 4"

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestUserReviewsView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestUserReviewsView.xaml
@@ -52,6 +52,7 @@
                             <Rectangle Fill="{DynamicResource GitHubHeaderSeparatorBrush}" Height="1" Margin="0 4"/>
 
                             <Expander Margin="0 0 4 0"
+                                      Foreground="{DynamicResource GitHubVsToolWindowText}"
                                       IsExpanded="{Binding IsExpanded, Mode=OneTime}"
                                       IsEnabled="{Binding HasDetails}">
                                 <Expander.Header>
@@ -69,7 +70,8 @@
                                     </StackPanel>
                                 </Expander.Header>
                                 <StackPanel Margin="16 4 0 4">
-                                    <Expander IsExpanded="True"
+                                    <Expander Foreground="{DynamicResource GitHubVsToolWindowText}"
+                                              IsExpanded="True"
                                               Margin="0 4"
                                               Visibility="{Binding Body, Converter={ghfvs:NullToVisibilityConverter}}">
                                         <Expander.Header>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestUserReviewsView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestUserReviewsView.xaml
@@ -69,7 +69,7 @@
                                         </TextBlock>
                                     </StackPanel>
                                 </Expander.Header>
-                                <StackPanel Margin="16 4 0 4"
+                                <StackPanel Margin="21 4 0 4"
                                             Visibility="{Binding HasDetails, Converter={ghfvs:BooleanToVisibilityConverter}}">
                                     <Expander Foreground="{DynamicResource GitHubVsToolWindowText}"
                                               IsExpanded="True"

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestUserReviewsView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestUserReviewsView.xaml
@@ -1,0 +1,105 @@
+﻿<UserControl x:Class="GitHub.VisualStudio.Views.GitHubPane.PullRequestUserReviewsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ghfvs="https://github.com/github/VisualStudio"
+             xmlns:local="clr-namespace:GitHub.VisualStudio.Views.GitHubPane"
+             xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
+             mc:Ignorable="d" d:DesignHeight="500" d:DesignWidth="300">
+
+    <d:DesignData.DataContext>
+        <ghfvs:PullRequestUserReviewsViewModelDesigner/>
+    </d:DesignData.DataContext>
+    
+    <Control.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI.Reactive;component/SharedDictionary.xaml" />
+                <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/Assets/Markdown.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Control.Resources>
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <StackPanel DockPanel.Dock="Top" Margin="8 0" Orientation="Vertical">
+                <TextBlock FontSize="16" VerticalAlignment="Center">
+                        <Run>Reviews by</Run>
+                        <Run FontWeight="SemiBold" Text="{Binding User.Login, Mode=OneWay}"/>
+                        <Run>for</Run>
+                        <Hyperlink Command="{Binding NavigateToPullRequest}">
+                            <Run>#</Run><Run Text="{Binding PullRequestNumber, Mode=OneWay}"/>
+                        </Hyperlink>
+                </TextBlock>
+
+                <TextBlock Foreground="{DynamicResource GitHubVsGrayText}"
+                           Margin="0"
+                           Text="{Binding PullRequestTitle}"
+                           TextWrapping="Wrap"/>
+                <StackPanel Orientation="Horizontal" Margin="0 4">
+                    <ghfvs:AccountAvatar Account="{Binding User}" Margin="0 0 4 0" Width="16" Height="16"/>
+                    <TextBlock Text="{Binding Reviews.Count, StringFormat={}{0} reviews}"
+                               VerticalAlignment="Center"/>
+                </StackPanel>
+            </StackPanel>
+            <ItemsControl ItemsSource="{Binding Reviews}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel>
+                            <Rectangle Fill="{DynamicResource GitHubHeaderSeparatorBrush}" Height="1" Margin="0 4"/>
+
+                            <Expander Margin="0 0 4 0"
+                                      IsExpanded="{Binding IsExpanded, Mode=OneTime}"
+                                      IsEnabled="{Binding HasDetails}">
+                                <Expander.Header>
+                                    <StackPanel Orientation="Horizontal">
+                                        <ghfvs:OcticonImage Icon="check" Foreground="#2cbe4e" Visibility="{Binding Model.State, Converter={ghfvs:EqualsToVisibilityConverter Approved}}"/>
+                                        <ghfvs:OcticonImage Icon="x" Foreground="#cb2431" Visibility="{Binding Model.State, Converter={ghfvs:EqualsToVisibilityConverter ChangesRequested}}"/>
+                                        <ghfvs:OcticonImage Icon="comment" Visibility="{Binding Model.State, Converter={ghfvs:EqualsToVisibilityConverter Commented}}"/>
+                                        <ghfvs:OcticonImage Icon="comment" Visibility="{Binding Model.State, Converter={ghfvs:EqualsToVisibilityConverter Dismissed}}"/>
+
+                                        <TextBlock FontWeight="SemiBold" Margin="2 0">
+                                            <Run Text="{Binding Model.User.Login, Mode=OneWay}"/>
+                                            <Run Text="{Binding StateDisplay, Mode=OneWay}"/>
+                                            <Run FontWeight="Normal" Text="{Binding Model.SubmittedAt, Mode=OneWay, Converter={ghfvs:DurationToStringConverter}}"/>
+                                        </TextBlock>
+                                    </StackPanel>
+                                </Expander.Header>
+                                <StackPanel Margin="16 4 0 4">
+                                    <Expander IsExpanded="True"
+                                              Margin="0 4"
+                                              Visibility="{Binding Body, Converter={ghfvs:NullToVisibilityConverter}}">
+                                        <Expander.Header>
+                                            <TextBlock FontWeight="SemiBold">Description</TextBlock>
+                                        </Expander.Header>
+                                        <markdig:MarkdownViewer Margin="22 4 0 0" Markdown="{Binding Body}"/>
+                                    </Expander>
+                                    <Expander IsExpanded="True"
+                                              Margin="0 4"
+                                              Visibility="{Binding FileComments.Count, Converter={ghfvs:CountToVisibilityConverter}}">
+                                        <Expander.Header>
+                                            <TextBlock FontWeight="SemiBold">Comments</TextBlock>
+                                        </Expander.Header>
+                                        <local:PullRequestFileCommentsView DataContext="{Binding FileComments}" 
+                                                                           Margin="22 4 0 0"/>
+                                    </Expander>
+                                    <Expander Margin="0 4"
+                                              Visibility="{Binding OutdatedFileComments.Count, Converter={ghfvs:CountToVisibilityConverter}}">
+                                        <Expander.Header>
+                                            <TextBlock FontWeight="SemiBold">Outdated comments</TextBlock>
+                                        </Expander.Header>
+                                        <local:PullRequestFileCommentsView DataContext="{Binding OutdatedFileComments}"
+                                                                           Margin="22 4 0 0"/>
+                                    </Expander>
+                                </StackPanel>
+                            </Expander>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestUserReviewsView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestUserReviewsView.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.Composition;
+using System.Windows.Controls;
+using GitHub.Exports;
+using GitHub.ViewModels.GitHubPane;
+
+namespace GitHub.VisualStudio.Views.GitHubPane
+{
+    [ExportViewFor(typeof(IPullRequestUserReviewsViewModel))]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public partial class PullRequestUserReviewsView : UserControl
+    {
+        public PullRequestUserReviewsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestReviewViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestReviewViewModelTests.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Linq;
+using GitHub.Models;
+using GitHub.Services;
+using GitHub.ViewModels.GitHubPane;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace UnitTests.GitHub.App.ViewModels.GitHubPane
+{
+    public class PullRequestReviewViewModelTests
+    {
+        [Test]
+        public void Empty_Body_Is_Exposed_As_Null()
+        {
+            var pr = CreatePullRequest();
+            ((PullRequestReviewModel)pr.Reviews[0]).Body = string.Empty;
+
+            var target = CreateTarget(pullRequest: pr);
+
+            Assert.That(target.Body, Is.Null);
+        }
+
+        [Test]
+        public void Creates_FileComments_And_OutdatedComments()
+        {
+            var pr = CreatePullRequest();
+            ((PullRequestReviewModel)pr.Reviews[0]).Body = string.Empty;
+
+            var target = CreateTarget(pullRequest: pr);
+
+            Assert.That(target.FileComments, Has.Count.EqualTo(2));
+            Assert.That(target.OutdatedFileComments, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public void HasDetails_True_When_Has_Body()
+        {
+            var pr = CreatePullRequest();
+            pr.ReviewComments = new IPullRequestReviewCommentModel[0];
+
+            var target = CreateTarget(pullRequest: pr);
+
+            Assert.That(target.HasDetails, Is.True);
+        }
+
+        [Test]
+        public void HasDetails_True_When_Has_Comments()
+        {
+            var pr = CreatePullRequest();
+            ((PullRequestReviewModel)pr.Reviews[0]).Body = string.Empty;
+
+            var target = CreateTarget(pullRequest: pr);
+
+            Assert.That(target.HasDetails, Is.True);
+        }
+
+        [Test]
+        public void HasDetails_False_When_Has_No_Body_Or_Comments()
+        {
+            var pr = CreatePullRequest();
+            ((PullRequestReviewModel)pr.Reviews[0]).Body = string.Empty;
+            pr.ReviewComments = new IPullRequestReviewCommentModel[0];
+
+            var target = CreateTarget(pullRequest: pr);
+
+            Assert.That(target.HasDetails, Is.False);
+        }
+
+        PullRequestReviewViewModel CreateTarget(
+            IPullRequestEditorService editorService = null,
+            IPullRequestSession session = null,
+            IPullRequestModel pullRequest = null,
+            IPullRequestReviewModel model = null)
+        {
+            editorService = editorService ?? Substitute.For<IPullRequestEditorService>();
+            session = session ?? Substitute.For<IPullRequestSession>();
+            pullRequest = pullRequest ?? CreatePullRequest();
+            model = model ?? pullRequest.Reviews[0];
+
+            return new PullRequestReviewViewModel(
+                editorService,
+                session,
+                pullRequest,
+                model);
+        }
+
+        private PullRequestModel CreatePullRequest(
+            int number = 5,
+            string title = "Pull Request Title",
+            string body = "Pull Request Body",
+            IAccount author = null,
+            DateTimeOffset? createdAt = null)
+        {
+            author = author ?? Substitute.For<IAccount>();
+            createdAt = createdAt ?? DateTimeOffset.Now;
+
+            return new PullRequestModel(number, title, author, createdAt.Value)
+            {
+                Body = body,
+                Reviews = new[]
+                {
+                    new PullRequestReviewModel
+                    {
+                        Id = 1,
+                        Body = "Looks good to me!",
+                        State = PullRequestReviewState.Approved,
+                    },
+                    new PullRequestReviewModel
+                    {
+                        Id = 2,
+                        Body = "Changes please.",
+                        State = PullRequestReviewState.ChangesRequested,
+                    },
+                },
+                ReviewComments = new[]
+                {
+                    new PullRequestReviewCommentModel
+                    {
+                        Body = "I like this.",
+                        PullRequestReviewId = 1,
+                        Position = 10,
+                    },
+                    new PullRequestReviewCommentModel
+                    {
+                        Body = "This is good.",
+                        PullRequestReviewId = 1,
+                        Position = 11,
+                    },
+                    new PullRequestReviewCommentModel
+                    {
+                        Body = "Fine, but outdated.",
+                        PullRequestReviewId = 1,
+                        Position = null,
+                    },
+                    new PullRequestReviewCommentModel
+                    {
+                        Body = "Not great.",
+                        PullRequestReviewId = 2,
+                        Position = 20,
+                    },
+                    new PullRequestReviewCommentModel
+                    {
+                        Body = "This sucks.",
+                        PullRequestReviewId = 2,
+                        Position = 21,
+                    },
+                    new PullRequestReviewCommentModel
+                    {
+                        Body = "Bad and old.",
+                        PullRequestReviewId = 2,
+                        Position = null,
+                    },
+                }
+            };
+        }
+    }
+}

--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestUserReviewsViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestUserReviewsViewModelTests.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using GitHub.Factories;
+using GitHub.Models;
+using GitHub.Services;
+using GitHub.ViewModels.GitHubPane;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace UnitTests.GitHub.App.ViewModels.GitHubPane
+{
+    public class PullRequestUserReviewsViewModelTests
+    {
+        const string AuthorLogin = "grokys";
+
+        [Test]
+        public async Task InitializeAsync_Loads_User()
+        {
+            var modelSerivce = Substitute.For<IModelService>();
+            var user = Substitute.For<IAccount>();
+            modelSerivce.GetUser(AuthorLogin).Returns(Observable.Return(user));
+
+            var target = CreateTarget(
+                modelServiceFactory: CreateFactory(modelSerivce));
+
+            await Initialize(target);
+
+            Assert.That(target.User, Is.SameAs(user));
+        }
+
+        [Test]
+        public async Task InitializeAsync_Creates_Reviews()
+        {
+            var author = Substitute.For<IAccount>();
+            author.Login.Returns(AuthorLogin);
+
+            var anotherAuthor = Substitute.For<IAccount>();
+            anotherAuthor.Login.Returns("SomeoneElse");
+
+            var pullRequest = new PullRequestModel(5, "PR title", author, DateTimeOffset.Now)
+            {
+                Reviews = new[]
+                {
+                    new PullRequestReviewModel
+                    {
+                        User = author,
+                        State = PullRequestReviewState.Approved,
+                    },
+                    new PullRequestReviewModel
+                    {
+                        User = author,
+                        State = PullRequestReviewState.ChangesRequested,
+                    },
+                    new PullRequestReviewModel
+                    {
+                        User = anotherAuthor,
+                        State = PullRequestReviewState.Approved,
+                    },
+                    new PullRequestReviewModel
+                    {
+                        User = author,
+                        State = PullRequestReviewState.Dismissed,
+                    },
+                    new PullRequestReviewModel
+                    {
+                        User = author,
+                        State = PullRequestReviewState.Pending,
+                    },
+                },
+                ReviewComments = new IPullRequestReviewCommentModel[0],
+            };
+
+            var modelSerivce = Substitute.For<IModelService>();
+            modelSerivce.GetUser(AuthorLogin).Returns(Observable.Return(author));
+            modelSerivce.GetPullRequest("owner", "repo", 5).Returns(Observable.Return(pullRequest));
+
+            var user = Substitute.For<IAccount>();
+            var target = CreateTarget(
+                modelServiceFactory: CreateFactory(modelSerivce));
+
+            await Initialize(target);
+
+            // Should load reviews by the correct author which are not Pending.
+            Assert.That(target.Reviews, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task Orders_Reviews_Descending()
+        {
+            var author = Substitute.For<IAccount>();
+            author.Login.Returns(AuthorLogin);
+
+            var pullRequest = new PullRequestModel(5, "PR title", author, DateTimeOffset.Now)
+            {
+                Reviews = new[]
+                {
+                    new PullRequestReviewModel
+                    {
+                        User = author,
+                        State = PullRequestReviewState.Approved,
+                        SubmittedAt = DateTimeOffset.Now - TimeSpan.FromDays(2),
+                    },
+                    new PullRequestReviewModel
+                    {
+                        User = author,
+                        State = PullRequestReviewState.ChangesRequested,
+                        SubmittedAt = DateTimeOffset.Now - TimeSpan.FromDays(3),
+                    },
+                    new PullRequestReviewModel
+                    {
+                        User = author,
+                        State = PullRequestReviewState.Dismissed,
+                        SubmittedAt = DateTimeOffset.Now - TimeSpan.FromDays(1),
+                    },
+                },
+                ReviewComments = new IPullRequestReviewCommentModel[0],
+            };
+
+            var modelSerivce = Substitute.For<IModelService>();
+            modelSerivce.GetUser(AuthorLogin).Returns(Observable.Return(author));
+            modelSerivce.GetPullRequest("owner", "repo", 5).Returns(Observable.Return(pullRequest));
+
+            var user = Substitute.For<IAccount>();
+            var target = CreateTarget(
+                modelServiceFactory: CreateFactory(modelSerivce));
+
+            await Initialize(target);
+
+            Assert.That(
+                target.Reviews.Select(x => x.Model.SubmittedAt),
+                Is.EqualTo(target.Reviews.Select(x => x.Model.SubmittedAt).OrderByDescending(x => x)));
+        }
+
+        [Test]
+        public async Task First_Review_Is_Expanded()
+        {
+            var author = Substitute.For<IAccount>();
+            author.Login.Returns(AuthorLogin);
+
+            var anotherAuthor = Substitute.For<IAccount>();
+            author.Login.Returns("SomeoneElse");
+
+            var pullRequest = new PullRequestModel(5, "PR title", author, DateTimeOffset.Now)
+            {
+                Reviews = new[]
+                {
+                    new PullRequestReviewModel
+                    {
+                        User = author,
+                        State = PullRequestReviewState.Approved,
+                    },
+                    new PullRequestReviewModel
+                    {
+                        User = author,
+                        State = PullRequestReviewState.ChangesRequested,
+                    },
+                    new PullRequestReviewModel
+                    {
+                        User = author,
+                        State = PullRequestReviewState.Dismissed,
+                    },
+                },
+                ReviewComments = new IPullRequestReviewCommentModel[0],
+            };
+
+            var modelSerivce = Substitute.For<IModelService>();
+            modelSerivce.GetUser(AuthorLogin).Returns(Observable.Return(author));
+            modelSerivce.GetPullRequest("owner", "repo", 5).Returns(Observable.Return(pullRequest));
+
+            var user = Substitute.For<IAccount>();
+            var target = CreateTarget(
+                modelServiceFactory: CreateFactory(modelSerivce));
+
+            await Initialize(target);
+
+            Assert.That(target.Reviews[0].IsExpanded, Is.True);
+            Assert.That(target.Reviews[1].IsExpanded, Is.False);
+            Assert.That(target.Reviews[2].IsExpanded, Is.False);
+        }
+
+        async Task Initialize(
+            PullRequestUserReviewsViewModel target,
+            ILocalRepositoryModel localRepository = null,
+            IConnection connection = null,
+            int pullRequestNumber = 5,
+            string login = AuthorLogin)
+        {
+            localRepository = localRepository ?? CreateRepository();
+            connection = connection ?? Substitute.For<IConnection>();
+
+            await target.InitializeAsync(
+                localRepository,
+                connection,
+                localRepository.Owner,
+                localRepository.Name,
+                pullRequestNumber,
+                login);
+        }
+
+        PullRequestUserReviewsViewModel CreateTarget(
+            IPullRequestEditorService editorService = null,
+            IPullRequestSessionManager sessionManager = null,
+            IModelServiceFactory modelServiceFactory = null)
+        {
+            editorService = editorService ?? Substitute.For<IPullRequestEditorService>();
+            sessionManager = sessionManager ?? Substitute.For<IPullRequestSessionManager>();
+            modelServiceFactory = modelServiceFactory ?? Substitute.For<IModelServiceFactory>();
+
+            return new PullRequestUserReviewsViewModel(
+                editorService,
+                sessionManager,
+                modelServiceFactory);
+        }
+
+        IModelServiceFactory CreateFactory(IModelService modelService)
+        {
+            var result = Substitute.For<IModelServiceFactory>();
+            result.CreateAsync(null).ReturnsForAnyArgs(modelService);
+            return result;
+        }
+
+        ILocalRepositoryModel CreateRepository(string owner = "owner", string name = "repo")
+        {
+            var result = Substitute.For<ILocalRepositoryModel>();
+            result.Owner.Returns(owner);
+            result.Name.Returns(name);
+            return result;
+        }
+    }
+}

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -257,6 +257,8 @@
     <Compile Include="GitHub.App\Services\AvatarProviderTests.cs" />
     <Compile Include="GitHub.App\Services\GitClientTests.cs" />
     <Compile Include="GitHub.App\ViewModels\GitHubPane\PullRequestFilesViewModelTests.cs" />
+    <Compile Include="GitHub.App\ViewModels\GitHubPane\PullRequestReviewViewModelTests.cs" />
+    <Compile Include="GitHub.App\ViewModels\GitHubPane\PullRequestUserReviewsViewModelTests.cs" />
     <Compile Include="GitHub.Exports.Reactive\Services\PullRequestEditorServiceTests.cs" />
     <Compile Include="GitHub.App\Services\OAuthCallbackListenerTests.cs" />
     <Compile Include="GitHub.App\Services\PullRequestServiceTests.cs" />


### PR DESCRIPTION
When the user clicks on a "Reviewer" item in the PR details view, navigate to a new view to show the PR reviews by that user.

![image](https://user-images.githubusercontent.com/1775141/37666763-a5baa2ea-2c60-11e8-98f5-cc5580b81d1a.png)

This PR also introduces:

- A new global style for `Expander`: the default WPF expander style doesn't fit in well with Visual Studio
- A `TrimmedPathTextBlock` control to intelligently trim paths (see screenshot above)

Depends on #1523
Part of #1491