### PR TITLE
 Make avatar in PR review summary clickable.

### DIFF
--- a/src/GitHub.VisualStudio.UI/UI/Controls/AccountAvatar.xaml
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/AccountAvatar.xaml
@@ -2,18 +2,28 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:GitHub.VisualStudio.UI.Controls"
+             Name="root"
              MinWidth="16" MinHeight="16">
-    <Grid>
-        <Grid.OpacityMask>
-            <VisualBrush Visual="{Binding ElementName=avatarMask}"/>
-        </Grid.OpacityMask>
-        <Border Name="avatarMask" Background="White" CornerRadius="3"
+    <Button Name="btn" Command="{Binding Command, ElementName=root}"
+            CommandParameter="{Binding CommandParameter, ElementName=root}"
+            CommandTarget="{Binding CommandTarget, ElementName=root}">
+        <Button.Template>
+            <ControlTemplate TargetType="Button">
+                <ContentPresenter/>
+            </ControlTemplate>
+        </Button.Template>
+        <Grid>
+            <Grid.OpacityMask>
+                <VisualBrush Visual="{Binding ElementName=avatarMask}"/>
+            </Grid.OpacityMask>
+            <Border Name="avatarMask" Background="White" CornerRadius="3"
                 Width="{Binding ActualWidth, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:AccountAvatar}}}"
                 Height="{Binding ActualHeight, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:AccountAvatar}}}"/>
-        <Image x:Name="avatar"
+            <Image x:Name="avatar"
                Width="{Binding Width, ElementName=avatarMask}"
                Height="{Binding Height, ElementName=avatarMask}"
                RenderOptions.BitmapScalingMode="HighQuality"
                Source="{Binding Account.Avatar, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:AccountAvatar}}}" />
-    </Grid>
+        </Grid>
+    </Button>
 </UserControl>

--- a/src/GitHub.VisualStudio.UI/UI/Controls/AccountAvatar.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/AccountAvatar.xaml.cs
@@ -1,16 +1,24 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
 using GitHub.Models;
 
 namespace GitHub.VisualStudio.UI.Controls
 {
-    public partial class AccountAvatar : UserControl
+    public partial class AccountAvatar : UserControl, ICommandSource
     {
         public static readonly DependencyProperty AccountProperty =
             DependencyProperty.Register(
                 nameof(Account),
                 typeof(IAccount),
                 typeof(AccountAvatar));
+        public static readonly DependencyProperty CommandProperty =
+            ButtonBase.CommandProperty.AddOwner(typeof(AccountAvatar));
+        public static readonly DependencyProperty CommandParameterProperty =
+            ButtonBase.CommandParameterProperty.AddOwner(typeof(AccountAvatar));
+        public static readonly DependencyProperty CommandTargetProperty =
+            ButtonBase.CommandTargetProperty.AddOwner(typeof(AccountAvatar));
 
         public AccountAvatar()
         {
@@ -21,6 +29,24 @@ namespace GitHub.VisualStudio.UI.Controls
         {
             get { return (IAccount)GetValue(AccountProperty); }
             set { SetValue(AccountProperty, value); }
+        }
+
+        public ICommand Command
+        {
+            get { return (ICommand)GetValue(CommandProperty); }
+            set { SetValue(CommandProperty, value); }
+        }
+
+        public object CommandParameter
+        {
+            get { return GetValue(CommandParameterProperty); }
+            set { SetValue(CommandParameterProperty, value); }
+        }
+
+        public IInputElement CommandTarget
+        {
+            get { return (IInputElement)GetValue(CommandTargetProperty); }
+            set { SetValue(CommandTargetProperty, value); }
         }
     }
 }

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestReviewSummaryView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestReviewSummaryView.xaml
@@ -57,7 +57,13 @@
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <c:AccountAvatar Grid.Column="0" VerticalAlignment="Top" Margin="2" Account="{Binding User}"/>
+                <c:AccountAvatar Grid.Column="0"
+                                 VerticalAlignment="Top"
+                                 Margin="2"
+                                 Account="{Binding User}"
+                                 Command="{Binding Path=DataContext.ShowReview, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type local:PullRequestDetailView}}}"
+                                 CommandParameter="{Binding}"
+                                 Cursor="Hand"/>
                 <ui:GitHubActionLink Grid.Column="1" FontWeight="SemiBold" Margin="2 1 2 0"
                                      Command="{Binding Path=DataContext.ShowReview, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type local:PullRequestDetailView}}}"
                                      CommandParameter="{Binding}"


### PR DESCRIPTION
Addresses this request in #1570:

> Could we make it so you can click on either the avatar or the ✔️ / 💬? https://github.com/github/VisualStudio/pull/1523#issuecomment-377020594

This makes the avatar in the "Reviewers" section clickable; when clicked it navigates to the user's reviews:

![image](https://user-images.githubusercontent.com/1775141/38365499-e4296cb8-38dc-11e8-86df-a5a3880096d0.png)

Depends on #1585
Part of #1491