### PR TITLE
Try really hard to avoid deadlocking GetService calls

### DIFF
--- a/src/GitHub.App/SampleData/SampleViewModels.cs
+++ b/src/GitHub.App/SampleData/SampleViewModels.cs
@@ -383,9 +383,9 @@ namespace GitHub.SampleData
             set;
         }
 
-        public void Login()
+        public Task Login()
         {
-
+            return null;
         }
 
         public ICommand OpenOnGitHub { get; }

--- a/src/GitHub.App/Services/GlobalConnection.cs
+++ b/src/GitHub.App/Services/GlobalConnection.cs
@@ -17,6 +17,6 @@ namespace GitHub.App.Services
             this.serviceProvider = serviceProvider;
         }
 
-        public IConnection Get() => serviceProvider.TryGetService<IConnection>();
+        public IConnection Get() => serviceProvider.TryGetMEFComponent<IConnection>();
     }
 }

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 using GitHub.Models;
+using System.Threading.Tasks;
 
 namespace GitHub.Services
 {
@@ -48,9 +49,9 @@ namespace GitHub.Services
             return view;
         }
 
-        public IVsTextView FindActiveView()
+        public async Task<IVsTextView> FindActiveView()
         {
-            var textManager = serviceProvider.GetService<SVsTextManager, IVsTextManager2>();
+            var textManager = await serviceProvider.TryGetServiceAsync<SVsTextManager, IVsTextManager2>();
             IVsTextView view;
             var hresult = textManager.GetActiveView2(1, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out view);
             return hresult == VSConstants.S_OK ? view : null;

--- a/src/GitHub.App/Services/TeamExplorerContext.cs
+++ b/src/GitHub.App/Services/TeamExplorerContext.cs
@@ -2,10 +2,12 @@
 using System.Linq;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
+using System.Threading.Tasks;
 using GitHub.Models;
 using GitHub.Logging;
 using Serilog;
 using EnvDTE;
+using Microsoft.VisualStudio.Threading;
 
 namespace GitHub.Services
 {
@@ -26,8 +28,10 @@ namespace GitHub.Services
     {
         static ILogger log = LogManager.ForContext<TeamExplorerContext>();
 
+        //readonly AsyncLazy<DTE> dte;
         readonly DTE dte;
         readonly IVSGitExt gitExt;
+        //readonly IGitHubServiceProvider serviceProvider;
 
         string solutionPath;
         string repositoryPath;
@@ -38,18 +42,10 @@ namespace GitHub.Services
         ILocalRepositoryModel repositoryModel;
 
         [ImportingConstructor]
-        public TeamExplorerContext(IGitHubServiceProvider serviceProvider, IVSGitExt gitExt)
-            : this(gitExt, serviceProvider)
-        {
-        }
-
-        public TeamExplorerContext(IVSGitExt gitExt, IGitHubServiceProvider serviceProvider)
+        public TeamExplorerContext(IVSGitExt gitExt, DTE dte)
         {
             this.gitExt = gitExt;
-
-            // This is a standard service which should always be available.
-            dte = serviceProvider.GetService<DTE>();
-
+            this.dte = dte;
             Refresh();
             gitExt.ActiveRepositoriesChanged += Refresh;
         }

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
@@ -26,10 +26,11 @@ namespace GitHub.ViewModels.GitHubPane
     {
         static readonly ILogger log = LogManager.ForContext<PullRequestListViewModel>();
 
+        readonly IGitHubServiceProvider serviceProvider;
         readonly IModelServiceFactory modelServiceFactory;
         readonly TrackingCollection<IAccount> trackingAuthors;
         readonly TrackingCollection<IAccount> trackingAssignees;
-        readonly IPackageSettings settings;
+        IPackageSettings settings;
         readonly IVisualStudioBrowser visualStudioBrowser;
         readonly bool constructing;
         PullRequestListUIState listSettings;
@@ -39,19 +40,19 @@ namespace GitHub.ViewModels.GitHubPane
 
         [ImportingConstructor]
         public PullRequestListViewModel(
+            IGitHubServiceProvider serviceProvider,
             IModelServiceFactory modelServiceFactory,
-            IPackageSettings settings,
             IPullRequestSessionManager sessionManager,
             IVisualStudioBrowser visualStudioBrowser)
         {
+            Guard.ArgumentNotNull(serviceProvider, nameof(serviceProvider));
             Guard.ArgumentNotNull(modelServiceFactory, nameof(modelServiceFactory));
-            Guard.ArgumentNotNull(settings, nameof(settings));
             Guard.ArgumentNotNull(sessionManager, nameof(sessionManager));
             Guard.ArgumentNotNull(visualStudioBrowser, nameof(visualStudioBrowser));
 
             constructing = true;
+            this.serviceProvider = serviceProvider;
             this.modelServiceFactory = modelServiceFactory;
-            this.settings = settings;
             this.visualStudioBrowser = visualStudioBrowser;
 
             Title = Resources.PullRequestsNavigationItemText;
@@ -121,6 +122,7 @@ namespace GitHub.ViewModels.GitHubPane
         public async Task InitializeAsync(ILocalRepositoryModel repository, IConnection connection)
         {
             IsLoading = true;
+            settings = await serviceProvider.TryGetServiceAsync<IPackageSettings>();
 
             try
             {

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestEditorService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestEditorService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TextManager.Interop;
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace GitHub.Services
 {
@@ -8,7 +9,7 @@ namespace GitHub.Services
         /// Find the active text view.
         /// </summary>
         /// <returns>The active view or null if view can't be found.</returns>
-        IVsTextView FindActiveView();
+        Task<IVsTextView> FindActiveView();
 
         /// <summary>
         /// Navigate to and place the caret at the best guess equivalent position in <see cref="targetFile"/>.

--- a/src/GitHub.Exports/Extensions/ServiceProviderExtensions.cs
+++ b/src/GitHub.Exports/Extensions/ServiceProviderExtensions.cs
@@ -43,7 +43,7 @@ namespace GitHub.Extensions
                 Debug.Print(ex.ToString());
                 log.Error(ex, "GetServiceSafe: Could not obtain instance of '{Type}'", type);
             }
-            return ui?.TryGetService(type);
+            return ui?.TryGetMEFComponent(type);
         }
 
         /// <summary>

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -239,7 +239,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Extensions\ServiceProviderExtensions.cs" />
+    <None Include="Extensions\ServiceProviderExtensions.cs" />
     <Compile Include="Services\VSServices.cs" />
     <Compile Include="Settings\generated\IPackageSettings.cs">
       <AutoGen>True</AutoGen>

--- a/src/GitHub.Exports/Services/IGitHubServiceProvider.cs
+++ b/src/GitHub.Exports/Services/IGitHubServiceProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.Composition.Hosting;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using GitHub.VisualStudio;
 
 namespace GitHub.Services
@@ -11,14 +12,6 @@ namespace GitHub.Services
         ExportProvider ExportProvider { get; }
         IServiceProvider GitServiceProvider { get; set; }
 
-        T GetService<T>() where T : class;
-        Ret GetService<T, Ret>() where T : class
-                                 where Ret : class;
-
-        object TryGetService(Type t);
-        object TryGetService(string typename);
-        T TryGetService<T>() where T : class;
-
         void AddService(Type t, object owner, object instance);
         void AddService<T>(object owner, T instance) where T : class;
         /// <summary>
@@ -28,5 +21,20 @@ namespace GitHub.Services
         /// <param name="owner">The owner, which either has to match what was passed to AddService,
         /// or if it's null, the service will be removed without checking for ownership</param>
         void RemoveService(Type t, object owner);
+
+        T TryGetServiceSync<T>() where T : class;
+
+        Task<T> TryGetServiceAsync<T>() where T : class;
+        Task<T1> TryGetServiceAsync<T, T1>() where T : class where T1 : class;
+
+        Task<T> TryGetServiceMainThread<T>() where T : class;
+
+        T TryGetMEFComponent<T>() where T : class;
+        object TryGetMEFComponent(Type serviceType);
+
+        T1 TryGetMEFComponent<T, T1>() where T : class where T1 : class;
+
+        T GetMEFComponent<T>() where T : class;
+        T1 GetMEFComponent<T, T1>() where T : class where T1 : class;
     }
 }

--- a/src/GitHub.Exports/Services/ISelectedTextProvider.cs
+++ b/src/GitHub.Exports/Services/ISelectedTextProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace GitHub.Services
 {

--- a/src/GitHub.Exports/Services/ITeamExplorerServiceHolder.cs
+++ b/src/GitHub.Exports/Services/ITeamExplorerServiceHolder.cs
@@ -40,8 +40,6 @@ namespace GitHub.Services
         /// </summary>
         /// <param name="who">The instance/key that previously subscribed to notifications</param>
         void Unsubscribe(object who);
-
-        IGitAwareItem HomeSection { get; }
     }
 
     public interface IGitAwareItem

--- a/src/GitHub.Exports/Services/StatusBarNotificationService.cs
+++ b/src/GitHub.Exports/Services/StatusBarNotificationService.cs
@@ -12,10 +12,10 @@ namespace GitHub.Services
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class StatusBarNotificationService : IStatusBarNotificationService
     {
-        readonly IServiceProvider serviceProvider;
+        readonly IGitHubServiceProvider serviceProvider;
 
         [ImportingConstructor]
-        public StatusBarNotificationService([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
+        public StatusBarNotificationService(IGitHubServiceProvider serviceProvider)
         {
             this.serviceProvider = serviceProvider;
         }
@@ -31,29 +31,29 @@ namespace GitHub.Services
             return false;
         }
 
-        public void ShowError(string message)
+        public async void ShowError(string message)
         {
-            ShowText(message);
+            await ShowText(message);
         }
 
-        public void ShowMessage(string message)
+        public async void ShowMessage(string message)
         {
-            ShowText(message);
+            await ShowText(message);
         }
 
-        public void ShowMessage(string message, ICommand command, bool showToolTips = true, Guid guid = default(Guid))
+        public async void ShowMessage(string message, ICommand command, bool showToolTips = true, Guid guid = default(Guid))
         {
-            ShowText(message);
+            await ShowText(message);
         }
 
-        public void ShowWarning(string message)
+        public async void ShowWarning(string message)
         {
-            ShowText(message);
+            await ShowText(message);
         }
 
-        void ShowText(string text)
+        async System.Threading.Tasks.Task ShowText(string text)
         {
-            var statusBar = serviceProvider.GetServiceSafe<IVsStatusbar>();
+            var statusBar = await serviceProvider.TryGetServiceMainThread<IVsStatusbar>();
             int frozen;
             if (!ErrorHandler.Succeeded(statusBar.IsFrozen(out frozen)))
                 return;

--- a/src/GitHub.Exports/Services/VSServices.cs
+++ b/src/GitHub.Exports/Services/VSServices.cs
@@ -60,14 +60,14 @@ namespace GitHub.Services
         /// <returns>True if a transient solution was successfully created in target directory (which should trigger opening of repository).</returns>
         public bool TryOpenRepository(string repoPath)
         {
-            var os = serviceProvider.TryGetService<IOperatingSystem>();
+            var os = serviceProvider.TryGetMEFComponent<IOperatingSystem>();
             if (os == null)
             {
                 log.Error("TryOpenRepository couldn't find IOperatingSystem service");
                 return false;
             }
 
-            var dte = serviceProvider.TryGetService<DTE>();
+            var dte = serviceProvider.TryGetMEFComponent<DTE>();
             if (dte == null)
             {
                 log.Error("TryOpenRepository couldn't find DTE service");

--- a/src/GitHub.Exports/ViewModels/IGitHubHomeSection.cs
+++ b/src/GitHub.Exports/ViewModels/IGitHubHomeSection.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿using System.Threading.Tasks;
+using System.Windows.Input;
 using GitHub.UI;
 
 namespace GitHub.VisualStudio.TeamExplorer.Home
@@ -33,6 +34,6 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
         /// <summary>
         /// Start the login flow.
         /// </summary>
-        void Login();
+        Task Login();
     }
 }

--- a/src/GitHub.Services.Vssdk/GitHub.Services.Vssdk.csproj
+++ b/src/GitHub.Services.Vssdk/GitHub.Services.Vssdk.csproj
@@ -44,6 +44,7 @@
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
+  <Import Project="$(SolutionDir)\src\common\signing.props" />
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.Imaging, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Imaging.14.3.25407\lib\net45\Microsoft.VisualStudio.Imaging.dll</HintPath>
@@ -155,6 +156,5 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />
-  <Import Project="$(SolutionDir)\src\common\signing.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/GitHub.StartPage/StartPagePackage.cs
+++ b/src/GitHub.StartPage/StartPagePackage.cs
@@ -117,8 +117,8 @@ namespace GitHub.StartPage
             IProgress<ServiceProgressData> progress,
             IRepositoryModel repository = null)
         {
-            var dialogService = gitHubServiceProvider.GetService<IDialogService>();
-            var cloneService = gitHubServiceProvider.GetService<IRepositoryCloneService>();
+            var dialogService = gitHubServiceProvider.TryGetMEFComponent<IDialogService>();
+            var cloneService = gitHubServiceProvider.TryGetMEFComponent<IRepositoryCloneService>();
             CloneDialogResult result = null;
             
             if (repository == null)
@@ -147,7 +147,7 @@ namespace GitHub.StartPage
                 }
                 catch
                 {
-                    var teServices = gitHubServiceProvider.TryGetService<ITeamExplorerServices>();
+                    var teServices = gitHubServiceProvider.TryGetMEFComponent<ITeamExplorerServices>();
                     teServices.ShowError($"Failed to clone the repository '{result.Repository.Name}'");
                     result = null;
                 }

--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerSectionBase.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerSectionBase.cs
@@ -118,7 +118,7 @@ namespace GitHub.VisualStudio.Base
 
         protected ITeamExplorerSection GetSection(Guid section)
         {
-            var tep = (ITeamExplorerPage)TEServiceProvider.GetServiceSafe(typeof(ITeamExplorerPage));
+            var tep = (ITeamExplorerPage)TEServiceProvider.GetService(typeof(ITeamExplorerPage));
             return tep?.GetSection(section);
         }
     }

--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerServiceHolder.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerServiceHolder.cs
@@ -148,23 +148,5 @@ namespace GitHub.VisualStudio.Base
             if (e.PropertyName == "CloneUrl")
                 ActiveRepo = sender as ILocalRepositoryModel;
         }
-
-        public IGitAwareItem HomeSection
-        {
-            get
-            {
-                if (ServiceProvider == null)
-                    return null;
-                var page = PageService;
-                if (page == null)
-                    return null;
-                return page.GetSection(new Guid(TeamExplorer.Home.GitHubHomeSection.GitHubHomeSectionId)) as IGitAwareItem;
-            }
-        }
-
-        ITeamExplorerPage PageService
-        {
-            get { return ServiceProvider.GetServiceSafe<ITeamExplorerPage>(); }
-        }
     }
 }

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection0.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection0.cs
@@ -18,10 +18,9 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             ISimpleApiClientFactory apiFactory,
             ITeamExplorerServiceHolder holder,
             IConnectionManager manager,
-            IPackageSettings settings,
             IVSServices vsServices,
             ILocalRepositories localRepositories)
-            : base(serviceProvider, apiFactory, holder, manager, settings, vsServices, localRepositories, 0)
+            : base(serviceProvider, apiFactory, holder, manager, vsServices, localRepositories, 0)
         {
         }
     }

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection1.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection1.cs
@@ -18,10 +18,9 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
             ISimpleApiClientFactory apiFactory,
             ITeamExplorerServiceHolder holder,
             IConnectionManager manager,
-            IPackageSettings settings,
             IVSServices vsServices,
             ILocalRepositories localRepositories)
-            : base(serviceProvider, apiFactory, holder, manager, settings, vsServices, localRepositories, 1)
+            : base(serviceProvider, apiFactory, holder, manager, vsServices, localRepositories, 1)
         {
         }
     }

--- a/src/GitHub.TeamFoundation.14/GitHub.TeamFoundation.14.csproj
+++ b/src/GitHub.TeamFoundation.14/GitHub.TeamFoundation.14.csproj
@@ -112,6 +112,7 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">

--- a/src/GitHub.TeamFoundation.14/Services/TeamExplorerServices.cs
+++ b/src/GitHub.TeamFoundation.14/Services/TeamExplorerServices.cs
@@ -30,7 +30,7 @@ namespace GitHub.Services
 
         public void ShowPublishSection()
         {
-            var te = serviceProvider.TryGetService<ITeamExplorer>();
+            var te = serviceProvider.GetMEFComponent<ITeamExplorer>();
             var foo = te.NavigateToPage(new Guid(TeamExplorerPageIds.GitCommits), null);
             var publish = foo?.GetSection(new Guid(GitHubPublishSection.GitHubPublishSectionId)) as GitHubPublishSection;
             publish?.Connect();
@@ -38,13 +38,13 @@ namespace GitHub.Services
 
         public void ShowMessage(string message)
         {
-            manager = serviceProvider.GetService<ITeamExplorer, ITeamExplorerNotificationManager>();
+            manager = serviceProvider.GetMEFComponent<ITeamExplorer, ITeamExplorerNotificationManager>();
             manager?.ShowNotification(message, NotificationType.Information, NotificationFlags.None, null, default(Guid));
         }
 
         public void ShowMessage(string message, ICommand command, bool showToolTips = true, Guid guid = default(Guid))
         {
-            manager = serviceProvider.GetService<ITeamExplorer, ITeamExplorerNotificationManager>();
+            manager = serviceProvider.GetMEFComponent<ITeamExplorer, ITeamExplorerNotificationManager>();
             manager?.ShowNotification(
                 message,
                 NotificationType.Information,
@@ -55,31 +55,31 @@ namespace GitHub.Services
 
         public void ShowWarning(string message)
         {
-            manager = serviceProvider.GetService<ITeamExplorer, ITeamExplorerNotificationManager>();
+            manager = serviceProvider.GetMEFComponent<ITeamExplorer, ITeamExplorerNotificationManager>();
             manager?.ShowNotification(message, NotificationType.Warning, NotificationFlags.None, null, default(Guid));
         }
 
         public void ShowError(string message)
         {
-            manager = serviceProvider.GetService<ITeamExplorer, ITeamExplorerNotificationManager>();
+            manager = serviceProvider.GetMEFComponent<ITeamExplorer, ITeamExplorerNotificationManager>();
             manager?.ShowNotification(message, NotificationType.Error, NotificationFlags.None, null, default(Guid));
         }
 
         public void HideNotification(Guid guid)
         {
-            manager = serviceProvider.GetService<ITeamExplorer, ITeamExplorerNotificationManager>();
+            manager = serviceProvider.GetMEFComponent<ITeamExplorer, ITeamExplorerNotificationManager>();
             manager?.HideNotification(guid);
         }
 
         public void ClearNotifications()
         {
-            manager = serviceProvider.GetService<ITeamExplorer, ITeamExplorerNotificationManager>();
+            manager = serviceProvider.GetMEFComponent<ITeamExplorer, ITeamExplorerNotificationManager>();
             manager?.ClearNotifications();
         }
 
         public bool IsNotificationVisible(Guid guid)
         {
-            manager = serviceProvider.GetService<ITeamExplorer, ITeamExplorerNotificationManager>();
+            manager = serviceProvider.GetMEFComponent<ITeamExplorer, ITeamExplorerNotificationManager>();
             return manager?.IsNotificationVisible(guid) ?? false;
         }
     }

--- a/src/GitHub.TeamFoundation.14/Sync/GitHubPublishSection.cs
+++ b/src/GitHub.TeamFoundation.14/Sync/GitHubPublishSection.cs
@@ -106,14 +106,14 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
 
         public void ShowPublish()
         {
-            var factory = ServiceProvider.GetService<IViewViewModelFactory>();
-            var viewModel = ServiceProvider.GetService<IRepositoryPublishViewModel>();
+            var factory = ServiceProvider.GetMEFComponent<IViewViewModelFactory>();
+            var viewModel = ServiceProvider.GetMEFComponent<IRepositoryPublishViewModel>();
             var busy = viewModel.WhenAnyValue(x => x.IsBusy).Subscribe(x => IsBusy = x);
             var completed = viewModel.PublishRepository
                 .Where(x => x == ProgressState.Success)
                 .Subscribe(_ =>
                 {
-                    ServiceProvider.TryGetService<ITeamExplorer>()?.NavigateToPage(new Guid(TeamExplorerPageIds.Home), null);
+                    ServiceProvider.TryGetMEFComponent<ITeamExplorer>()?.NavigateToPage(new Guid(TeamExplorerPageIds.Home), null);
                     HandleCreatedRepo(ActiveRepo);
                 });
 
@@ -141,7 +141,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
 
         private void ShowNotification(ILocalRepositoryModel newrepo, string msg)
         {
-            var teServices = ServiceProvider.TryGetService<ITeamExplorerServices>();
+            var teServices = ServiceProvider.TryGetMEFComponent<ITeamExplorerServices>();
 
             teServices.ClearNotifications();
             teServices.ShowMessage(
@@ -156,18 +156,18 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
                     */
                     var prefix = str.Substring(0, 2);
                     if (prefix == "u:")
-                        OpenInBrowser(ServiceProvider.TryGetService<IVisualStudioBrowser>(), new Uri(str.Substring(2)));
+                        OpenInBrowser(ServiceProvider.TryGetMEFComponent<IVisualStudioBrowser>(), new Uri(str.Substring(2)));
                     else if (prefix == "o:")
                     {
                         if (ErrorHandler.Succeeded(ServiceProvider.GetSolution().OpenSolutionViaDlg(str.Substring(2), 1)))
-                            ServiceProvider.TryGetService<ITeamExplorer>()?.NavigateToPage(new Guid(TeamExplorerPageIds.Home), null);
+                            ServiceProvider.TryGetMEFComponent<ITeamExplorer>()?.NavigateToPage(new Guid(TeamExplorerPageIds.Home), null);
                     }
                     else if (prefix == "c:")
                     {
-                        var vsGitServices = ServiceProvider.TryGetService<IVSGitServices>();
+                        var vsGitServices = ServiceProvider.TryGetMEFComponent<IVSGitServices>();
                         vsGitServices.SetDefaultProjectPath(newrepo.LocalPath);
                         if (ErrorHandler.Succeeded(ServiceProvider.GetSolution().CreateNewProjectViaDlg(null, null, 0)))
-                            ServiceProvider.TryGetService<ITeamExplorer>()?.NavigateToPage(new Guid(TeamExplorerPageIds.Home), null);
+                            ServiceProvider.TryGetMEFComponent<ITeamExplorer>()?.NavigateToPage(new Guid(TeamExplorerPageIds.Home), null);
                     }
                 })
             );

--- a/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/InfoPanel.xaml.cs
@@ -63,7 +63,7 @@ namespace GitHub.VisualStudio.UI.Controls
             get
             {
                 if (browser == null)
-                    browser = Services.GitHubServiceProvider.TryGetService<IVisualStudioBrowser>();
+                    browser = Services.GitHubServiceProvider.TryGetMEFComponent<IVisualStudioBrowser>();
                 return browser;
             }
         }

--- a/src/GitHub.VisualStudio/Commands/AddConnectionCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/AddConnectionCommand.cs
@@ -19,7 +19,7 @@ namespace GitHub.VisualStudio.Commands
         protected AddConnectionCommand(IGitHubServiceProvider serviceProvider)
             : base(CommandSet, CommandId)
         {
-            dialogService = new Lazy<IDialogService>(() => serviceProvider.TryGetService<IDialogService>());
+            dialogService = new Lazy<IDialogService>(() => serviceProvider.TryGetMEFComponent<IDialogService>());
         }
 
         /// <summary>

--- a/src/GitHub.VisualStudio/Commands/BlameLinkCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/BlameLinkCommand.cs
@@ -42,7 +42,7 @@ namespace GitHub.VisualStudio.Commands
             var link = await GenerateLink(LinkType.Blame);
             if (link == null)
                 return;
-            var browser = ServiceProvider.TryGetService<IVisualStudioBrowser>();
+            var browser = ServiceProvider.TryGetMEFComponent<IVisualStudioBrowser>();
             browser?.OpenUrl(link.ToUri());
 
             await UsageTracker.IncrementCounter(x => x.NumberOfOpenInGitHub);

--- a/src/GitHub.VisualStudio/Commands/CopyLinkCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/CopyLinkCommand.cs
@@ -47,13 +47,13 @@ namespace GitHub.VisualStudio.Commands
             try
             {
                 Clipboard.SetText(link);
-                var ns = ServiceProvider.TryGetService<IStatusBarNotificationService>();
+                var ns = ServiceProvider.TryGetMEFComponent<IStatusBarNotificationService>();
                 ns?.ShowMessage(Resources.LinkCopiedToClipboardMessage);
                 await UsageTracker.IncrementCounter(x => x.NumberOfLinkToGitHub);
             }
             catch
             {
-                var ns = ServiceProvider.TryGetService<IStatusBarNotificationService>();
+                var ns = ServiceProvider.TryGetMEFComponent<IStatusBarNotificationService>();
                 ns?.ShowMessage(Resources.Error_FailedToCopyToClipboard);
             }
         }

--- a/src/GitHub.VisualStudio/Commands/CreateGistCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/CreateGistCommand.cs
@@ -5,6 +5,7 @@ using GitHub.Commands;
 using GitHub.Logging;
 using GitHub.Services;
 using GitHub.Services.Vssdk.Commands;
+using Microsoft.VisualStudio.Threading;
 
 namespace GitHub.VisualStudio.Commands
 {
@@ -14,11 +15,11 @@ namespace GitHub.VisualStudio.Commands
     [Export(typeof(ICreateGistCommand))]
     public class CreateGistCommand : VsCommand, ICreateGistCommand
     {
-        readonly Lazy<IDialogService> dialogService;
-        readonly Lazy<ISelectedTextProvider> selectedTextProvider;
+        readonly IDialogService dialogService;
+        readonly ISelectedTextProvider selectedTextProvider;
 
         [ImportingConstructor]
-        protected CreateGistCommand(Lazy<IDialogService> dialogService, Lazy<ISelectedTextProvider> selectedTextProvider)
+        protected CreateGistCommand(IDialogService dialogService, ISelectedTextProvider selectedTextProvider)
             : base(CommandSet, CommandId)
         {
             this.dialogService = dialogService;
@@ -35,20 +36,17 @@ namespace GitHub.VisualStudio.Commands
         /// </summary>
         public const int CommandId = PkgCmdIDList.createGistCommand;
 
-        ISelectedTextProvider SelectedTextProvider => selectedTextProvider.Value;
-
         /// <summary>
         /// Shows the Create Gist dialog.
         /// </summary>
         public override Task Execute()
         {
-            return dialogService.Value.ShowCreateGist();
+            return dialogService.ShowCreateGist();
         }
 
         protected override void QueryStatus()
         {
-            Log.Assert(SelectedTextProvider != null, "Could not get an instance of ISelectedTextProvider");
-            Visible = !string.IsNullOrWhiteSpace(SelectedTextProvider?.GetSelectedText());
+            Visible = !string.IsNullOrWhiteSpace(selectedTextProvider.GetSelectedText());
         }
     }
 }

--- a/src/GitHub.VisualStudio/Commands/LinkCommandBase.cs
+++ b/src/GitHub.VisualStudio/Commands/LinkCommandBase.cs
@@ -28,8 +28,8 @@ namespace GitHub.VisualStudio.Commands
             : base(commandSet, commandId)
         {
             ServiceProvider = serviceProvider;
-            apiFactory = new Lazy<ISimpleApiClientFactory>(() => ServiceProvider.TryGetService<ISimpleApiClientFactory>());
-            usageTracker = new Lazy<IUsageTracker>(() => serviceProvider.TryGetService<IUsageTracker>());
+            apiFactory = new Lazy<ISimpleApiClientFactory>(() => ServiceProvider.TryGetMEFComponent<ISimpleApiClientFactory>());
+            usageTracker = new Lazy<IUsageTracker>(() => serviceProvider.TryGetMEFComponent<IUsageTracker>());
         }
 
         protected ILocalRepositoryModel ActiveRepo { get; private set; }
@@ -45,7 +45,7 @@ namespace GitHub.VisualStudio.Commands
             {
                 if (!string.IsNullOrEmpty(path))
                 {
-                    var repo = ServiceProvider.TryGetService<IGitService>().GetRepository(path);
+                    var repo = ServiceProvider.TryGetMEFComponent<IGitService>().GetRepository(path);
                     return new LocalRepositoryModel(repo.Info.WorkingDirectory.TrimEnd('\\'));
                 }
             }
@@ -59,11 +59,11 @@ namespace GitHub.VisualStudio.Commands
 
         protected ILocalRepositoryModel GetActiveRepo()
         {
-            var activeRepo = ServiceProvider.TryGetService<ITeamExplorerServiceHolder>()?.ActiveRepo;
+            var activeRepo = ServiceProvider.TryGetMEFComponent<ITeamExplorerServiceHolder>()?.ActiveRepo;
             // activeRepo can be null at this point because it is set elsewhere as the result of async operation that may not have completed yet.
             if (activeRepo == null)
             {
-                var path = ServiceProvider.TryGetService<IVSGitServices>()?.GetActiveRepoPath() ?? String.Empty;
+                var path = ServiceProvider.TryGetMEFComponent<IVSGitServices>()?.GetActiveRepoPath() ?? String.Empty;
                 try
                 {
                     activeRepo = !string.IsNullOrEmpty(path) ? new LocalRepositoryModel(path) : null;
@@ -78,11 +78,11 @@ namespace GitHub.VisualStudio.Commands
 
         void RefreshRepo()
         {
-            ActiveRepo = ServiceProvider.TryGetService<ITeamExplorerServiceHolder>().ActiveRepo;
+            ActiveRepo = ServiceProvider.TryGetMEFComponent<ITeamExplorerServiceHolder>().ActiveRepo;
 
             if (ActiveRepo == null)
             {
-                var vsGitServices = ServiceProvider.TryGetService<IVSGitServices>();
+                var vsGitServices = ServiceProvider.TryGetMEFComponent<IVSGitServices>();
                 string path = vsGitServices?.GetActiveRepoPath() ?? String.Empty;
                 try
                 {
@@ -120,7 +120,7 @@ namespace GitHub.VisualStudio.Commands
             if (!await IsGitHubRepo())
                 return false;
 
-            var activeDocument = ServiceProvider.TryGetService<IActiveDocumentSnapshot>();
+            var activeDocument = ServiceProvider.TryGetMEFComponent<IActiveDocumentSnapshot>();
 
             return activeDocument != null &&
                 IsFileDescendantOfDirectory(activeDocument.Name, ActiveRepo.LocalPath);
@@ -128,7 +128,7 @@ namespace GitHub.VisualStudio.Commands
 
         protected Task<UriString> GenerateLink(LinkType linkType)
         {
-            var activeDocument = ServiceProvider.TryGetService<IActiveDocumentSnapshot>();
+            var activeDocument = ServiceProvider.TryGetMEFComponent<IActiveDocumentSnapshot>();
             if (activeDocument == null)
                 return null;
 

--- a/src/GitHub.VisualStudio/Commands/OpenLinkCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/OpenLinkCommand.cs
@@ -41,7 +41,7 @@ namespace GitHub.VisualStudio.Commands
             var link = await GenerateLink(LinkType.Blob);
             if (link == null)
                 return;
-            var browser = ServiceProvider.TryGetService<IVisualStudioBrowser>();
+            var browser = ServiceProvider.TryGetMEFComponent<IVisualStudioBrowser>();
             browser?.OpenUrl(link.ToUri());
 
             await UsageTracker.IncrementCounter(x => x.NumberOfOpenInGitHub);

--- a/src/GitHub.VisualStudio/Commands/OpenPullRequestsCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/OpenPullRequestsCommand.cs
@@ -42,7 +42,7 @@ namespace GitHub.VisualStudio.Commands
         {
             try
             {
-                var host = await serviceProvider.TryGetService<IGitHubToolWindowManager>().ShowGitHubPane();
+                var host = await serviceProvider.TryGetMEFComponent<IGitHubToolWindowManager>().ShowGitHubPane();
                 await host.ShowPullRequests();
             }
             catch (Exception ex)

--- a/src/GitHub.VisualStudio/Commands/ShowCurrentPullRequestCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/ShowCurrentPullRequestCommand.cs
@@ -58,7 +58,7 @@ namespace GitHub.VisualStudio.Commands
                 }
 
                 var pullRequest = session.PullRequest;
-                var manager = serviceProvider.TryGetService<IGitHubToolWindowManager>();
+                var manager = serviceProvider.TryGetMEFComponent<IGitHubToolWindowManager>();
                 var host = await manager.ShowGitHubPane();
                 await host.ShowPullRequest(session.RepositoryOwner, host.LocalRepository.Name, pullRequest.Number);
 

--- a/src/GitHub.VisualStudio/Commands/ShowGitHubPaneCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/ShowGitHubPaneCommand.cs
@@ -42,7 +42,7 @@ namespace GitHub.VisualStudio.Commands
         {
             try
             {
-                var host = await serviceProvider.TryGetService<IGitHubToolWindowManager>().ShowGitHubPane();
+                var host = await serviceProvider.TryGetMEFComponent<IGitHubToolWindowManager>().ShowGitHubPane();
             }
             catch (Exception ex)
             {

--- a/src/GitHub.VisualStudio/Services/SelectedTextProvider.cs
+++ b/src/GitHub.VisualStudio/Services/SelectedTextProvider.cs
@@ -5,6 +5,7 @@ using GitHub.Extensions;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TextManager.Interop;
+using System.Threading.Tasks;
 
 namespace GitHub.VisualStudio
 {
@@ -12,17 +13,16 @@ namespace GitHub.VisualStudio
     [PartCreationPolicy(CreationPolicy.NonShared)]
     public class SelectedTextProvider : ISelectedTextProvider
     {
-        readonly IGitHubServiceProvider serviceProvider;
+        readonly IVsTextManager textManager;
 
         [ImportingConstructor]
-        public SelectedTextProvider(IGitHubServiceProvider serviceProvider)
+        public SelectedTextProvider([Import(typeof(SVsTextManager))] IVsTextManager textManager)
         {
-            this.serviceProvider = serviceProvider;
+            this.textManager = textManager;
         }
 
         public string GetSelectedText()
         {
-            IVsTextManager textManager = serviceProvider.GetService<SVsTextManager, IVsTextManager>();
             string selectedText;
             IVsTextView activeView;
 

--- a/src/GitHub.VisualStudio/Services/ShowDialogService.cs
+++ b/src/GitHub.VisualStudio/Services/ShowDialogService.cs
@@ -56,7 +56,7 @@ namespace GitHub.VisualStudio.UI.Services
 
         IGitHubDialogWindowViewModel CreateViewModel()
         {
-            return serviceProvider.GetService<IGitHubDialogWindowViewModel>();
+            return serviceProvider.TryGetMEFComponent<IGitHubDialogWindowViewModel>();
         }
     }
 }

--- a/src/GitHub.VisualStudio/Services/UsageService.cs
+++ b/src/GitHub.VisualStudio/Services/UsageService.cs
@@ -129,7 +129,7 @@ namespace GitHub.Services
             {
                 await ThreadingHelper.SwitchToMainThreadAsync();
 
-                var program = serviceProvider.GetService<IProgram>();
+                var program = serviceProvider.TryGetMEFComponent<IProgram>();
 
                 var localApplicationDataPath = environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
 

--- a/src/GitHub.VisualStudio/Settings/PackageSettings.cs
+++ b/src/GitHub.VisualStudio/Settings/PackageSettings.cs
@@ -12,13 +12,25 @@ namespace GitHub.VisualStudio.Settings
 {
     public partial class PackageSettings : NotificationAwareObject, IPackageSettings
     {
-        readonly SettingsStore settingsStore;
+        readonly IServiceProvider serviceProvider;
+        SettingsStore settingsStore;
+        public SettingsStore SettingsStore
+        {
+            get
+            {
+                if (settingsStore == null)
+                {
+                    var sm = new ShellSettingsManager(serviceProvider);
+                    settingsStore = new SettingsStore(sm.GetWritableSettingsStore(SettingsScope.UserSettings), Info.ApplicationInfo.ApplicationSafeName);
+                    LoadSettings();
+                }
+                return settingsStore;
+            }
+        }
 
         public PackageSettings(IServiceProvider serviceProvider)
         {
-            var sm = new ShellSettingsManager(serviceProvider);
-            settingsStore = new SettingsStore(sm.GetWritableSettingsStore(SettingsScope.UserSettings), Info.ApplicationInfo.ApplicationSafeName);
-            LoadSettings();
+            this.serviceProvider = serviceProvider;
         }
 
         public void Save()

--- a/src/GitHub.VisualStudio/Settings/generated/PackageSettingsGen.cs
+++ b/src/GitHub.VisualStudio/Settings/generated/PackageSettingsGen.cs
@@ -79,20 +79,20 @@ namespace GitHub.VisualStudio.Settings {
 
         void LoadSettings()
         {
-            CollectMetrics = (bool)settingsStore.Read("CollectMetrics", true);
-            EditorComments = (bool)settingsStore.Read("EditorComments", false);
-            UIState = SimpleJson.DeserializeObject<UIState>((string)settingsStore.Read("UIState", "{}"));
-            HideTeamExplorerWelcomeMessage = (bool)settingsStore.Read("HideTeamExplorerWelcomeMessage", false);
-            EnableTraceLogging = (bool)settingsStore.Read("EnableTraceLogging", false);
+            CollectMetrics = (bool)SettingsStore.Read("CollectMetrics", true);
+            EditorComments = (bool)SettingsStore.Read("EditorComments", false);
+            UIState = SimpleJson.DeserializeObject<UIState>((string)SettingsStore.Read("UIState", "{}"));
+            HideTeamExplorerWelcomeMessage = (bool)SettingsStore.Read("HideTeamExplorerWelcomeMessage", false);
+            EnableTraceLogging = (bool)SettingsStore.Read("EnableTraceLogging", false);
         }
 
         void SaveSettings()
         {
-            settingsStore.Write("CollectMetrics", CollectMetrics);
-            settingsStore.Write("EditorComments", EditorComments);
-            settingsStore.Write("UIState", SimpleJson.SerializeObject(UIState));
-            settingsStore.Write("HideTeamExplorerWelcomeMessage", HideTeamExplorerWelcomeMessage);
-            settingsStore.Write("EnableTraceLogging", EnableTraceLogging);
+            SettingsStore.Write("CollectMetrics", CollectMetrics);
+            SettingsStore.Write("EditorComments", EditorComments);
+            SettingsStore.Write("UIState", SimpleJson.SerializeObject(UIState));
+            SettingsStore.Write("HideTeamExplorerWelcomeMessage", HideTeamExplorerWelcomeMessage);
+            SettingsStore.Write("EnableTraceLogging", EnableTraceLogging);
         }
 
     }

--- a/src/GitHub.VisualStudio/Settings/generated/PackageSettingsGen.tt
+++ b/src/GitHub.VisualStudio/Settings/generated/PackageSettingsGen.tt
@@ -49,13 +49,13 @@ foreach (var j in json.Children().Children().Children()) {
     if (j["type"].ToString() == "object")
     {
 #>
-            <#= j["name"] #> = SimpleJson.DeserializeObject<<#= j["typename"] #>>((string)settingsStore.Read("<#= j["name"] #>", "{}"));
+            <#= j["name"] #> = SimpleJson.DeserializeObject<<#= j["typename"] #>>((string)SettingsStore.Read("<#= j["name"] #>", "{}"));
 <#
     }
     else
     {
 #>
-            <#= j["name"] #> = (<#= j["type"] #>)settingsStore.Read("<#= j["name"] #>", <#= j["default"] #>);
+            <#= j["name"] #> = (<#= j["type"] #>)SettingsStore.Read("<#= j["name"] #>", <#= j["default"] #>);
 <#
     }
 }
@@ -69,13 +69,13 @@ foreach (var j in json.Children().Children().Children()) {
     if (j["type"].ToString() == "object")
     {
 #>
-            settingsStore.Write("<#= j["name"] #>", SimpleJson.SerializeObject(<#= j["name"] #>));
+            SettingsStore.Write("<#= j["name"] #>", SimpleJson.SerializeObject(<#= j["name"] #>));
 <#
     }
     else
     {
 #>
-            settingsStore.Write("<#= j["name"] #>", <#= j["name"] #>);
+            SettingsStore.Write("<#= j["name"] #>", <#= j["name"] #>);
 <#
     }
 }

--- a/src/GitHub.VisualStudio/UI/GitHubPane.cs
+++ b/src/GitHub.VisualStudio/UI/GitHubPane.cs
@@ -97,11 +97,11 @@ namespace GitHub.VisualStudio.UI
                 // Allow MEF to initialize its cache asynchronously
                 var provider = (IGitHubServiceProvider)await asyncPackage.GetServiceAsync(typeof(IGitHubServiceProvider));
 
-                var teServiceHolder = provider.GetService<ITeamExplorerServiceHolder>();
+                var teServiceHolder = provider.TryGetService<ITeamExplorerServiceHolder>();
                 teServiceHolder.ServiceProvider = this;
 
-                var factory = provider.GetService<IViewViewModelFactory>();
-                var viewModel = provider.ExportProvider.GetExportedValue<IGitHubPaneViewModel>();
+                var factory = provider.TryGetService<IViewViewModelFactory>();
+                var viewModel = provider.TryGetService<IGitHubPaneViewModel>();
                 await viewModel.InitializeAsync(this);
 
                 View = factory.CreateView<IGitHubPaneViewModel>();

--- a/src/GitHub.VisualStudio/UI/GitHubPane.cs
+++ b/src/GitHub.VisualStudio/UI/GitHubPane.cs
@@ -97,11 +97,11 @@ namespace GitHub.VisualStudio.UI
                 // Allow MEF to initialize its cache asynchronously
                 var provider = (IGitHubServiceProvider)await asyncPackage.GetServiceAsync(typeof(IGitHubServiceProvider));
 
-                var teServiceHolder = provider.TryGetService<ITeamExplorerServiceHolder>();
+                var teServiceHolder = provider.TryGetMEFComponent<ITeamExplorerServiceHolder>();
                 teServiceHolder.ServiceProvider = this;
 
-                var factory = provider.TryGetService<IViewViewModelFactory>();
-                var viewModel = provider.TryGetService<IGitHubPaneViewModel>();
+                var factory = provider.TryGetMEFComponent<IViewViewModelFactory>();
+                var viewModel = provider.TryGetMEFComponent<IGitHubPaneViewModel>();
                 await viewModel.InitializeAsync(this);
 
                 View = factory.CreateView<IGitHubPaneViewModel>();

--- a/src/GitHub.VisualStudio/Views/Dialog/GistCreationView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/Dialog/GistCreationView.xaml.cs
@@ -43,10 +43,10 @@ namespace GitHub.VisualStudio.Views.Dialog
                     .Where(x => x != null)
                     .Subscribe(gist =>
                     {
-                        var browser = serviceProvider.TryGetService<IVisualStudioBrowser>();
+                        var browser = serviceProvider.TryGetMEFComponent<IVisualStudioBrowser>();
                         browser?.OpenUrl(new Uri(gist.HtmlUrl));
 
-                        var ns = serviceProvider.TryGetService<IStatusBarNotificationService>();
+                        var ns = serviceProvider.TryGetMEFComponent<IStatusBarNotificationService>();
                         ns?.ShowMessage(UI.Resources.gistCreatedMessage);
                     });
 

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml.cs
@@ -111,7 +111,7 @@ namespace GitHub.VisualStudio.Views.GitHubPane
                     {
                         AddBufferTag(buffer, ViewModel.Session, fullPath, null);
 
-                        var textView = NavigationService.FindActiveView();
+                        var textView = await NavigationService.FindActiveView();
                         EnableNavigateToEditor(textView, file);
                     }
                 }
@@ -139,7 +139,7 @@ namespace GitHub.VisualStudio.Views.GitHubPane
 
                 var fullPath = ViewModel.GetLocalFilePath(file);
 
-                var activeView = NavigationService.FindActiveView();
+                var activeView = await NavigationService.FindActiveView();
                 if (activeView == null)
                 {
                     ShowErrorInStatusBar("Couldn't find active view");

--- a/src/GitHub.VisualStudio/Views/ViewLocator.cs
+++ b/src/GitHub.VisualStudio/Views/ViewLocator.cs
@@ -77,7 +77,7 @@ namespace GitHub.VisualStudio.Views
             {
                 if (factoryProvider == null)
                 {
-                    factoryProvider = Services.GitHubServiceProvider.TryGetService<IViewViewModelFactory>();
+                    factoryProvider = Services.GitHubServiceProvider.TryGetMEFComponent<IViewViewModelFactory>();
                 }
 
                 return factoryProvider;

--- a/test/UnitTests/GitHub.App/Services/TeamExplorerContextTests.cs
+++ b/test/UnitTests/GitHub.App/Services/TeamExplorerContextTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using NSubstitute;
 using EnvDTE;
 using GitHub.Models;
+using UnitTests;
 
 namespace GitHub.App.UnitTests.Services
 {
@@ -214,9 +215,7 @@ namespace GitHub.App.UnitTests.Services
         static TeamExplorerContext CreateTeamExplorerContext(IVSGitExt gitExt, DTE dte = null)
         {
             dte = dte ?? Substitute.For<DTE>();
-            var sp = Substitute.For<IGitHubServiceProvider>();
-            sp.GetService<DTE>().Returns(dte);
-            return new TeamExplorerContext(gitExt, sp);
+            return new TeamExplorerContext(gitExt, dte);
         }
 
         static ILocalRepositoryModel CreateRepositoryModel(string path, string branchName = null, string headSha = null, string trackedSha = null)

--- a/test/UnitTests/GitHub.App/ViewModels/Dialog/GistCreationViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/Dialog/GistCreationViewModelTests.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 
 public class GistCreationViewModelTests
 {
-    static IGistCreationViewModel CreateViewModel(IServiceProvider provider, string selectedText = "", string fileName = "", bool isPrivate = false)
+    static IGistCreationViewModel CreateViewModel(IGitHubServiceProvider provider, string selectedText = "", string fileName = "", bool isPrivate = false)
     {
         var selectedTextProvider = Substitute.For<ISelectedTextProvider>();
         selectedTextProvider.GetSelectedText().Returns(selectedText);
@@ -31,7 +31,7 @@ public class GistCreationViewModelTests
         var gistPublishService = provider.GetGistPublishService();
         var notificationService = Substitute.For<INotificationService>();
 
-        return new GistCreationViewModel(modelServiceFactory, selectedTextProvider, gistPublishService, notificationService, Substitute.For<IUsageTracker>())
+        return new GistCreationViewModel(provider, modelServiceFactory, selectedTextProvider, gistPublishService, notificationService)
         {
             FileName = fileName,
             IsPrivate = isPrivate

--- a/test/UnitTests/GitHub.App/ViewModels/Dialog/PullRequestCreationViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/Dialog/PullRequestCreationViewModelTests.cs
@@ -41,7 +41,7 @@ public class PullRequestCreationViewModelTests : TestBaseClass
 
     struct TestData
     {
-        public IServiceProvider ServiceProvider;
+        public IGitHubServiceProvider ServiceProvider;
         public ILocalRepositoryModel ActiveRepo;
         public LibGit2Sharp.IRepository L2Repo;
         public IRepositoryModel SourceRepo;

--- a/test/UnitTests/GitHub.App/ViewModels/Dialog/RepositoryCreationViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/Dialog/RepositoryCreationViewModelTests.cs
@@ -23,7 +23,7 @@ public class RepositoryCreationViewModelTests
     static object DefaultInstance = new object();
 
     static IRepositoryCreationViewModel GetMeAViewModel(
-        IServiceProvider provider = null,
+        IGitHubServiceProvider provider = null,
         IRepositoryCreationService creationService = null,
         IModelService modelService = null)
     {

--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModelTests.cs
@@ -19,13 +19,15 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
         [Test]
         public void SelectingAssigneeShouldTriggerFilter()
         {
-            var connection = Substitute.For<IConnection>();
+            var serviceProvider = Substitutes.ServiceProvider;
+            var connection = serviceProvider.GetConnection();
             var factory = CreateModelServiceFactory();
             var repository = Substitute.For<ILocalRepositoryModel>();
-            var settings = CreateSettings();
+            var settings = serviceProvider.TryGetServiceSync<IPackageSettings>();
+            settings.UIState.Returns(new UIState());
             var sessionManager = Substitute.For<IPullRequestSessionManager>();
             var browser = Substitute.For<IVisualStudioBrowser>();
-            var prViewModel = new PullRequestListViewModel(factory, settings, sessionManager, browser);
+            var prViewModel = new PullRequestListViewModel(serviceProvider, factory, sessionManager, browser);
 
             prViewModel.InitializeAsync(repository, connection).Wait();
             prViewModel.PullRequests.Received(1).Filter = AnyFilter;
@@ -37,13 +39,15 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
         [Test]
         public void ResettingAssigneeToNoneShouldNotTriggerFilter()
         {
-            var connection = Substitute.For<IConnection>();
+            var serviceProvider = Substitutes.ServiceProvider;
+            var connection = serviceProvider.GetConnection();
             var factory = CreateModelServiceFactory();
             var repository = Substitute.For<ILocalRepositoryModel>();
-            var settings = CreateSettings();
+            var settings = serviceProvider.TryGetServiceSync<IPackageSettings>();
+            settings.UIState.Returns(new UIState());
             var sessionManager = Substitute.For<IPullRequestSessionManager>();
             var browser = Substitute.For<IVisualStudioBrowser>();
-            var prViewModel = new PullRequestListViewModel(factory, settings, sessionManager, browser);
+            var prViewModel = new PullRequestListViewModel(serviceProvider, factory, sessionManager, browser);
 
             prViewModel.InitializeAsync(repository, connection).Wait();
             prViewModel.PullRequests.Received(1).Filter = AnyFilter;
@@ -61,13 +65,15 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
         [Test]
         public void SelectingAuthorShouldTriggerFilter()
         {
-            var connection = Substitute.For<IConnection>();
+            var serviceProvider = Substitutes.ServiceProvider;
+            var connection = serviceProvider.GetConnection();
             var factory = CreateModelServiceFactory();
             var repository = Substitute.For<ILocalRepositoryModel>();
-            var settings = CreateSettings();
+            var settings = serviceProvider.TryGetServiceSync<IPackageSettings>();
+            settings.UIState.Returns(new UIState());
             var sessionManager = Substitute.For<IPullRequestSessionManager>();
             var browser = Substitute.For<IVisualStudioBrowser>();
-            var prViewModel = new PullRequestListViewModel(factory, settings, sessionManager, browser);
+            var prViewModel = new PullRequestListViewModel(serviceProvider, factory, sessionManager, browser);
 
             prViewModel.InitializeAsync(repository, connection).Wait();
             prViewModel.PullRequests.Received(1).Filter = AnyFilter;
@@ -79,13 +85,15 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
         [Test]
         public void ResettingAuthorToNoneShouldNotTriggerFilter()
         {
-            var connection = Substitute.For<IConnection>();
+            var serviceProvider = Substitutes.ServiceProvider;
+            var connection = serviceProvider.GetConnection();
             var factory = CreateModelServiceFactory();
             var repository = Substitute.For<ILocalRepositoryModel>();
-            var settings = CreateSettings();
+            var settings = serviceProvider.TryGetServiceSync<IPackageSettings>();
+            settings.UIState.Returns(new UIState());
             var sessionManager = Substitute.For<IPullRequestSessionManager>();
             var browser = Substitute.For<IVisualStudioBrowser>();
-            var prViewModel = new PullRequestListViewModel(factory, settings, sessionManager, browser);
+            var prViewModel = new PullRequestListViewModel(serviceProvider, factory, sessionManager, browser);
 
             prViewModel.InitializeAsync(repository, connection).Wait();
             prViewModel.PullRequests.Received(1).Filter = AnyFilter;
@@ -103,13 +111,15 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
         [TestCase("https://github.com/owner/repo", 666, "https://github.com/owner/repo/pull/666")]
         public void OpenPullRequestOnGitHubShouldOpenBrowser(string cloneUrl, int pullNumber, string expectUrl)
         {
-            var connection = Substitute.For<IConnection>();
+            var serviceProvider = Substitutes.ServiceProvider;
+            var connection = serviceProvider.GetConnection();
             var factory = CreateModelServiceFactory();
             var repository = Substitute.For<ILocalRepositoryModel>();
-            var settings = CreateSettings();
+            var settings = serviceProvider.TryGetServiceSync<IPackageSettings>();
+            settings.UIState.Returns(new UIState());
             var sessionManager = Substitute.For<IPullRequestSessionManager>();
             var browser = Substitute.For<IVisualStudioBrowser>();
-            var prViewModel = new PullRequestListViewModel(factory, settings, sessionManager, browser);
+            var prViewModel = new PullRequestListViewModel(serviceProvider, factory, sessionManager, browser);
 
             prViewModel.InitializeAsync(repository, connection).Wait();
             prViewModel.SelectedRepository = Substitute.For<IRemoteRepositoryModel>();
@@ -147,13 +157,6 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
             result.CreateAsync(null).ReturnsForAnyArgs(modelService);
             result.CreateBlocking(null).ReturnsForAnyArgs(modelService);
             return result;
-        }
-
-        IPackageSettings CreateSettings()
-        {
-            var settings = Substitute.For<IPackageSettings>();
-            settings.UIState.Returns(new UIState());
-            return settings;
         }
     }
 }

--- a/test/UnitTests/GitHub.Exports/VSServicesTests.cs
+++ b/test/UnitTests/GitHub.Exports/VSServicesTests.cs
@@ -98,8 +98,8 @@ public class VSServicesTests
             }
 
             var provider = Substitute.For<IGitHubServiceProvider>();
-            provider.TryGetService<DTE>().Returns(dte);
-            provider.TryGetService<IOperatingSystem>().Returns(os);
+            provider.TryGetMEFComponent<DTE>().Returns(dte);
+            provider.TryGetMEFComponent<IOperatingSystem>().Returns(os);
             return new VSServices(provider, log);
         }
     }


### PR DESCRIPTION
`new ShellSettingsManager` in the PackageSettings constructor calls GetService, which might be a potential deadlock situation. Also, to avoid calls to GetService that might deadlock, cache the services we create in GitHubServiceProvider so that it returns cached instances immediately and bypasses GetService.

I also fixed some other calls around the code, particularly direct calls to `ExportProvider` (`GitHubServiceProvider.TryGetService` does that for us)