### PR TITLE
Fix navigate to editor.

### DIFF
--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -182,6 +182,9 @@ namespace GitHub.Services
                 if (!workingDirectory)
                 {
                     AddBufferTag(diffViewer.RightView.TextBuffer, session, rightPath, file.CommitSha, DiffSide.Right);
+                    EnableNavigateToEditor(diffViewer.LeftView, session, file);
+                    EnableNavigateToEditor(diffViewer.RightView, session, file);
+                    EnableNavigateToEditor(diffViewer.InlineView, session, file);
                 }
 
                 if (workingDirectory)

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -516,7 +516,9 @@ namespace GitHub.Services
 
         static string GetAbsolutePath(IPullRequestSession session, IPullRequestSessionFile file)
         {
-            return Path.Combine(session.LocalRepository.LocalPath, file.RelativePath);
+            var localPath = session.LocalRepository.LocalPath;
+            var relativePath = file.RelativePath.Replace('/', Path.DirectorySeparatorChar);
+            return Path.Combine(localPath, relativePath);
         }
 
         static IDisposable OpenInProvisionalTab()

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -102,6 +102,10 @@ namespace GitHub.Services
                     if (!workingDirectory)
                     {
                         AddBufferTag(buffer, session, fullPath, commitSha, null);
+
+                        var textView = FindActiveView();
+                        var file = await session.GetFile(relativePath);
+                        EnableNavigateToEditor(textView, session, file);
                     }
                 }
 


### PR DESCRIPTION
This code was accidentally removed in fa8aab8

- Fix navigate from `View Changes` to editor
- Fix navigate from `View File` to editor

Previously the menu option to navigate from the diff view to the file in the solution was missing from the context menu - this adds it back.

Depends on #1578
Part of #1491 
Fixes #1580