### PR TITLE
Pass IPackageSettings to UsageTracker ctor.

### DIFF
--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -254,7 +254,8 @@ namespace GitHub.VisualStudio
             {
                 var usageService = await GetServiceAsync(typeof(IUsageService)) as IUsageService;
                 var serviceProvider = await GetServiceAsync(typeof(IGitHubServiceProvider)) as IGitHubServiceProvider;
-                return new UsageTracker(serviceProvider, usageService);
+                var settings = await GetServiceAsync(typeof(IPackageSettings)) as IPackageSettings;
+                return new UsageTracker(serviceProvider, usageService, settings);
             }
             else if (serviceType == typeof(IVSGitExt))
             {

--- a/src/GitHub.VisualStudio/Services/UsageTracker.cs
+++ b/src/GitHub.VisualStudio/Services/UsageTracker.cs
@@ -28,14 +28,15 @@ namespace GitHub.Services
         IDisposable timer;
         bool firstTick = true;
 
-        [ImportingConstructor]
         public UsageTracker(
             IGitHubServiceProvider gitHubServiceProvider,
-            IUsageService service)
+            IUsageService service,
+            IPackageSettings settings)
         {
             this.gitHubServiceProvider = gitHubServiceProvider;
             this.service = service;
-            timer = StartTimer();            
+            this.userSettings = settings;
+            timer = StartTimer();
         }
 
         public void Dispose()
@@ -71,7 +72,6 @@ namespace GitHub.Services
 
                 client = gitHubServiceProvider.TryGetService<IMetricsService>();
                 connectionManager = gitHubServiceProvider.GetService<IConnectionManager>();
-                userSettings = gitHubServiceProvider.GetService<IPackageSettings>();
                 vsservices = gitHubServiceProvider.GetService<IVSServices>();
                 initialized = true;
             }

--- a/test/UnitTests/GitHub.VisualStudio/Services/MetricsTests.cs
+++ b/test/UnitTests/GitHub.VisualStudio/Services/MetricsTests.cs
@@ -23,7 +23,7 @@ namespace MetricsTests
         public void ShouldStartTimer()
         {
             var service = Substitute.For<IUsageService>();
-            var target = new UsageTracker(CreateServiceProvider(), service);
+            var target = new UsageTracker(CreateServiceProvider(), service, CreatePackageSettings());
 
             service.Received(1).StartTimer(Arg.Any<Func<Task>>(), TimeSpan.FromMinutes(3), TimeSpan.FromHours(8));
         }
@@ -147,7 +147,8 @@ namespace MetricsTests
             var usageService = CreateUsageService(model);
             var target = new UsageTracker(
                 CreateServiceProvider(),
-                usageService);
+                usageService,
+                CreatePackageSettings());
 
             await target.IncrementCounter(x => x.NumberOfClones);
             UsageData result = usageService.ReceivedCalls().First(x => x.GetMethodInfo().Name == "WriteLocalData").GetArguments()[0] as UsageData;
@@ -162,7 +163,8 @@ namespace MetricsTests
 
             var target = new UsageTracker(
                 CreateServiceProvider(),
-                service);
+                service,
+                CreatePackageSettings());
 
             await target.IncrementCounter(x => x.NumberOfClones);
             await service.Received(1).WriteLocalData(Arg.Is<UsageData>(data => 
@@ -196,7 +198,8 @@ namespace MetricsTests
 
             var target = new UsageTracker(
                 CreateServiceProvider(),
-                service);
+                service,
+                CreatePackageSettings());
 
             await target.IncrementCounter(x => x.NumberOfClones);
             await service.Received(1).WriteLocalData(Arg.Is<UsageData>(data =>
@@ -228,17 +231,21 @@ namespace MetricsTests
             var result = Substitute.For<IGitHubServiceProvider>();
             var connectionManager = Substitute.For<IConnectionManager>();
             var metricsService = Substitute.For<IMetricsService>();
-            var packageSettings = Substitute.For<IPackageSettings>();
             var vsservices = Substitute.For<IVSServices>();
 
             connectionManager.Connections.Returns(new ObservableCollectionEx<IConnection>());
-            packageSettings.CollectMetrics.Returns(true);
 
             result.GetService<IConnectionManager>().Returns(connectionManager);
-            result.GetService<IPackageSettings>().Returns(packageSettings);
             result.GetService<IVSServices>().Returns(vsservices);
             result.TryGetService<IMetricsService>().Returns(hasMetricsService ? metricsService : null);
 
+            return result;
+        }
+
+        static IPackageSettings CreatePackageSettings()
+        {
+            var result = Substitute.For<IPackageSettings>();
+            result.CollectMetrics.Returns(true);
             return result;
         }
 

--- a/test/UnitTests/GitHub.VisualStudio/Services/MetricsTests.cs
+++ b/test/UnitTests/GitHub.VisualStudio/Services/MetricsTests.cs
@@ -221,7 +221,7 @@ namespace MetricsTests
             service.WhenForAnyArgs(x => x.StartTimer(null, new TimeSpan(), new TimeSpan()))
                 .Do(x => tick = x.ArgAt<Func<Task>>(0));
 
-            var target = new UsageTracker(serviceProvider, service);
+            var target = new UsageTracker(serviceProvider, service, CreatePackageSettings());
 
             return Tuple.Create(target, tick);
         }


### PR DESCRIPTION
`UsageTracker` was querying `IPackageSettings` in its initialization and this was causing an occasional race condition between `AsyncPackage.AddService` and `AsyncPackage.GetService`.  Instead pass the `IPackageSettings` to the `UsageTracker` constructor.

We really need a better solution for this in general, but this fix should work for now.