### PR TITLE
Fix empty PR display when repository origin has differing capitalization.

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
@@ -326,15 +326,15 @@ namespace GitHub.ViewModels.GitHubPane
             string repo,
             int number)
         {
-            if (repo != localRepository.Name)
-            {
-                throw new NotSupportedException();
-            }
-
             IsLoading = true;
 
             try
             {
+                if (!string.Equals(repo, localRepository.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new NotSupportedException("Showing pull requests from other repositories not yet supported.");
+                }
+
                 LocalRepository = localRepository;
                 RemoteRepositoryOwner = owner;
                 Number = number;
@@ -343,6 +343,10 @@ namespace GitHub.ViewModels.GitHubPane
 
                 await Refresh();
                 teamExplorerContext.StatusChanged += RefreshIfActive;
+            }
+            catch (Exception ex)
+            {
+                Error = ex;
             }
             finally
             {


### PR DESCRIPTION
Previously, if a repository was cloned with non-canonical capitalization then a invalid pane wwould be shown when clicking on a PR. This:

- Catches errors thrown in `PullRequestDetailModel.InitializeAsync` and displays an error message
- Does a case-insensitive compare of the repository name in `PullRequestDetailModel.InitializeAsync`
- Adds a descriptive message to the exception thrown

# Testing:

- Update a repository `origin` URL to have a different capitalization to the repository on GitHub, e.g. use `https://github.com/github/visualstudio` instead of `https://github.com/github/VisualStudio` for this repository
- Open a PR from the GitHub pane
- Previously would show an empty PR details as in #1590. With this PR, should show the correct details

Fixes #1590