### PR TITLE
Display PR review comments inline.

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestDetailViewModelDesigner.cs
@@ -125,11 +125,6 @@ This requires that errors be propagated from the viewmodel to the view and from 
 
         public Task InitializeAsync(ILocalRepositoryModel localRepository, IConnection connection, string owner, string repo, int number) => Task.CompletedTask;
 
-        public Task<string> ExtractFile(IPullRequestFileNode file, bool head)
-        {
-            return null;
-        }
-
         public string GetLocalFilePath(IPullRequestFileNode file)
         {
             return null;

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -326,6 +326,20 @@ namespace GitHub.Services
             });
         }
 
+        public async Task<string> GetMergeBase(ILocalRepositoryModel repository, IPullRequestModel pullRequest)
+        {
+            using (var repo = gitService.GetRepository(repository.LocalPath))
+            {
+                return await gitClient.GetPullRequestMergeBase(
+                    repo,
+                    pullRequest.Base.RepositoryCloneUrl,
+                    pullRequest.Base.Sha,
+                    pullRequest.Head.Sha,
+                    pullRequest.Base.Ref,
+                    pullRequest.Number);
+            }
+        }
+
         public IObservable<TreeChanges> GetTreeChanges(ILocalRepositoryModel repository, IPullRequestModel pullRequest)
         {
             return Observable.Defer(async () =>
@@ -446,46 +460,18 @@ namespace GitHub.Services
             });
         }
 
-        public IObservable<string> ExtractFile(
+        public async Task<string> ExtractToTempFile(
             ILocalRepositoryModel repository,
             IPullRequestModel pullRequest,
-            string fileName,
-            bool head,
+            string relativePath,
+            string commitSha,
             Encoding encoding)
         {
-            return Observable.Defer(async () =>
+            using (var repo = gitService.GetRepository(repository.LocalPath))
             {
-                using (var repo = gitService.GetRepository(repository.LocalPath))
-                {
-                    var remote = await gitClient.GetHttpRemote(repo, "origin");
-                    string sha;
-
-                    if (head)
-                    {
-                        sha = pullRequest.Head.Sha;
-                    }
-                    else
-                    {
-                        try
-                        {
-                            sha = await gitClient.GetPullRequestMergeBase(
-                                repo,
-                                pullRequest.Base.RepositoryCloneUrl,
-                                pullRequest.Base.Sha,
-                                pullRequest.Head.Sha,
-                                pullRequest.Base.Ref,
-                                pullRequest.Number);
-                        }
-                        catch (NotFoundException ex)
-                        {
-                            throw new NotFoundException($"The Pull Request file failed to load. Please check your network connection and click refresh to try again. If this issue persists, please let us know at support@github.com", ex);
-                        }
-                    }
-
-                    var file = await ExtractToTempFile(repo, pullRequest.Number, sha, fileName, encoding);
-                    return Observable.Return(file);
-                }
-            });
+                var remote = await gitClient.GetHttpRemote(repo, "origin");
+                return await ExtractToTempFile(repo, pullRequest.Number, commitSha, relativePath, encoding);
+            }
         }
 
         public Encoding GetEncoding(ILocalRepositoryModel repository, string relativePath)

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
@@ -487,27 +487,6 @@ namespace GitHub.ViewModels.GitHubPane
         }
 
         /// <summary>
-        /// Gets a file as it appears in the pull request.
-        /// </summary>
-        /// <param name="file">The changed file.</param>
-        /// <param name="head">
-        /// If true, gets the file at the PR head, otherwise gets the file at the PR merge base.
-        /// </param>
-        /// <returns>The path to a temporary file.</returns>
-        public Task<string> ExtractFile(IPullRequestFileNode file, bool head)
-        {
-            var path = file.RelativePath;
-            var encoding = pullRequestsService.GetEncoding(LocalRepository, path);
-
-            if (!head && file.OldPath != null)
-            {
-                path = file.OldPath;
-            }
-
-            return pullRequestsService.ExtractFile(LocalRepository, model, path, head, encoding).ToTask();
-        }
-
-        /// <summary>
         /// Gets the full path to a file in the working directory.
         /// </summary>
         /// <param name="file">The file.</param>

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModel.cs
@@ -44,12 +44,12 @@ namespace GitHub.ViewModels.GitHubPane
             this.service = service;
 
             DiffFile = ReactiveCommand.CreateAsyncTask(x =>
-                editorService.OpenDiff(pullRequestSession, ((IPullRequestFileNode)x).RelativePath, false));
+                editorService.OpenDiff(pullRequestSession, ((IPullRequestFileNode)x).RelativePath, "HEAD"));
             ViewFile = ReactiveCommand.CreateAsyncTask(x =>
                 editorService.OpenFile(pullRequestSession, ((IPullRequestFileNode)x).RelativePath, false));
             DiffFileWithWorkingDirectory = ReactiveCommand.CreateAsyncTask(
                 isBranchCheckedOut,
-                x => editorService.OpenDiff(pullRequestSession, ((IPullRequestFileNode)x).RelativePath, true));
+                x => editorService.OpenDiff(pullRequestSession, ((IPullRequestFileNode)x).RelativePath));
             OpenFileInWorkingDirectory = ReactiveCommand.CreateAsyncTask(
                 isBranchCheckedOut,
                 x => editorService.OpenFile(pullRequestSession, ((IPullRequestFileNode)x).RelativePath, true));

--- a/src/GitHub.Exports.Reactive/Models/IInlineCommentThreadModel.cs
+++ b/src/GitHub.Exports.Reactive/Models/IInlineCommentThreadModel.cs
@@ -36,19 +36,14 @@ namespace GitHub.Models
         bool IsStale { get; set; }
 
         /// <summary>
-        /// Gets or sets the 0-based line number of the comment.
+        /// Gets or sets the 0-based line number of the comment, or -1 of the thread is outdated.
         /// </summary>
         int LineNumber { get; set; }
 
         /// <summary>
-        /// Gets the SHA of the commit that the thread was left con.
+        /// Gets the SHA of the commit that the thread appears on.
         /// </summary>
-        string OriginalCommitSha { get; }
-
-        /// <summary>
-        /// Gets the 1-based line number in the original diff that the thread was left on.
-        /// </summary>
-        int OriginalPosition { get; }
+        string CommitSha { get; }
 
         /// <summary>
         /// Gets the relative path to the file that the thread is on.

--- a/src/GitHub.Exports.Reactive/Models/IPullRequestSessionFile.cs
+++ b/src/GitHub.Exports.Reactive/Models/IPullRequestSessionFile.cs
@@ -34,6 +34,12 @@ namespace GitHub.Models
         string CommitSha { get; }
 
         /// <summary>
+        /// Gets a value indicating whether <see cref="CommitSha"/> is tracking the related pull
+        /// request HEAD or whether it is pinned at a particular commit.
+        /// </summary>
+        bool IsTrackingHead { get; }
+
+        /// <summary>
         /// Gets the path to the file relative to the repository.
         /// </summary>
         string RelativePath { get; }

--- a/src/GitHub.Exports.Reactive/Models/PullRequestTextBufferInfo.cs
+++ b/src/GitHub.Exports.Reactive/Models/PullRequestTextBufferInfo.cs
@@ -1,12 +1,13 @@
 ﻿using System;
+using GitHub.Extensions;
 using GitHub.Services;
 
 namespace GitHub.Models
 {
     /// <summary>
     /// When attached as a property to a Visual Studio ITextBuffer, informs the inline comment
-    /// tagger that the buffer represents a buffer opened from a pull request at the HEAD commit
-    /// of a pull request.
+    /// tagger that the buffer represents a buffer opened from a pull request at the specified
+    /// commit of a pull request.
     /// </summary>
     public class PullRequestTextBufferInfo
     {
@@ -15,14 +16,21 @@ namespace GitHub.Models
         /// </summary>
         /// <param name="session">The pull request session.</param>
         /// <param name="relativePath">The relative path to the file in the repository.</param>
+        /// <param name="commitSha">The SHA of the commit.</param>
         /// <param name="side">Which side of a diff comparision the buffer represents.</param>
         public PullRequestTextBufferInfo(
             IPullRequestSession session,
             string relativePath,
+            string commitSha,
             DiffSide? side)
         {
+            Guard.ArgumentNotNull(session, nameof(session));
+            Guard.ArgumentNotEmptyString(relativePath, nameof(relativePath));
+            Guard.ArgumentNotEmptyString(commitSha, nameof(commitSha));
+
             Session = session;
             RelativePath = relativePath;
+            CommitSha = commitSha;
             Side = side;
         }
 
@@ -35,6 +43,11 @@ namespace GitHub.Models
         /// Gets the relative path to the file in the repository.
         /// </summary>
         public string RelativePath { get; }
+
+        /// <summary>
+        /// Gets the SHA of the commit.
+        /// </summary>
+        public string CommitSha { get; }
 
         /// <summary>
         /// Gets a value indicating which side of a diff comparision the buffer represents.

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestEditorService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestEditorService.cs
@@ -26,12 +26,12 @@ namespace GitHub.Services
         /// </summary>
         /// <param name="session">The pull request session.</param>
         /// <param name="relativePath">The path to the file, relative to the repository.</param>
-        /// <param name="workingDirectory">
-        /// If true the right hand side of the diff will be the current state of the file in the
-        /// working directory, if false it will be the HEAD commit of the pull request.
+        /// <param name="headSha">
+        /// The commit SHA of the right hand side of the diff. Pass null to compare with the
+        /// working directory, or "HEAD" to compare with the HEAD commit of the pull request.
         /// </param>
         /// <returns>A task tracking the operation.</returns>
-        Task OpenDiff(IPullRequestSession session, string relativePath, bool workingDirectory);
+        Task OpenDiff(IPullRequestSession session, string relativePath, string headSha = null);
 
         /// <summary>
         /// Opens an diff viewer for a file in a pull request with the specified inline comment

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestService.cs
@@ -5,8 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using GitHub.Models;
 using LibGit2Sharp;
-using Octokit;
-using IConnection = GitHub.Models.IConnection;
 
 namespace GitHub.Services
 {
@@ -116,6 +114,14 @@ namespace GitHub.Services
         IObservable<BranchTrackingDetails> CalculateHistoryDivergence(ILocalRepositoryModel repository, int pullRequestNumber);
 
         /// <summary>
+        /// Gets the SHA of the merge base for a pull request.
+        /// </summary>
+        /// <param name="repository">The repository.</param>
+        /// <param name="pullRequest">The pull request details.</param>
+        /// <returns></returns>
+        Task<string> GetMergeBase(ILocalRepositoryModel repository, IPullRequestModel pullRequest);
+
+        /// <summary>
         /// Gets the changes between the pull request base and head.
         /// </summary>
         /// <param name="repository">The repository.</param>
@@ -148,19 +154,19 @@ namespace GitHub.Services
         Encoding GetEncoding(ILocalRepositoryModel repository, string relativePath);
 
         /// <summary>
-        /// Gets a file as it appears in a pull request.
+        /// Extracts a file at the specified commit to a temporary file.
         /// </summary>
         /// <param name="repository">The repository.</param>
         /// <param name="pullRequest">The pull request details.</param>
-        /// <param name="fileName">The filename relative to the repository root.</param>
-        /// <param name="head">If true, gets the file at the PR head, otherwise gets the file at the PR base.</param>
+        /// <param name="relativePath">The path to the file, relative to the repository root.</param>
+        /// <param name="commitSha">The SHA of the commit.</param>
         /// <param name="encoding">The encoding to use.</param>
-        /// <returns>The paths of the left and right files for the diff.</returns>
-        IObservable<string> ExtractFile(
+        /// <returns>The path to the temporary file.</returns>
+        Task<string> ExtractToTempFile(
             ILocalRepositoryModel repository,
             IPullRequestModel pullRequest,
-            string fileName,
-            bool head,
+            string relativePath,
+            string commitSha,
             Encoding encoding);
 
         /// <summary>

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestSession.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestSession.cs
@@ -62,11 +62,14 @@ namespace GitHub.Services
         /// Gets a file touched by the pull request.
         /// </summary>
         /// <param name="relativePath">The relative path to the file.</param>
+        /// <param name="commitSha">
+        /// The commit at which to get the file contents, or "HEAD" to track the pull request head.
+        /// </param>
         /// <returns>
         /// A <see cref="IPullRequestSessionFile"/> object or null if the file was not touched by
         /// the pull request.
         /// </returns>
-        Task<IPullRequestSessionFile> GetFile(string relativePath);
+        Task<IPullRequestSessionFile> GetFile(string relativePath, string commitSha = "HEAD");
 
         /// <summary>
         /// Gets the merge base SHA for the pull request.

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestDetailViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestDetailViewModel.cs
@@ -191,16 +191,6 @@ namespace GitHub.ViewModels.GitHubPane
             int number);
 
         /// <summary>
-        /// Gets a file as it appears in the pull request.
-        /// </summary>
-        /// <param name="file">The changed file.</param>
-        /// <param name="head">
-        /// If true, gets the file at the PR head, otherwise gets the file at the PR merge base.
-        /// </param>
-        /// <returns>The path to a temporary file.</returns>
-        Task<string> ExtractFile(IPullRequestFileNode file, bool head);
-
-        /// <summary>
         /// Gets the full path to a file in the working directory.
         /// </summary>
         /// <param name="file">The file.</param>

--- a/src/GitHub.InlineReviews/Models/InlineCommentThreadModel.cs
+++ b/src/GitHub.InlineReviews/Models/InlineCommentThreadModel.cs
@@ -19,7 +19,7 @@ namespace GitHub.InlineReviews.Models
         /// Initializes a new instance of the <see cref="InlineCommentThreadModel"/> class.
         /// </summary>
         /// <param name="relativePath">The relative path to the file that the thread is on.</param>
-        /// <param name="originalCommitSha">The SHA of the commit that the thread was left con.</param>
+        /// <param name="commitSha">The SHA of the commit that the thread appears on.</param>
         /// <param name="originalPosition">
         /// The 1-based line number in the original diff that the thread was left on.
         /// </param>
@@ -28,20 +28,18 @@ namespace GitHub.InlineReviews.Models
         /// </param>
         public InlineCommentThreadModel(
             string relativePath,
-            string originalCommitSha,
-            int originalPosition,
+            string commitSha,
             IList<DiffLine> diffMatch,
             IEnumerable<IPullRequestReviewCommentModel> comments)
         {
             Guard.ArgumentNotNull(relativePath, nameof(relativePath));
-            Guard.ArgumentNotNull(originalCommitSha, nameof(originalCommitSha));
+            Guard.ArgumentNotNull(commitSha, nameof(commitSha));
             Guard.ArgumentNotNull(diffMatch, nameof(diffMatch));
 
             Comments = comments.ToList();
             DiffMatch = diffMatch;
             DiffLineType = diffMatch[0].Type;
-            OriginalCommitSha = originalCommitSha;
-            OriginalPosition = originalPosition;
+            CommitSha = commitSha;
             RelativePath = relativePath;
         }
 
@@ -69,10 +67,7 @@ namespace GitHub.InlineReviews.Models
         }
 
         /// <inheritdoc/>
-        public string OriginalCommitSha { get; }
-
-        /// <inheritdoc/>
-        public int OriginalPosition { get; }
+        public string CommitSha { get; }
 
         /// <inheritdoc/>
         public string RelativePath { get; }

--- a/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
@@ -48,13 +48,15 @@ namespace GitHub.InlineReviews.Services
         /// <param name="pullRequest">The pull request session.</param>
         /// <param name="relativePath">The relative path to the file.</param>
         /// <param name="diff">The diff.</param>
+        /// <param name="headSha">The SHA of the <paramref name="diff"/> HEAD.</param>
         /// <returns>
         /// A collection of <see cref="IInlineCommentThreadModel"/> objects with updated line numbers.
         /// </returns>
         IReadOnlyList<IInlineCommentThreadModel> BuildCommentThreads(
             IPullRequestModel pullRequest,
             string relativePath,
-            IReadOnlyList<DiffChunk> diff);
+            IReadOnlyList<DiffChunk> diff,
+            string headSha);
 
         /// <summary>
         /// Updates a set of comment thread models for a file based on a new diff.

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
@@ -301,7 +301,8 @@ namespace GitHub.InlineReviews.Services
                     file.InlineCommentThreads = sessionService.BuildCommentThreads(
                         session.PullRequest,
                         file.RelativePath,
-                        file.Diff);
+                        file.Diff,
+                        session.PullRequest.Head.Sha);
                 }
                 else
                 {

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -76,7 +76,8 @@ namespace GitHub.InlineReviews.Services
         public IReadOnlyList<IInlineCommentThreadModel> BuildCommentThreads(
             IPullRequestModel pullRequest,
             string relativePath,
-            IReadOnlyList<DiffChunk> diff)
+            IReadOnlyList<DiffChunk> diff,
+            string headSha)
         {
             relativePath = relativePath.Replace("\\", "/");
 
@@ -101,8 +102,7 @@ namespace GitHub.InlineReviews.Services
 
                 var thread = new InlineCommentThreadModel(
                     relativePath,
-                    comments.Key.Item1,
-                    comments.Key.Item2,
+                    headSha,
                     diffLines,
                     comments);
                 threads.Add(thread);

--- a/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
@@ -136,9 +136,10 @@ namespace GitHub.InlineReviews.Tags
 
             if (bufferInfo != null)
             {
+                var commitSha = bufferInfo.Side == DiffSide.Left ? "HEAD" : bufferInfo.CommitSha;
                 session = bufferInfo.Session;
                 relativePath = bufferInfo.RelativePath;
-                file = await session.GetFile(relativePath);
+                file = await session.GetFile(relativePath, commitSha);
                 fileSubscription = file.LinesChanged.Subscribe(LinesChanged);
                 side = bufferInfo.Side ?? DiffSide.Right;
                 NotifyTagsChanged();

--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
@@ -114,9 +114,10 @@ namespace GitHub.InlineReviews.ViewModels
 
             if (info != null)
             {
+                var commitSha = info.Side == DiffSide.Left ? "HEAD" : info.CommitSha;
                 relativePath = info.RelativePath;
                 side = info.Side ?? DiffSide.Right;
-                file = await info.Session.GetFile(relativePath);
+                file = await info.Session.GetFile(relativePath, commitSha);
                 session = info.Session;
                 await UpdateThread();
             }

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.Utilities;
 using NSubstitute;
 using NUnit.Framework;
 using System.ComponentModel;
+using GitHub.Api;
 
 namespace GitHub.InlineReviews.UnitTests.Services
 {
@@ -260,7 +261,8 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 sessionService.BuildCommentThreads(
                     target.CurrentSession.PullRequest,
                     FilePath,
-                    Arg.Any<IReadOnlyList<DiffChunk>>())
+                    Arg.Any<IReadOnlyList<DiffChunk>>(),
+                    Arg.Any<string>())
                     .Returns(threads);
 
                 var file = await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
@@ -284,7 +286,8 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 sessionService.BuildCommentThreads(
                     target.CurrentSession.PullRequest,
                     FilePath,
-                    Arg.Any<IReadOnlyList<DiffChunk>>())
+                    Arg.Any<IReadOnlyList<DiffChunk>>(),
+                    Arg.Any<string>())
                     .Returns(threads);
 
                 var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
@@ -307,7 +310,8 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 sessionService.BuildCommentThreads(
                     target.CurrentSession.PullRequest,
                     FilePath,
-                    Arg.Any<IReadOnlyList<DiffChunk>>())
+                    Arg.Any<IReadOnlyList<DiffChunk>>(),
+                    Arg.Any<string>())
                     .Returns(threads);
 
                 var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
@@ -346,7 +350,8 @@ namespace GitHub.InlineReviews.UnitTests.Services
                 sessionService.BuildCommentThreads(
                     target.CurrentSession.PullRequest,
                     FilePath,
-                    Arg.Any<IReadOnlyList<DiffChunk>>())
+                    Arg.Any<IReadOnlyList<DiffChunk>>(),
+                    Arg.Any<string>())
                     .Returns(threads);
 
                 var file = (PullRequestSessionLiveFile)await target.GetLiveFile(FilePath, textView, textView.TextBuffer);
@@ -635,7 +640,7 @@ Line 4";
                     CreateInlineCommentThreadModel(expectedLineNumber),
                 };
 
-                sessionService.BuildCommentThreads(null, null, null).ReturnsForAnyArgs(threads);
+                sessionService.BuildCommentThreads(null, null, null, null).ReturnsForAnyArgs(threads);
 
                 var target = CreateTarget(sessionService: sessionService);
                 var file = await target.GetLiveFile(FilePath, textView, textView.TextBuffer);

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionServiceTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using GitHub.Api;
 using GitHub.Factories;
 using GitHub.InlineReviews.Services;
 using GitHub.InlineReviews.UnitTests.TestDoubles;
@@ -46,7 +47,8 @@ Line 4";
                     var result = target.BuildCommentThreads(
                         pullRequest,
                         FilePath,
-                        diff);
+                        diff,
+                        "HEAD_SHA");
 
                     var thread = result.Single();
                     Assert.That(2, Is.EqualTo(thread.LineNumber));
@@ -70,7 +72,8 @@ Line 4";
                     var result = target.BuildCommentThreads(
                         pullRequest,
                         FilePath,
-                        diff);
+                        diff,
+                        "HEAD_SHA");
 
                     Assert.That(result, Is.Empty);
                 }
@@ -105,7 +108,8 @@ Line 4";
                     var result = target.BuildCommentThreads(
                         pullRequest,
                         FilePath,
-                        diff);
+                        diff,
+                        "HEAD_SHA");
 
                     var thread = result.Single();
                     Assert.That(4, Is.EqualTo(thread.LineNumber));
@@ -145,7 +149,8 @@ Line 4";
                     var result = target.BuildCommentThreads(
                         pullRequest,
                         FilePath,
-                        diff);
+                        diff,
+                        "HEAD_SHA");
 
                     Assert.That(2, Is.EqualTo(result.Count));
                     Assert.That(-1, Is.EqualTo(result[1].LineNumber));
@@ -184,7 +189,8 @@ Line 4";
                     var result = target.BuildCommentThreads(
                         pullRequest,
                         winFilePath,
-                        diff);
+                        diff,
+                        "HEAD_SHA");
 
                     var thread = result.First();
                     Assert.That(4, Is.EqualTo(thread.LineNumber));
@@ -226,7 +232,8 @@ Line 4";
                     var threads = target.BuildCommentThreads(
                         pullRequest,
                         FilePath,
-                        diff);
+                        diff,
+                        "HEAD_SHA");
 
                     Assert.That(2, Is.EqualTo(threads[0].LineNumber));
 
@@ -271,7 +278,8 @@ Line 4";
                     var threads = target.BuildCommentThreads(
                         pullRequest,
                         FilePath,
-                        diff);
+                        diff,
+                        "HEAD_SHA");
 
                     threads[0].IsStale = true;
                     var changedLines = target.UpdateCommentThreads(threads, diff);


### PR DESCRIPTION
When the user clicks a review comment represented by a `PullRequestReviewFileCommentViewModel`, open the comment inline in a diff view:

![2018-03-21_13-47-30](https://user-images.githubusercontent.com/1775141/37710659-98b44156-2d0e-11e8-889c-a3dec7ae1bb4.gif)

This also handles showing outdated comments in a diff representing the commit at which the comment was left. Doing this required a few changes to the inline comment/PR session manager classes to make them accept a commit SHA instead of just assuming that the PR head will be needed.

Depends on #1545 
Part of #1491