### PR TITLE
Reuse existing tabs when opening files from changes tree

### DIFF
--- a/src/GitHub.App/Api/ApiClient.cs
+++ b/src/GitHub.App/Api/ApiClient.cs
@@ -149,30 +149,10 @@ namespace GitHub.Api
 
         public HostAddress HostAddress { get; }
 
-        static string GetSha256Hash(string input)
-        {
-            Guard.ArgumentNotEmptyString(input, nameof(input));
-
-            try
-            {
-                using (var sha256 = SHA256.Create())
-                {
-                    var bytes = Encoding.UTF8.GetBytes(input);
-                    var hash = sha256.ComputeHash(bytes);
-
-                    return string.Join("", hash.Select(b => b.ToString("x2", CultureInfo.InvariantCulture)));
-                }
-            }
-            catch (Exception e)
-            {
-                log.Error(e, "IMPOSSIBLE! Generating Sha256 hash caused an exception");
-                return null;
-            }
-        }
-
         static string GetFingerprint()
         {
-            return GetSha256Hash(ProductName + ":" + GetMachineIdentifier());
+            var fingerprint = ProductName + ":" + GetMachineIdentifier();
+            return fingerprint.GetSha256Hash();
         }
 
         static string GetMachineNameSafe()

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -420,8 +420,7 @@ namespace GitHub.Services
                         leftBufferInfo.Session.PullRequest.Number == session.PullRequest.Number &&
                         leftBufferInfo.CommitSha == mergeBase)
                     {
-                        windowFrame.Show();
-                        return true;
+                        return ErrorHandler.Succeeded(windowFrame.Show());
                     }
                 }
             }
@@ -563,8 +562,13 @@ namespace GitHub.Services
         static IDifferenceViewer GetDiffViewer(IVsWindowFrame frame)
         {
             object docView;
-            frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out docView);
-            return (docView as IVsDifferenceCodeWindow)?.DifferenceViewer;
+
+            if (ErrorHandler.Succeeded(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out docView)))
+            {
+                return (docView as IVsDifferenceCodeWindow)?.DifferenceViewer;
+            }
+
+            return null;
         }
 
         static IDisposable OpenInProvisionalTab()

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
+using EnvDTE;
 using GitHub.Commands;
 using GitHub.Extensions;
 using GitHub.Models;
@@ -16,6 +17,7 @@ using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Differencing;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.TextManager.Interop;
@@ -128,8 +130,6 @@ namespace GitHub.Services
                 var file = await session.GetFile(relativePath, headSha ?? "HEAD");
                 var mergeBase = await pullRequestService.GetMergeBase(session.LocalRepository, session.PullRequest);
                 var encoding = pullRequestService.GetEncoding(session.LocalRepository, file.RelativePath);
-                var rightPath = file.RelativePath;
-                var leftPath = await GetBaseFileName(session, file);
                 var rightFile = workingDirectory ?
                     Path.Combine(session.LocalRepository.LocalPath, relativePath) :
                     await pullRequestService.ExtractToTempFile(
@@ -138,12 +138,20 @@ namespace GitHub.Services
                         relativePath,
                         file.CommitSha,
                         encoding);
+
+                if (FocusExistingDiffViewer(session, mergeBase, rightFile))
+                {
+                    return;
+                }
+
                 var leftFile = await pullRequestService.ExtractToTempFile(
                     session.LocalRepository,
                     session.PullRequest,
                     relativePath,
                     mergeBase,
                     encoding);
+                var leftPath = await GetBaseFileName(session, file);
+                var rightPath = file.RelativePath;
                 var leftLabel = $"{leftPath};{session.GetBaseBranchDisplay()}";
                 var rightLabel = workingDirectory ? rightPath : $"{rightPath};PR {session.PullRequest.Number}";
                 var caption = $"Diff - {Path.GetFileName(file.RelativePath)}";
@@ -173,9 +181,7 @@ namespace GitHub.Services
                         (uint)options);
                 }
 
-                object docView;
-                frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out docView);
-                var diffViewer = ((IVsDifferenceCodeWindow)docView).DifferenceViewer;
+                var diffViewer = GetDiffViewer(frame);
 
                 AddBufferTag(diffViewer.LeftView.TextBuffer, session, leftPath, mergeBase, DiffSide.Left);
 
@@ -384,6 +390,45 @@ namespace GitHub.Services
             return view;
         }
 
+        bool FocusExistingDiffViewer(
+            IPullRequestSession session,
+            string mergeBase,
+            string rightPath)
+        {
+            IVsUIHierarchy uiHierarchy;
+            uint itemID;
+            IVsWindowFrame windowFrame;
+
+            // Diff documents are indexed by the path on the right hand side of the comparison.
+            if (VsShellUtilities.IsDocumentOpen(
+                    serviceProvider,
+                    rightPath,
+                    Guid.Empty,
+                    out uiHierarchy,
+                    out itemID,
+                    out windowFrame))
+            {
+                var diffViewer = GetDiffViewer(windowFrame);
+
+                if (diffViewer != null)
+                {
+                    PullRequestTextBufferInfo leftBufferInfo;
+
+                    if (diffViewer.LeftView.TextBuffer.Properties.TryGetProperty(
+                            typeof(PullRequestTextBufferInfo),
+                            out leftBufferInfo) &&
+                        leftBufferInfo.Session.PullRequest.Number == session.PullRequest.Number &&
+                        leftBufferInfo.CommitSha == mergeBase)
+                    {
+                        windowFrame.Show();
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         void ShowErrorInStatusBar(string message)
         {
             statusBar.ShowMessage(message);
@@ -416,7 +461,7 @@ namespace GitHub.Services
             }
         }
 
-        void EnableNavigateToEditor(IWpfTextView textView, IPullRequestSession session, IPullRequestSessionFile file)
+        void EnableNavigateToEditor(ITextView textView, IPullRequestSession session, IPullRequestSessionFile file)
         {
             var view = vsEditorAdaptersFactory.GetViewAdapter(textView);
             EnableNavigateToEditor(view, session, file);
@@ -513,6 +558,13 @@ namespace GitHub.Services
         static string GetAbsolutePath(IPullRequestSession session, IPullRequestSessionFile file)
         {
             return Path.Combine(session.LocalRepository.LocalPath, file.RelativePath);
+        }
+
+        static IDifferenceViewer GetDiffViewer(IVsWindowFrame frame)
+        {
+            object docView;
+            frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out docView);
+            return (docView as IVsDifferenceCodeWindow)?.DifferenceViewer;
         }
 
         static IDisposable OpenInProvisionalTab()

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using LibGit2Sharp;
 using GitHub.Logging;
 using GitHub.Extensions;
+using static System.FormattableString;
 
 namespace GitHub.Services
 {
@@ -680,7 +681,7 @@ namespace GitHub.Services
             var key = relativeDir + '|' + encoding.WebName;
             var relativePathHash = key.GetSha256Hash();
             var tempDir = Path.Combine(Path.GetTempPath(), "GitHubVisualStudio", "FileContents", relativePathHash);
-            var tempFileName = $"{Path.GetFileNameWithoutExtension(relativePath)}@{commitSha}{Path.GetExtension(relativePath)}";
+            var tempFileName = Invariant($"{Path.GetFileNameWithoutExtension(relativePath)}@{commitSha}{Path.GetExtension(relativePath)}");
             return Path.Combine(tempDir, tempFileName);
         }
 

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModel.cs
@@ -57,15 +57,18 @@ namespace GitHub.ViewModels.GitHubPane
                 .ToProperty(this, x => x.CanApproveRequestChanges);
 
             Files = files;
+
+            var hasBodyOrComments = this.WhenAnyValue(
+                x => x.Body,
+                x => x.FileComments.Count,
+                (body, comments) => !string.IsNullOrWhiteSpace(body) || comments > 0);
+
             Approve = ReactiveCommand.CreateAsyncTask(_ => DoSubmit(Octokit.PullRequestReviewEvent.Approve));
             Comment = ReactiveCommand.CreateAsyncTask(
-                this.WhenAnyValue(
-                    x => x.Body,
-                    x => x.FileComments.Count,
-                    (body, comments) => !string.IsNullOrWhiteSpace(body) || comments > 0),
+                hasBodyOrComments,
                 _ => DoSubmit(Octokit.PullRequestReviewEvent.Comment));
             RequestChanges = ReactiveCommand.CreateAsyncTask(
-                this.WhenAnyValue(x => x.Body, body => !string.IsNullOrWhiteSpace(body)),
+                hasBodyOrComments,
                 _ => DoSubmit(Octokit.PullRequestReviewEvent.RequestChanges));
             Cancel = ReactiveCommand.CreateAsyncTask(DoCancel);
         }

--- a/src/GitHub.Extensions/StringExtensions.cs
+++ b/src/GitHub.Extensions/StringExtensions.cs
@@ -4,8 +4,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using GitHub.Logging;
+using Splat;
 
 namespace GitHub.Extensions
 {
@@ -221,6 +224,24 @@ namespace GitHub.Extensions
             var result = matches.Cast<Match>().Select(match => match.Value.ToLower(CultureInfo.InvariantCulture));
             var combined = String.Join(" ", result);
             return Char.ToUpper(combined[0], CultureInfo.InvariantCulture) + combined.Substring(1);
+        }
+
+        /// <summary>
+        /// Generates a SHA256 hash for a string.
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <returns>The SHA256 hash.</returns>
+        public static string GetSha256Hash(this string input)
+        {
+            Guard.ArgumentNotNull(input, nameof(input));
+
+            using (var sha256 = SHA256.Create())
+            {
+                var bytes = Encoding.UTF8.GetBytes(input);
+                var hash = sha256.ComputeHash(bytes);
+
+                return string.Join("", hash.Select(b => b.ToString("x2", CultureInfo.InvariantCulture)));
+            }
         }
     }
 }

--- a/test/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
+++ b/test/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
@@ -593,7 +593,14 @@ public class PullRequestServiceTests : TestBaseClass
             gitClient.ExtractFile(Arg.Any<IRepository>(), "123", "filename").Returns(GetFileTask(fileContent));
             var file = await target.ExtractToTempFile(repository, pr, "filename", "123", Encoding.UTF8);
 
-            Assert.That(File.ReadAllText(file), Is.EqualTo(fileContent));
+            try
+            {
+                Assert.That(File.ReadAllText(file), Is.EqualTo(fileContent));
+            }
+            finally
+            {
+                File.Delete(file);
+            }
         }
 
         [Test]
@@ -607,7 +614,14 @@ public class PullRequestServiceTests : TestBaseClass
             gitClient.ExtractFile(Arg.Any<IRepository>(), "123", "filename").Returns(GetFileTask(null));
             var file = await target.ExtractToTempFile(repository, pr, "filename", "123", Encoding.UTF8);
 
-            Assert.That(File.ReadAllText(file), Is.EqualTo(string.Empty));
+            try
+            {
+                Assert.That(File.ReadAllText(file), Is.EqualTo(string.Empty));
+            }
+            finally
+            {
+                File.Delete(file);
+            }
         }
 
         // https://github.com/github/VisualStudio/issues/1010
@@ -631,8 +645,15 @@ public class PullRequestServiceTests : TestBaseClass
             gitClient.ExtractFile(Arg.Any<IRepository>(), "123", "filename").Returns(GetFileTask(fileContent));
             var file = await target.ExtractToTempFile(repository, pr, "filename", "123", encoding);
 
-            Assert.That(File.ReadAllText(expectedPath), Is.EqualTo(File.ReadAllText(file)));
-            Assert.That(File.ReadAllBytes(expectedPath), Is.EqualTo(File.ReadAllBytes(file)));
+            try
+            {
+                Assert.That(File.ReadAllText(expectedPath), Is.EqualTo(File.ReadAllText(file)));
+                Assert.That(File.ReadAllBytes(expectedPath), Is.EqualTo(File.ReadAllBytes(file)));
+            }
+            finally
+            {
+                File.Delete(file);
+            }
         }
 
         static IPullRequestModel CreatePullRequest()

--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModelTests.cs
@@ -257,17 +257,15 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
         [Test]
         public async Task Comment_Is_Enabled_When_Has_File_Comments()
         {
-            var comment = CreateReviewComment(12);
             var review = CreateReview(12, "grokys", body: "", state: PullRequestReviewState.Pending);
-            var model = CreatePullRequest(
-                authorLogin: "shana",
-                reviews: new[] { review },
-                reviewComments: new[] { comment });
-            var session = CreateSession();
+            var model = CreatePullRequest("shana", review);
+            var session = CreateSession(
+                "grokys",
+                CreateSessionFile(
+                    CreateInlineCommentThread(CreateReviewComment(12))));
 
             var target = CreateTarget(model, session);
             await Initialize(target);
-            target.Body = "Review body";
 
             Assert.IsTrue(target.Comment.CanExecute(null));
         }
@@ -292,19 +290,14 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
         }
 
         [Test]
-        public async Task RequestChanges_Is_Disabled_When_Has_Empty_Body()
+        public async Task RequestChanges_Is_Disabled_When_Has_Empty_Body_And_No_File_RequestChangess()
         {
-            var comment = CreateReviewComment(12);
             var review = CreateReview(12, "grokys", body: "", state: PullRequestReviewState.Pending);
-            var model = CreatePullRequest(
-                authorLogin: "shana",
-                reviews: new[] { review },
-                reviewComments: new[] { comment });
+            var model = CreatePullRequest("shana", review);
             var session = CreateSession();
 
             var target = CreateTarget(model, session);
             await Initialize(target);
-            target.Body = "";
 
             Assert.IsFalse(target.RequestChanges.CanExecute(null));
         }
@@ -318,7 +311,23 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
 
             var target = CreateTarget(model, session);
             await Initialize(target);
-            target.Body = "Request Changes";
+            target.Body = "Review body";
+
+            Assert.IsTrue(target.RequestChanges.CanExecute(null));
+        }
+
+        [Test]
+        public async Task RequestChanges_Is_Enabled_When_Has_File_Comments()
+        {
+            var review = CreateReview(12, "grokys", body: "", state: PullRequestReviewState.Pending);
+            var model = CreatePullRequest("shana", review);
+            var session = CreateSession(
+                "grokys",
+                CreateSessionFile(
+                    CreateInlineCommentThread(CreateReviewComment(12))));
+
+            var target = CreateTarget(model, session);
+            await Initialize(target);
 
             Assert.IsTrue(target.RequestChanges.CanExecute(null));
         }


### PR DESCRIPTION
This fixes the following issue in #1570:

> Each time I click a comment the entire diff view reloads https://github.com/github/VisualStudio/pull/1549#pullrequestreview-107912375

## To test

- Open a PR or PR review in the GitHub pane
- Open a file by double clicking or using the context menu
- Optionally make the tab non-temporary (i.e. move it from the right to the left)
- Open the same document
- The same tab should be used rather than a new tab being opened

## Implementation

This requires that when we extract a file to a temp file, that the same file at the same commit is always extracted to the same location. To do this, we use a hash of the file's relative path in the repository and the encoding as the temp directory name, and place the commit sha in the temp file's filename.

Depends on #1582
Part of #1491