### PR TITLE
Add the ability to cancel a Pull Request review.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '2.4.4.{build}'
+version: '2.4.99.{build}'
 skip_tags: true
 install:
 - ps: |

--- a/src/GitHub.App/SampleData/PullRequestReviewAuthoringViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestReviewAuthoringViewModelDesigner.cs
@@ -48,6 +48,7 @@ However, if you're two-way binding these properties to a UI, then ignore the rea
         public IPullRequestModel PullRequestModel { get; set; }
         public string RemoteRepositoryOwner { get; set; }
         public ReactiveCommand<Unit> Submit { get; }
+        public ReactiveCommand<Unit> Cancel { get; }
 
         public Task InitializeAsync(
             ILocalRepositoryModel localRepository,

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModel.cs
@@ -58,6 +58,7 @@ namespace GitHub.ViewModels.GitHubPane
 
             Files = files;
             Submit = ReactiveCommand.CreateAsyncTask(DoSubmit);
+            Cancel = ReactiveCommand.CreateAsyncTask(DoCancel);
         }
 
         /// <inheritdoc/>
@@ -112,6 +113,7 @@ namespace GitHub.ViewModels.GitHubPane
 
         public ReactiveCommand<object> NavigateToPullRequest { get; }
         public ReactiveCommand<Unit> Submit { get; }
+        public ReactiveCommand<Unit> Cancel { get; }
 
         public async Task InitializeAsync(
             ILocalRepositoryModel localRepository,
@@ -249,6 +251,30 @@ namespace GitHub.ViewModels.GitHubPane
                     await session.PostReview(Body, e);
                     Close();
                 }
+            }
+            catch (Exception ex)
+            {
+                OperationError = ex.Message;
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        async Task DoCancel(object arg)
+        {
+            OperationError = null;
+            IsBusy = true;
+
+            try
+            {
+                if (Model?.Id != 0)
+                {
+                    await session.CancelReview();
+                }
+
+                Close();
             }
             catch (Exception ex)
             {

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestSession.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestSession.cs
@@ -123,6 +123,14 @@ namespace GitHub.Services
         Task<IPullRequestReviewModel> StartReview();
 
         /// <summary>
+        /// Cancels the currently pending review.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// There is no pending review.
+        /// </exception>
+        Task CancelReview();
+
+        /// <summary>
         /// Posts the currently pending review.
         /// </summary>
         /// <param name="body">The review body.</param>

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewAuthoringViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewAuthoringViewModel.cs
@@ -73,6 +73,11 @@ namespace GitHub.ViewModels.GitHubPane
         ReactiveCommand<Unit> Submit { get; }
 
         /// <summary>
+        /// Gets a command which cancels the review.
+        /// </summary>
+        ReactiveCommand<Unit> Cancel { get; }
+
+        /// <summary>
         /// Initializes the view model for creating a new review.
         /// </summary>
         /// <param name="localRepository">The local repository.</param>

--- a/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
@@ -182,6 +182,14 @@ namespace GitHub.InlineReviews.Services
             string pullRequestId);
 
         /// <summary>
+        /// Cancels a pending review on the server.
+        /// </summary>
+        /// <param name="reviewId">The GraphQL ID of the review.</param>
+        Task CancelPendingReview(
+            ILocalRepositoryModel localRepository,
+            string reviewId);
+
+        /// <summary>
         /// Posts PR review with no comments.
         /// </summary>
         /// <param name="localRepository">The local repository.</param>

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -214,6 +214,26 @@ namespace GitHub.InlineReviews.Services
         }
 
         /// <inheritdoc/>
+        public async Task CancelReview()
+        {
+            if (!HasPendingReview)
+            {
+                throw new InvalidOperationException("There is no pending review to cancel.");
+            }
+
+            await service.CancelPendingReview(LocalRepository, pendingReviewNodeId);
+
+            PullRequest.Reviews = PullRequest.Reviews
+                .Where(x => x.NodeId != pendingReviewNodeId)
+                .ToList();
+            PullRequest.ReviewComments = PullRequest.ReviewComments
+                .Where(x => x.PullRequestReviewId != PendingReviewId)
+                .ToList();
+
+            await Update(PullRequest);
+        }
+
+        /// <inheritdoc/>
         public async Task<IPullRequestReviewModel> PostReview(string body, Octokit.PullRequestReviewEvent e)
         {
             IPullRequestReviewModel model;

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -350,6 +350,26 @@ namespace GitHub.InlineReviews.Services
         }
 
         /// <inheritdoc/>
+        public async Task CancelPendingReview(
+            ILocalRepositoryModel localRepository,
+            string reviewId)
+        {
+            var address = HostAddress.Create(localRepository.CloneUrl.Host);
+            var graphql = await graphqlFactory.CreateConnection(address);
+
+            var delete = new DeletePullRequestReviewInput
+            {
+                PullRequestReviewId = reviewId,
+            };
+
+            var deleteReview = new Mutation()
+                .DeletePullRequestReview(delete)
+                .Select(x => x.ClientMutationId);
+
+            await graphql.Run(deleteReview);
+        }
+
+        /// <inheritdoc/>
         public async Task<IPullRequestReviewModel> PostReview(
             ILocalRepositoryModel localRepository,
             string remoteRepositoryOwner,

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestReviewAuthoringView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestReviewAuthoringView.xaml
@@ -74,7 +74,7 @@
                     </ui:DropDownButton.DropDownContent>
                 </ui:DropDownButton>
                 <Rectangle Fill="{DynamicResource GitHubHeaderSeparatorBrush}" Width="1" Height="16" Margin="4 0"/>
-                <ui:GitHubActionLink VerticalAlignment="Center">Cancel</ui:GitHubActionLink>
+                <ui:GitHubActionLink Command="{Binding Cancel}" VerticalAlignment="Center">Cancel</ui:GitHubActionLink>
             </StackPanel>
 
             <TextBox Grid.Column="0"

--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="c3d3dc68-c977-411f-b3e8-03b0dccf7dfc" Version="2.4.4.0" Language="en-US" Publisher="GitHub, Inc" />
+    <Identity Id="c3d3dc68-c977-411f-b3e8-03b0dccf7dfc" Version="2.4.99.0" Language="en-US" Publisher="GitHub, Inc" />
     <DisplayName>GitHub Extension for Visual Studio</DisplayName>
     <Description xml:space="preserve">A Visual Studio Extension that brings the GitHub Flow into Visual Studio.</Description>
     <PackageId>GitHub.VisualStudio</PackageId>

--- a/src/common/SolutionInfo.cs
+++ b/src/common/SolutionInfo.cs
@@ -18,6 +18,6 @@ using System.Runtime.InteropServices;
 namespace System
 {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "2.4.4.0";
+        internal const string Version = "2.4.99.0";
     }
 }

--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModelTests.cs
@@ -244,6 +244,41 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
             Assert.True(closed);
         }
 
+        [Test]
+        public async Task Cancel_Calls_Session_CancelReview_And_Closes_When_Has_Pending_Review()
+        {
+            var review = CreateReview(12, "grokys", state: PullRequestReviewState.Pending);
+            var model = CreatePullRequest("shana", review);
+            var session = CreateSession();
+            var closed = false;
+
+            var target = CreateTarget(model, session);
+            await Initialize(target);
+
+            target.CloseRequested.Subscribe(_ => closed = true);
+            target.Cancel.Execute(null);
+
+            await session.Received(1).CancelReview();
+            Assert.True(closed);
+        }
+
+        [Test]
+        public async Task Cancel_Just_Closes_When_Has_No_Pending_Review()
+        {
+            var model = CreatePullRequest("shana");
+            var session = CreateSession();
+            var closed = false;
+
+            var target = CreateTarget(model, session);
+            await Initialize(target);
+
+            target.CloseRequested.Subscribe(_ => closed = true);
+            target.Cancel.Execute(null);
+
+            await session.Received(0).CancelReview();
+            Assert.True(closed);
+        }
+
         static PullRequestReviewAuthoringViewModel CreateTarget(
             IPullRequestModel model,
             IPullRequestSession session = null)


### PR DESCRIPTION
This makes the Cancel button on the Pull Request Review authoring page work: previously clicking it did nothing. Now it should cancel the review on the server (if a review had actually been started there), and close the PR authoring pane.

Depends on #1567 
Part of #1491
