### PR TITLE
Use correct GraphQL endpoint for enterprise.

### DIFF
--- a/src/GitHub.Api/GraphQLClientFactory.cs
+++ b/src/GitHub.Api/GraphQLClientFactory.cs
@@ -35,7 +35,7 @@ namespace GitHub.Api
         {
             var credentials = new GraphQLKeychainCredentialStore(keychain, address);
             var header = new ProductHeaderValue(program.ProductHeader.Name, program.ProductHeader.Version);
-            return Task.FromResult<Octokit.GraphQL.IConnection>(new Connection(header, credentials));
+            return Task.FromResult<Octokit.GraphQL.IConnection>(new Connection(header, address.GraphQLUri, credentials));
         }
     }
 }

--- a/src/GitHub.Exports/Primitives/HostAddress.cs
+++ b/src/GitHub.Exports/Primitives/HostAddress.cs
@@ -44,7 +44,7 @@ namespace GitHub.Primitives
         {
             WebUri = new Uri(enterpriseUri, new Uri("/", UriKind.Relative));
             ApiUri = new Uri(enterpriseUri, new Uri("/api/v3/", UriKind.Relative));
-            //CredentialCacheKeyHost = ApiUri.Host;
+            GraphQLUri = new Uri(enterpriseUri, new Uri("/api/graphql", UriKind.Relative));
             CredentialCacheKeyHost = WebUri.ToString();
         }
 
@@ -52,7 +52,7 @@ namespace GitHub.Primitives
         {
             WebUri = new Uri("https://github.com");
             ApiUri = new Uri("https://api.github.com");
-            //CredentialCacheKeyHost = "github.com";
+            GraphQLUri = new Uri("https://api.github.com/graphql");
             CredentialCacheKeyHost = WebUri.ToString();
         }
 
@@ -66,6 +66,12 @@ namespace GitHub.Primitives
         ///  "https://github-enterprise.com/api/v3"
         /// </summary>
         public Uri ApiUri { get; set; }
+
+        /// <summary>
+        /// The Base Url to the host's GraphQL API endpoint. For example, "https://api.github.com/graphql" or
+        ///  "https://github-enterprise.com/api/graphql"
+        /// </summary>
+        public Uri GraphQLUri { get; set; }
 
         // If the host name is "api.github.com" or "gist.github.com", we really only want "github.com",
         // since that's the same cache key for all the other github.com operations.


### PR DESCRIPTION
Previously we were always using github.com's endpoint even when talking to an enterprise instance.

This should fix PR reviews not working with enterprise instances.

Depends on #1572 
Part of #1491