### PR TITLE
Fix opening Pull Request on GitHub.

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItem.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItem.xaml
@@ -121,7 +121,7 @@
           </Grid.ColumnDefinitions>
           <Button x:Name="prHashtagLink"
                   Grid.Column="0"
-                  Command="{Binding OpenPROnGitHub, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"
+                  Command="{Binding DataContext.OpenPullRequestOnGitHub, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:PullRequestListView}}}"
                   CommandParameter="{Binding Number}"
                   Content="{Binding Number}"
                   ToolTip="{x:Static prop:Resources.OpenPROnGitHubToolTip}"


### PR DESCRIPTION
When #number link in the pull request list is clicked, the pull request should be opened on GitHub.

This was broken in the MVVM refactor, when the command to open on GitHub moved. Bind from the view to the correct command.

Fixes #1576 