### PR TITLE
Limit avatar download attempts

### DIFF
--- a/src/GitHub.App/Services/ImageDownloader.cs
+++ b/src/GitHub.App/Services/ImageDownloader.cs
@@ -27,12 +27,15 @@ namespace GitHub.Services
             exceptionCache = new Dictionary<string, Exception>();
         }
 
+        public static string CachedExceptionMessage(string host) =>
+            "Throwing cached exception for host: " + host;
+        public static string CouldNotDownloadExceptionMessage(Uri imageUri) =>
+            string.Format(CultureInfo.InvariantCulture, "Could not download image from {0}", imageUri);
+
         public IObservable<byte[]> DownloadImageBytes(Uri imageUri)
         {
             return ExceptionCachingDownloadImageBytesAsync(imageUri).ToObservable();
         }
-
-        public static string CachedExceptionMessage(string host) => "Throwing cached exception for host: " + host;
 
         async Task<byte[]> ExceptionCachingDownloadImageBytesAsync(Uri imageUri)
         {
@@ -75,7 +78,7 @@ namespace GitHub.Services
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
-                throw new HttpRequestException(string.Format(CultureInfo.InvariantCulture, "Could not download image from {0}", imageUri));
+                throw new HttpRequestException(CouldNotDownloadExceptionMessage(imageUri));
             }
 
             if (response.ContentType == null || !response.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))

--- a/src/GitHub.App/Services/ImageDownloader.cs
+++ b/src/GitHub.App/Services/ImageDownloader.cs
@@ -5,11 +5,11 @@ using System.Net;
 using System.Net.Http;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GitHub.Logging;
 using Octokit;
 using Octokit.Internal;
-using System.Collections.Generic;
 
 namespace GitHub.Services
 {
@@ -31,6 +31,8 @@ namespace GitHub.Services
             "Throwing cached exception for host: " + host;
         public static string CouldNotDownloadExceptionMessage(Uri imageUri) =>
             string.Format(CultureInfo.InvariantCulture, "Could not download image from {0}", imageUri);
+        public static string NonImageContentExceptionMessage(string contentType) =>
+            string.Format(CultureInfo.InvariantCulture, "Server responded with a non-image content type: {0}", contentType);
 
         public IObservable<byte[]> DownloadImageBytes(Uri imageUri)
         {
@@ -83,9 +85,7 @@ namespace GitHub.Services
 
             if (response.ContentType == null || !response.ContentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
             {
-                throw new HttpRequestException(
-                    string.Format(CultureInfo.InvariantCulture,
-                        "Server responded with a non-image content type: {0}", response.ContentType));
+                throw new HttpRequestException(NonImageContentExceptionMessage(response.ContentType));
             }
 
             return response.Body as byte[];

--- a/src/GitHub.App/Services/ImageDownloader.cs
+++ b/src/GitHub.App/Services/ImageDownloader.cs
@@ -30,7 +30,7 @@ namespace GitHub.Services
         }
 
         public static string CachedExceptionMessage(string host) =>
-            string.Format(CultureInfo.InvariantCulture, "Host '{0}' previously returned a non-image content type ", host);
+            string.Format(CultureInfo.InvariantCulture, "Host '{0}' previously returned a non-image content type", host);
         public static string CouldNotDownloadExceptionMessage(Uri imageUri) =>
             string.Format(CultureInfo.InvariantCulture, "Could not download image from '{0}'", imageUri);
         public static string NonImageContentExceptionMessage(string contentType) =>
@@ -42,7 +42,7 @@ namespace GitHub.Services
         /// <remarks>
         /// If a host returns a non-image content type, this will be remembered and subsequent download requests
         /// to the same host will automatically throw a <see cref="NonImageContentException"/>. This prevents a
-        /// barrage of download requests when authentication is required but not supported.
+        /// barrage of download requests when authentication is required (but not currently supported).
         /// </remarks>
         /// <param name="imageUri">The URI of an image.</param>
         /// <returns>The bytes for a given image URI.</returns>

--- a/src/GitHub.App/Services/ImageDownloader.cs
+++ b/src/GitHub.App/Services/ImageDownloader.cs
@@ -28,12 +28,24 @@ namespace GitHub.Services
         }
 
         public static string CachedExceptionMessage(string host) =>
-            "Throwing cached exception for host: " + host;
+            string.Format(CultureInfo.InvariantCulture, "Host '{0}' previously returned a non-image content type ", host);
         public static string CouldNotDownloadExceptionMessage(Uri imageUri) =>
-            string.Format(CultureInfo.InvariantCulture, "Could not download image from {0}", imageUri);
+            string.Format(CultureInfo.InvariantCulture, "Could not download image from '{0}'", imageUri);
         public static string NonImageContentExceptionMessage(string contentType) =>
-            string.Format(CultureInfo.InvariantCulture, "Server responded with a non-image content type: {0}", contentType);
+            string.Format(CultureInfo.InvariantCulture, "Server responded with a non-image content type '{0}'", contentType);
 
+        /// <summary>
+        /// Get the bytes for a given image URI.
+        /// </summary>
+        /// <remarks>
+        /// If a host returns a non-image content type, this will be remembered and subsequent download requests
+        /// to the same host will automatically throw a <see cref="NonImageContentException"/>. This prevents a
+        /// barrage of download requests when authentication is required but not supported.
+        /// </remarks>
+        /// <param name="imageUri">The URI of an image.</param>
+        /// <returns>The bytes for a given image URI.</returns>
+        /// <exception cref="HttpRequestException">When the URI returns a status code that isn't OK/200.</exception>
+        /// <exception cref="NonImageContentException">When the URI returns a non-image content type.</exception>
         public IObservable<byte[]> DownloadImageBytes(Uri imageUri)
         {
             return ExceptionCachingDownloadImageBytesAsync(imageUri).ToObservable();

--- a/src/GitHub.App/Services/ImageDownloader.cs
+++ b/src/GitHub.App/Services/ImageDownloader.cs
@@ -5,6 +5,8 @@ using System.Net;
 using System.Net.Http;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
+using System.Runtime.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GitHub.Logging;
@@ -106,14 +108,15 @@ namespace GitHub.Services
         IHttpClient HttpClient { get { return httpClient.Value; } }
     }
 
+    [Serializable]
     public class NonImageContentException : HttpRequestException
     {
-        public NonImageContentException(string message) : base(message)
-        {
-        }
+        public NonImageContentException() { }
+        public NonImageContentException(string message) : base(message) { }
+        public NonImageContentException(string message, Exception inner) : base(message, inner) { }
 
-        public NonImageContentException(string message, Exception inner) : base(message, inner)
-        {
-        }
+        [SuppressMessage("Microsoft.Usage", "CA2236:CallBaseClassMethodsOnISerializableTypes",
+            Justification = "HttpRequestException doesn't have required constructor")]
+        protected NonImageContentException(SerializationInfo info, StreamingContext context) { }
     }
 }

--- a/test/UnitTests/GitHub.App/Services/ImageDownloaderTests.cs
+++ b/test/UnitTests/GitHub.App/Services/ImageDownloaderTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Reactive.Linq;
+using GitHub.Services;
+using Octokit;
+using Octokit.Internal;
+using NSubstitute;
+using NUnit.Framework;
+
+public class ImageDownloaderTests
+{
+    public class TheDownloadImageBytesMethod
+    {
+        [Test]
+        public async Task HttpStatusCode_OK()
+        {
+            var url = new Uri("http://foo.bar");
+            var httpClient = Substitute.For<IHttpClient>();
+            var response = Substitute.For<IResponse>();
+            response.StatusCode.Returns(HttpStatusCode.OK);
+            response.ContentType.Returns("image/xxx");
+            response.Body.Returns(Array.Empty<byte>());
+            httpClient.Send(null, default(CancellationToken)).ReturnsForAnyArgs(Task.FromResult(response));
+            var target = new ImageDownloader(new Lazy<IHttpClient>(() => httpClient));
+
+            var bytes = await target.DownloadImageBytes(url);
+
+            Assert.IsEmpty(bytes);
+        }
+
+        [Test]
+        public void ContentTypeText_ThrowsHttpRequestException()
+        {
+            var url = new Uri("http://foo.bar");
+            var httpClient = Substitute.For<IHttpClient>();
+            var response = Substitute.For<IResponse>();
+            response.StatusCode.Returns(HttpStatusCode.OK);
+            response.ContentType.Returns("text/plain");
+            response.Body.Returns(Array.Empty<byte>());
+            httpClient.Send(null, default(CancellationToken)).ReturnsForAnyArgs(Task.FromResult(response));
+            var target = new ImageDownloader(new Lazy<IHttpClient>(() => httpClient));
+
+            Assert.ThrowsAsync<HttpRequestException>(async () => await target.DownloadImageBytes(url));
+        }
+
+        [Test]
+        public void HttpStatusCode_NotFound404_ThrowsHttpRequestException()
+        {
+            var url = new Uri("http://foo.bar");
+            var httpClient = Substitute.For<IHttpClient>();
+            var response = Substitute.For<IResponse>();
+            response.StatusCode.Returns(HttpStatusCode.NotFound);
+            httpClient.Send(null, default(CancellationToken)).ReturnsForAnyArgs(Task.FromResult(response));
+            var target = new ImageDownloader(new Lazy<IHttpClient>(() => httpClient));
+
+            Assert.ThrowsAsync<HttpRequestException>(async () => await target.DownloadImageBytes(url));
+        }
+    }
+}

--- a/test/UnitTests/GitHub.App/Services/ImageDownloaderTests.cs
+++ b/test/UnitTests/GitHub.App/Services/ImageDownloaderTests.cs
@@ -43,7 +43,7 @@ public class ImageDownloaderTests
             httpClient.Send(null, default(CancellationToken)).ReturnsForAnyArgs(Task.FromResult(response));
             var target = new ImageDownloader(new Lazy<IHttpClient>(() => httpClient));
 
-            Assert.ThrowsAsync<HttpRequestException>(async () => await target.DownloadImageBytes(url));
+            Assert.ThrowsAsync<NonImageContentException>(async () => await target.DownloadImageBytes(url));
         }
 
         [Test]
@@ -60,41 +60,22 @@ public class ImageDownloaderTests
         }
 
         [Test]
-        public void NotFoundTwiceForSameHost_ThrowsCachedHttpRequestException()
+        public void NotFoundTwiceForSameHost_CouldNotDownloadExceptionMessage()
         {
             var host = "flaky404.githubusercontent.com";
             var url = new Uri("https://" + host + "/u/00000000?v=4");
-            var expectMessage = ImageDownloader.CachedExceptionMessage(host);
+            var expectMessage = ImageDownloader.CouldNotDownloadExceptionMessage(url);
             var httpClient = Substitute.For<IHttpClient>();
             var response = Substitute.For<IResponse>();
             response.StatusCode.Returns(HttpStatusCode.NotFound);
             httpClient.Send(null, default(CancellationToken)).ReturnsForAnyArgs(Task.FromResult(response));
             var target = new ImageDownloader(new Lazy<IHttpClient>(() => httpClient));
 
-            Assert.ThrowsAsync<HttpRequestException>(async () => await target.DownloadImageBytes(url));
-            var ex = Assert.CatchAsync<HttpRequestException>(async () => await target.DownloadImageBytes(url));
+            var ex1 = Assert.CatchAsync<HttpRequestException>(async () => await target.DownloadImageBytes(url));
+            var ex2 = Assert.CatchAsync<HttpRequestException>(async () => await target.DownloadImageBytes(url));
 
-            Assert.That(ex.Message, Is.EqualTo(expectMessage));
-        }
-
-        [Test]
-        public void NotFoundTwiceForDifferentHosts_DoesNotThrowCachedHttpRequestException()
-        {
-            var url1 = new Uri("https://host1/u/00000000?v=4");
-            var url2 = new Uri("https://host2/u/00000000?v=4");
-            var expectMessage1 = ImageDownloader.CouldNotDownloadExceptionMessage(url1);
-            var expectMessage2 = ImageDownloader.CouldNotDownloadExceptionMessage(url2);
-            var httpClient = Substitute.For<IHttpClient>();
-            var response = Substitute.For<IResponse>();
-            response.StatusCode.Returns(HttpStatusCode.NotFound);
-            httpClient.Send(null, default(CancellationToken)).ReturnsForAnyArgs(Task.FromResult(response));
-            var target = new ImageDownloader(new Lazy<IHttpClient>(() => httpClient));
-
-            var ex1 = Assert.CatchAsync<HttpRequestException>(async () => await target.DownloadImageBytes(url1));
-            var ex2 = Assert.CatchAsync<HttpRequestException>(async () => await target.DownloadImageBytes(url2));
-
-            Assert.That(ex1?.Message, Is.EqualTo(expectMessage1));
-            Assert.That(ex2?.Message, Is.EqualTo(expectMessage2));
+            Assert.That(ex1?.Message, Is.EqualTo(expectMessage));
+            Assert.That(ex2?.Message, Is.EqualTo(expectMessage));
         }
 
         [Test]

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -183,6 +183,7 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=62aa029873c516b4, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Rx-Core.2.2.5-custom\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
@@ -240,6 +241,7 @@
     <Compile Include="GitHub.App\Models\RepositoryModelTests.cs" />
     <Compile Include="GitHub.App\Services\AvatarProviderTests.cs" />
     <Compile Include="GitHub.App\Services\GitClientTests.cs" />
+    <Compile Include="GitHub.App\Services\ImageDownloaderTests.cs" />
     <Compile Include="GitHub.Exports.Reactive\Services\PullRequestEditorServiceTests.cs" />
     <Compile Include="GitHub.App\Services\OAuthCallbackListenerTests.cs" />
     <Compile Include="GitHub.App\Services\PullRequestServiceTests.cs" />


### PR DESCRIPTION
This PR limits the number of attempts that will be made to download avatar when a host requires authentication (which isn't currently supported for images).

GitHub Enterprise returns a `200/OK` with a content type of `text/html` when authentication is required to download an avatar.

#### What this PR does

- When an avatar returns a non-image content type, remember this for subsequent calls to the same host

#### Reviewers

- Thanks @darn for confirming the fix: https://github.com/github/VisualStudio/issues/1547#issuecomment-378647420

#### Todo

- [x] We should refine the type and/or number of exceptions that can be thrown before a host is blacklisted to make it more robust.
  - Changed to only remember exceptions caused by hosts returning non-image content 

Fixes #1547 