### PR TITLE
Validate PR review state before allowing submission.

### DIFF
--- a/src/GitHub.App/SampleData/PullRequestReviewAuthoringViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/PullRequestReviewAuthoringViewModelDesigner.cs
@@ -47,7 +47,9 @@ However, if you're two-way binding these properties to a UI, then ignore the rea
         public string OperationError { get; set; }
         public IPullRequestModel PullRequestModel { get; set; }
         public string RemoteRepositoryOwner { get; set; }
-        public ReactiveCommand<Unit> Submit { get; }
+        public ReactiveCommand<Unit> Approve { get; }
+        public ReactiveCommand<Unit> Comment { get; }
+        public ReactiveCommand<Unit> RequestChanges { get; }
         public ReactiveCommand<Unit> Cancel { get; }
 
         public Task InitializeAsync(

--- a/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewAuthoringViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/GitHubPane/IPullRequestReviewAuthoringViewModel.cs
@@ -68,9 +68,19 @@ namespace GitHub.ViewModels.GitHubPane
         ReactiveCommand<object> NavigateToPullRequest { get; }
 
         /// <summary>
-        /// Gets a command which submits the review.
+        /// Gets a command which submits the review as an approval.
         /// </summary>
-        ReactiveCommand<Unit> Submit { get; }
+        ReactiveCommand<Unit> Approve { get; }
+
+        /// <summary>
+        /// Gets a command which submits the review as a comment.
+        /// </summary>
+        ReactiveCommand<Unit> Comment { get; }
+
+        /// <summary>
+        /// Gets a command which submits the review requesting changes.
+        /// </summary>
+        ReactiveCommand<Unit> RequestChanges { get; }
 
         /// <summary>
         /// Gets a command which cancels the review.

--- a/src/GitHub.VisualStudio.UI/Styles/GitHubActionLink.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/GitHubActionLink.xaml
@@ -13,6 +13,15 @@
       <Setter.Value>
         <ControlTemplate TargetType="{x:Type ui:GitHubActionLink}">
           <TextBlock TextTrimming="{TemplateBinding TextTrimming}" TextWrapping="{TemplateBinding TextWrapping}">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock">
+                <Style.Triggers>
+                  <Trigger Property="IsEnabled" Value="False">
+                    <Setter Property="Opacity" Value="0.5"/>
+                  </Trigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
             <Hyperlink Command="{TemplateBinding Command}"
                        CommandParameter="{TemplateBinding CommandParameter}"
                        Foreground="{TemplateBinding Foreground}">
@@ -40,8 +49,7 @@
                       </MultiTrigger.Setters>
                     </MultiTrigger>
                     <Trigger Property="IsEnabled" Value="False">
-                        <Setter Property="Foreground" Value="{StaticResource GHBlueLinkButtonDisabledBrush}"/>
-                        <Setter Property="TextDecorations" Value="None" />
+                      <Setter Property="TextDecorations" Value="None" />
                     </Trigger>
                   </Style.Triggers>
                 </Style>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestReviewAuthoringView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestReviewAuthoringView.xaml
@@ -56,15 +56,13 @@
                                 BorderThickness="1"
                                 Padding="4">
                             <StackPanel Background="{DynamicResource GitHubVsToolWindowBackground}">
-                                <ui:GitHubActionLink Command="{Binding Submit}" CommandParameter="Comment" Margin="4">Comment only</ui:GitHubActionLink>
-                                <ui:GitHubActionLink Command="{Binding Submit}"
-                                                     CommandParameter="Approve"
+                                <ui:GitHubActionLink Command="{Binding Comment}" Margin="4">Comment only</ui:GitHubActionLink>
+                                <ui:GitHubActionLink Command="{Binding Approve}"
                                                      Visibility="{Binding CanApproveRequestChanges, Converter={ui:BooleanToVisibilityConverter}}"
                                                      Margin="4">
                                     Approve
                                 </ui:GitHubActionLink>
-                                <ui:GitHubActionLink Command="{Binding Submit}"
-                                                     CommandParameter="RequestChanges"
+                                <ui:GitHubActionLink Command="{Binding RequestChanges}"
                                                      Visibility="{Binding CanApproveRequestChanges, Converter={ui:BooleanToVisibilityConverter}}"
                                                      Margin="4">
                                     Request changes


### PR DESCRIPTION
Split the `PullRequestReviewAuthoringViewModel.Submit` command into 2 separate commands and add a `CanExecute` observable for them:

- `Approve` can always be submitted
- `Comment` needs either a review body or >0 review comments
- `RequestChanges` needs either a review body or >0 review comments

## HACK

Disabling the `GitHubActionLink`s that are used for the approve/comment/request changes buttons had no visual effect. Seems that hyperlinks don't respect [dependency property precedence](https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/dependency-property-value-precedence), so the `IsEnabled=False` trigger for `Hyperlink.Foreground` doesn't override the foreground `TemplateBinding`. Not sure what we can do here other than set the control's opacity when disabled, so that's what I did for now.

Depends on #1581 
Part of #1491