### PR TITLE
Create and add MEF commands on background thread

### DIFF
--- a/src/GitHub.InlineReviews/InlineReviewsPackage.cs
+++ b/src/GitHub.InlineReviews/InlineReviewsPackage.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
-using System.Threading;
 using GitHub.Commands;
 using GitHub.InlineReviews.Views;
+using GitHub.Services.Vssdk;
 using GitHub.Services.Vssdk.Commands;
 using GitHub.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -17,13 +16,10 @@ namespace GitHub.InlineReviews
     [ProvideAutoLoad(Guids.UIContext_Git, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideToolWindow(typeof(PullRequestCommentsPane), DocumentLikeTool = true)]
-    public class InlineReviewsPackage : AsyncPackage
+    public class InlineReviewsPackage : AsyncMenuPackage
     {
-        protected override async Task InitializeAsync(
-            CancellationToken cancellationToken,
-            IProgress<ServiceProgressData> progress)
+        protected override async Task InitializeMenusAsync(OleMenuCommandService menuService)
         {
-            var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
             var exports = componentModel.DefaultExportProvider;
 
@@ -31,11 +27,5 @@ namespace GitHub.InlineReviews
                 exports.GetExportedValue<INextInlineCommentCommand>(),
                 exports.GetExportedValue<IPreviousInlineCommentCommand>());
         }
-
-        // The IDesignerHost and ISelectionService services are requested by MenuCommandService.EnsureVerbs().
-        // When called from a non-Main thread this would throw despite the fact these services don't exist.
-        // This override allows IMenuCommandService.AddCommands to be called form a background thread.
-        protected override object GetService(Type serviceType)
-            => (serviceType == typeof(ISelectionService) || serviceType == typeof(IDesignerHost)) ? null : base.GetService(serviceType);
     }
 }

--- a/src/GitHub.InlineReviews/InlineReviewsPackage.cs
+++ b/src/GitHub.InlineReviews/InlineReviewsPackage.cs
@@ -38,11 +38,14 @@ namespace GitHub.InlineReviews
             var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
             var exports = componentModel.DefaultExportProvider;
+            var commands = new IVsCommandBase[]
+            {
+                exports.GetExportedValue<INextInlineCommentCommand>(),
+                exports.GetExportedValue<IPreviousInlineCommentCommand>()
+            };
 
             await JoinableTaskFactory.SwitchToMainThreadAsync();
-            menuService.AddCommands(
-                exports.GetExportedValue<INextInlineCommentCommand>(),
-                exports.GetExportedValue<IPreviousInlineCommentCommand>());
+            menuService.AddCommands(commands);
         }
     }
 }

--- a/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
+++ b/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Threading;
 using System.Runtime.InteropServices;
-using GitHub.Services;
 using GitHub.VisualStudio;
 using GitHub.InlineReviews.Services;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
 using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.ComponentModelHost;
 
 namespace GitHub.InlineReviews
 {
@@ -27,9 +27,9 @@ namespace GitHub.InlineReviews
 
         async Task InitializeStatusBar()
         {
-            var usageTracker = (IUsageTracker)await GetServiceAsync(typeof(IUsageTracker));
-            var serviceProvider = (IGitHubServiceProvider)await GetServiceAsync(typeof(IGitHubServiceProvider));
-            var barManager = new PullRequestStatusBarManager(usageTracker, serviceProvider);
+            var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
+            var exports = componentModel.DefaultExportProvider;
+            var barManager = exports.GetExportedValue<PullRequestStatusBarManager>();
 
             await JoinableTaskFactory.SwitchToMainThreadAsync();
             barManager.StartShowingStatus();

--- a/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 using System.Windows;
-using System.Windows.Input;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.ComponentModel.Composition;
+using GitHub.Commands;
 using GitHub.InlineReviews.Views;
 using GitHub.InlineReviews.ViewModels;
 using GitHub.Services;
-using GitHub.VisualStudio;
 using GitHub.Models;
 using GitHub.Logging;
-using GitHub.Extensions;
 using Serilog;
 using ReactiveUI;
 
@@ -19,21 +17,28 @@ namespace GitHub.InlineReviews.Services
     /// <summary>
     /// Manage the UI that shows the PR for the current branch.
     /// </summary>
+    [Export(typeof(PullRequestStatusBarManager))]
     public class PullRequestStatusBarManager
     {
         static readonly ILogger log = LogManager.ForContext<PullRequestStatusBarManager>();
         const string StatusBarPartName = "PART_SccStatusBarHost";
 
         readonly IUsageTracker usageTracker;
-        readonly IGitHubServiceProvider serviceProvider;
+        readonly IShowCurrentPullRequestCommand showCurrentPullRequestCommand;
 
-        IPullRequestSessionManager pullRequestSessionManager;
+        // More the moment this must be constructed on the main thread.
+        // TeamExplorerContext needs to retrieve DTE using GetService.
+        readonly Lazy<IPullRequestSessionManager> pullRequestSessionManager;
 
         [ImportingConstructor]
-        public PullRequestStatusBarManager(IUsageTracker usageTracker, IGitHubServiceProvider serviceProvider)
+        public PullRequestStatusBarManager(
+            IUsageTracker usageTracker,
+            IShowCurrentPullRequestCommand showCurrentPullRequestCommand,
+            Lazy<IPullRequestSessionManager> pullRequestSessionManager)
         {
             this.usageTracker = usageTracker;
-            this.serviceProvider = serviceProvider;
+            this.showCurrentPullRequestCommand = showCurrentPullRequestCommand;
+            this.pullRequestSessionManager = pullRequestSessionManager;
         }
 
         /// <summary>
@@ -46,8 +51,7 @@ namespace GitHub.InlineReviews.Services
         {
             try
             {
-                pullRequestSessionManager = serviceProvider.GetService<IPullRequestSessionManager>();
-                pullRequestSessionManager.WhenAnyValue(x => x.CurrentSession)
+                pullRequestSessionManager.Value.WhenAnyValue(x => x.CurrentSession)
                     .Subscribe(x => RefreshCurrentSession());
             }
             catch (Exception e)
@@ -58,16 +62,14 @@ namespace GitHub.InlineReviews.Services
 
         void RefreshCurrentSession()
         {
-            var pullRequest = pullRequestSessionManager.CurrentSession?.PullRequest;
+            var pullRequest = pullRequestSessionManager.Value.CurrentSession?.PullRequest;
             var viewModel = pullRequest != null ? CreatePullRequestStatusViewModel(pullRequest) : null;
             ShowStatus(viewModel);
         }
 
         PullRequestStatusViewModel CreatePullRequestStatusViewModel(IPullRequestModel pullRequest)
         {
-            var dte = serviceProvider.TryGetService<EnvDTE.DTE>();
-            var command = new RaisePullRequestCommand(dte, usageTracker);
-            var pullRequestStatusViewModel = new PullRequestStatusViewModel(command);
+            var pullRequestStatusViewModel = new PullRequestStatusViewModel(showCurrentPullRequestCommand);
             pullRequestStatusViewModel.Number = pullRequest.Number;
             pullRequestStatusViewModel.Title = pullRequest.Title;
             return pullRequestStatusViewModel;
@@ -110,45 +112,6 @@ namespace GitHub.InlineReviews.Services
         {
             var contentControl = mainWindow?.Template?.FindName(StatusBarPartName, mainWindow) as ContentControl;
             return contentControl?.Content as StatusBar;
-        }
-
-        class RaisePullRequestCommand : ICommand
-        {
-            readonly string guid = Guids.guidGitHubCmdSetString;
-            readonly int id = PkgCmdIDList.showCurrentPullRequestCommand;
-
-            readonly EnvDTE.DTE dte;
-            readonly IUsageTracker usageTracker;
-
-            internal RaisePullRequestCommand(EnvDTE.DTE dte, IUsageTracker usageTracker)
-            {
-                this.dte = dte;
-                this.usageTracker = usageTracker;
-            }
-
-            public bool CanExecute(object parameter) => true;
-
-            public void Execute(object parameter)
-            {
-                try
-                {
-                    object customIn = null;
-                    object customOut = null;
-                    dte?.Commands.Raise(guid, id, ref customIn, ref customOut);
-                }
-                catch (Exception e)
-                {
-                    log.Error(e, "Couldn't raise {Guid}:{ID}", guid, id);
-                }
-
-                usageTracker.IncrementCounter(x => x.NumberOfShowCurrentPullRequest).Forget();
-            }
-
-            public event EventHandler CanExecuteChanged
-            {
-                add { }
-                remove { }
-            }
         }
     }
 }

--- a/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.ComponentModel.Composition;
@@ -9,6 +10,7 @@ using GitHub.InlineReviews.ViewModels;
 using GitHub.Services;
 using GitHub.Models;
 using GitHub.Logging;
+using GitHub.Extensions;
 using Serilog;
 using ReactiveUI;
 
@@ -69,10 +71,15 @@ namespace GitHub.InlineReviews.Services
 
         PullRequestStatusViewModel CreatePullRequestStatusViewModel(IPullRequestModel pullRequest)
         {
-            var pullRequestStatusViewModel = new PullRequestStatusViewModel(showCurrentPullRequestCommand);
+            var trackingCommand = new UsageTrackingCommand(showCurrentPullRequestCommand, usageTracker);
+            var pullRequestStatusViewModel = new PullRequestStatusViewModel(trackingCommand);
             pullRequestStatusViewModel.Number = pullRequest.Number;
             pullRequestStatusViewModel.Title = pullRequest.Title;
             return pullRequestStatusViewModel;
+        }
+
+        void IncrementNumberOfShowCurrentPullRequest()
+        {
         }
 
         void ShowStatus(PullRequestStatusViewModel pullRequestStatusViewModel = null)
@@ -112,6 +119,42 @@ namespace GitHub.InlineReviews.Services
         {
             var contentControl = mainWindow?.Template?.FindName(StatusBarPartName, mainWindow) as ContentControl;
             return contentControl?.Content as StatusBar;
+        }
+
+        class UsageTrackingCommand : ICommand
+        {
+            readonly ICommand command;
+            readonly IUsageTracker usageTracker;
+
+            internal UsageTrackingCommand(ICommand command, IUsageTracker usageTracker)
+            {
+                this.command = command;
+                this.usageTracker = usageTracker;
+            }
+
+            public event EventHandler CanExecuteChanged
+            {
+                add
+                {
+                    command.CanExecuteChanged += value;
+                }
+
+                remove
+                {
+                    command.CanExecuteChanged -= value;
+                }
+            }
+
+            public bool CanExecute(object parameter)
+            {
+                return command.CanExecute(parameter);
+            }
+
+            public void Execute(object parameter)
+            {
+                command.Execute(parameter);
+                usageTracker.IncrementCounter(x => x.NumberOfShowCurrentPullRequest).Forget();
+            }
         }
     }
 }

--- a/src/GitHub.Services.Vssdk/AsyncMenuPackage.cs
+++ b/src/GitHub.Services.Vssdk/AsyncMenuPackage.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading;
+using System.ComponentModel.Design;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
+
+namespace GitHub.Services.Vssdk
+{
+    public abstract class AsyncMenuPackage : AsyncPackage
+    {
+        IVsUIShell vsUIShell;
+
+        sealed protected async override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            vsUIShell = await GetServiceAsync(typeof(SVsUIShell)) as IVsUIShell;
+
+            var menuCommandService = (OleMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
+            await InitializeMenusAsync(menuCommandService);
+        }
+
+        protected abstract Task InitializeMenusAsync(OleMenuCommandService menuService);
+
+        // The IDesignerHost, ISelectionService and IVsUIShell are requested by the MenuCommandService.
+        // This override allows IMenuCommandService.AddCommands to be called form a background thread.
+        protected override object GetService(Type serviceType)
+        {
+            if (serviceType == typeof(SVsUIShell))
+            {
+                return vsUIShell;
+            }
+
+            if (serviceType == typeof(ISelectionService) || serviceType == typeof(IDesignerHost))
+            {
+                return null;
+            }
+
+            return base.GetService(serviceType);
+        }
+    }
+}

--- a/src/GitHub.Services.Vssdk/GitHub.Services.Vssdk.csproj
+++ b/src/GitHub.Services.Vssdk/GitHub.Services.Vssdk.csproj
@@ -139,6 +139,7 @@
     <Compile Include="..\common\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="AsyncMenuPackage.cs" />
     <Compile Include="Commands\MenuCommandServiceExtensions.cs" />
     <Compile Include="Commands\VsCommand.cs" />
     <Compile Include="Commands\VsCommandBase.cs" />

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -2,7 +2,6 @@
 using System.Windows;
 using System.Threading;
 using System.Threading.Tasks;
-using System.ComponentModel.Design;
 using System.ComponentModel.Composition;
 using System.Runtime.InteropServices;
 using GitHub.Api;
@@ -14,6 +13,7 @@ using GitHub.Services;
 using GitHub.Services.Vssdk.Commands;
 using GitHub.ViewModels.GitHubPane;
 using GitHub.VisualStudio.UI;
+using GitHub.Services.Vssdk;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
@@ -30,35 +30,15 @@ namespace GitHub.VisualStudio
     [ProvideAutoLoad(Guids.UIContext_Git, PackageAutoLoadFlags.BackgroundLoad)]
     [ProvideToolWindow(typeof(GitHubPane), Orientation = ToolWindowOrientation.Right, Style = VsDockStyle.Tabbed, Window = EnvDTE.Constants.vsWindowKindSolutionExplorer)]
     [ProvideOptionPage(typeof(OptionsPage), "GitHub for Visual Studio", "General", 0, 0, supportsAutomation: true)]
-    public class GitHubPackage : AsyncPackage
+    public class GitHubPackage : AsyncMenuPackage
     {
         static readonly ILogger log = LogManager.ForContext<GitHubPackage>();
 
-        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        protected async override Task InitializeMenusAsync(OleMenuCommandService menuService)
         {
             LogVersionInformation();
-            await base.InitializeAsync(cancellationToken, progress);
             await GetServiceAsync(typeof(IUsageTracker));
-            await InitializeMenus();
-        }
 
-        // The IDesignerHost and ISelectionService services are requested by MenuCommandService.EnsureVerbs().
-        // When called from a non-Main thread this would throw despite the fact these services don't exist.
-        // This override allows IMenuCommandService.AddCommands to be called form a background thread.
-        protected override object GetService(Type serviceType)
-            => (serviceType == typeof(ISelectionService) || serviceType == typeof(IDesignerHost)) ? null : base.GetService(serviceType);
-
-        void LogVersionInformation()
-        {
-            var packageVersion = ApplicationInfo.GetPackageVersion(this);
-            var hostVersionInfo = ApplicationInfo.GetHostVersionInfo();
-            log.Information("Initializing GitHub Extension v{PackageVersion} in {$FileDescription} ({$ProductVersion})",
-                packageVersion, hostVersionInfo.FileDescription, hostVersionInfo.ProductVersion);
-        }
-
-        async Task InitializeMenus()
-        {
-            var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
             var exports = componentModel.DefaultExportProvider;
 
@@ -71,6 +51,14 @@ namespace GitHub.VisualStudio
                 exports.GetExportedValue<IOpenPullRequestsCommand>(),
                 exports.GetExportedValue<IShowCurrentPullRequestCommand>(),
                 exports.GetExportedValue<IShowGitHubPaneCommand>());
+        }
+
+        void LogVersionInformation()
+        {
+            var packageVersion = ApplicationInfo.GetPackageVersion(this);
+            var hostVersionInfo = ApplicationInfo.GetHostVersionInfo();
+            log.Information("Initializing GitHub Extension v{PackageVersion} in {$FileDescription} ({$ProductVersion})",
+                packageVersion, hostVersionInfo.FileDescription, hostVersionInfo.ProductVersion);
         }
 
         async Task EnsurePackageLoaded(Guid packageGuid)

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -7,7 +7,6 @@ using System.ComponentModel.Composition;
 using System.Runtime.InteropServices;
 using GitHub.Api;
 using GitHub.Commands;
-using GitHub.Helpers;
 using GitHub.Info;
 using GitHub.Exports;
 using GitHub.Logging;
@@ -59,9 +58,8 @@ namespace GitHub.VisualStudio
             var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
             var exports = componentModel.DefaultExportProvider;
-
-            await JoinableTaskFactory.SwitchToMainThreadAsync();
-            menuService.AddCommands(
+            var commands = new IVsCommandBase[]
+            {
                 exports.GetExportedValue<IAddConnectionCommand>(),
                 exports.GetExportedValue<IBlameLinkCommand>(),
                 exports.GetExportedValue<ICopyLinkCommand>(),
@@ -69,7 +67,11 @@ namespace GitHub.VisualStudio
                 exports.GetExportedValue<IOpenLinkCommand>(),
                 exports.GetExportedValue<IOpenPullRequestsCommand>(),
                 exports.GetExportedValue<IShowCurrentPullRequestCommand>(),
-                exports.GetExportedValue<IShowGitHubPaneCommand>());
+                exports.GetExportedValue<IShowGitHubPaneCommand>()
+            };
+
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
+            menuService.AddCommands(commands);
         }
 
         async Task EnsurePackageLoaded(Guid packageGuid)


### PR DESCRIPTION
#### What this PR does

- Create MEF commands on the background thread
- Allow menuService.AddCommands to be called from a b/g thread
- Created `AsyncMenuPackage` that allows `IMenuCommandService` to be used on b/g tread
- Make `PullRequestStatusBarPackage` use MEF on b/g thread before using it on Main thread
  - I'm hoping this will help mitigate #1516

#### Notes

I attempted to do everything on the background thread, including calling `AddCommand` on the `IMenuCommandService` service. There had been reports of this also working on a background thread:
https://gitter.im/Microsoft/extendvs?at=5ab13986458cbde55757fe4e

Unfortunately `MenuCommandService.EnsureVerbs` includes a call to `GetService`:
https://gitter.im/Microsoft/extendvs?at=5ab141aaf3f6d24c6898259e

This can only be called on a background thread by a non-`AsyncPackage`, for exampe:
http://source.roslyn.io/#Microsoft.VisualStudio.LanguageServices/RoslynPackage.cs,106
(`IMenuCommandService` and `IOleCommandTarget`) are services that are created for each `Package`)

IMenuCommandService.AddCommands to be called form a background thread:
```cs
// The IDesignerHost and ISelectionService services are requested by MenuCommandService.EnsureVerbs().
// When called from a non-Main thread this would throw despite the fact these services don't exist.
// This override allows IMenuCommandService.AddCommands to be called form a background thread.
protected override object GetService(Type serviceType) =>
    (serviceType == typeof(ISelectionService) ||
    serviceType == typeof(IDesignerHost)) ? null : base.GetService(serviceType);
```

This allows us to do *all* menu related initialization on a b/g thread!