### PR TITLE
Fix avatar in inline comments.

### DIFF
--- a/src/GitHub.VisualStudio.UI/UI/Controls/AccountAvatar.xaml
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/AccountAvatar.xaml
@@ -4,9 +4,10 @@
              xmlns:local="clr-namespace:GitHub.VisualStudio.UI.Controls"
              Name="root"
              MinWidth="16" MinHeight="16">
-    <Button Name="btn" Command="{Binding Command, ElementName=root}"
+    <Button Command="{Binding Command, ElementName=root}"
             CommandParameter="{Binding CommandParameter, ElementName=root}"
-            CommandTarget="{Binding CommandTarget, ElementName=root}">
+            CommandTarget="{Binding CommandTarget, ElementName=root}"
+            MinWidth="0">
         <Button.Template>
             <ControlTemplate TargetType="Button">
                 <ContentPresenter/>


### PR DESCRIPTION
Don't use the default button width for the button in the avatar view. [The default button width is 76](https://github.com/github/VisualStudio/blob/25fae6b454680894d3300a595fc3bcce65ce84eb/src/GitHub.VisualStudio.UI/Styles/Buttons.xaml#L13); don't use this for the button in the avatar as it will likely be much smaller, and in fact was making the avatar invisible in the inline comment view.

Before:

![2018-04-17_11-24-10](https://user-images.githubusercontent.com/1775141/38861259-6983bc02-4232-11e8-943b-a6594113ed05.png)

After:

![2018-04-17_11-26-02](https://user-images.githubusercontent.com/1775141/38861269-6e7c1268-4232-11e8-8cb4-a8c55cabbc0f.png)
