### PR TITLE
WIP: Fix inline comment peek view focus

### DIFF
--- a/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml.cs
+++ b/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml.cs
@@ -2,6 +2,7 @@
 using System.Reactive.Subjects;
 using System.Windows.Controls;
 using GitHub.VisualStudio.UI.Helpers;
+using Microsoft.VisualStudio.Editor;
 
 namespace GitHub.InlineReviews.Views
 {
@@ -17,6 +18,7 @@ namespace GitHub.InlineReviews.Views
             desiredHeight = new Subject<double>();
             threadView.LayoutUpdated += ThreadViewLayoutUpdated;
             threadScroller.PreviewMouseWheel += ScrollViewerUtilities.FixMouseWheelScroll;
+            CommandRouting.SetInterceptsCommandRouting(this, true);
         }
 
         public IObservable<double> DesiredHeight => desiredHeight;


### PR DESCRIPTION
Trying to fix #1588 

@olegtk this is the code with the change you suggested, but it seems to have no effect. Any other ideas?