### PR TITLE
Add metrics for Team Explorer -Home - Pull Requests button

### DIFF
--- a/src/GitHub.Exports/Models/UsageModel.cs
+++ b/src/GitHub.Exports/Models/UsageModel.cs
@@ -68,7 +68,7 @@ namespace GitHub.Models
             public int NumberOfPRReviewDiffViewInlineCommentStartReview { get; set; }
             public int NumberOfPRReviewPosts { get; set; }
             public int NumberOfShowCurrentPullRequest { get; set; }
-            public int NumberOfTeamExplorerOpenPullRequestList { get; set; }
+            public int NumberOfTeamExplorerHomeOpenPullRequestList { get; set; }
         }
     }
 }

--- a/src/GitHub.Exports/Models/UsageModel.cs
+++ b/src/GitHub.Exports/Models/UsageModel.cs
@@ -68,6 +68,7 @@ namespace GitHub.Models
             public int NumberOfPRReviewDiffViewInlineCommentStartReview { get; set; }
             public int NumberOfPRReviewPosts { get; set; }
             public int NumberOfShowCurrentPullRequest { get; set; }
+            public int NumberOfTeamExplorerOpenPullRequestList { get; set; }
         }
     }
 }

--- a/src/GitHub.TeamFoundation.14/Home/PullRequestsNavigationItem.cs
+++ b/src/GitHub.TeamFoundation.14/Home/PullRequestsNavigationItem.cs
@@ -37,7 +37,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
         public override void Execute()
         {
             openPullRequests.Execute();
-            usageTracker.IncrementCounter(x => x.NumberOfTeamExplorerOpenPullRequestList).Forget();
+            usageTracker.IncrementCounter(x => x.NumberOfTeamExplorerHomeOpenPullRequestList).Forget();
         }
     }
 }

--- a/src/GitHub.TeamFoundation.14/Home/PullRequestsNavigationItem.cs
+++ b/src/GitHub.TeamFoundation.14/Home/PullRequestsNavigationItem.cs
@@ -18,19 +18,26 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
         public const string PullRequestsNavigationItemId = "5245767A-B657-4F8E-BFEE-F04159F1DDA3";
 
         readonly IOpenPullRequestsCommand openPullRequests;
+        readonly IUsageTracker usageTracker;
 
         [ImportingConstructor]
         public PullRequestsNavigationItem(IGitHubServiceProvider serviceProvider,
             ISimpleApiClientFactory apiFactory,
             ITeamExplorerServiceHolder holder,
-            IOpenPullRequestsCommand openPullRequests)
+            IOpenPullRequestsCommand openPullRequests,
+            IUsageTracker usageTracker)
             : base(serviceProvider, apiFactory, holder, Octicon.git_pull_request)
         {
             this.openPullRequests = openPullRequests;
+            this.usageTracker = usageTracker;
             Text = Resources.PullRequestsNavigationItemText;
             ArgbColor = Colors.RedNavigationItem.ToInt32();
         }
 
-        public override void Execute() => openPullRequests.Execute();
+        public override void Execute()
+        {
+            openPullRequests.Execute();
+            usageTracker.IncrementCounter(x => x.NumberOfTeamExplorerOpenPullRequestList).Forget();
+        }
     }
 }


### PR DESCRIPTION
This PR adds a counter called `NumberOfTeamExplorerHomeOpenPullRequestList` for clicks on the `Team Explorer - Home`, `Pull Requests` button.

![image](https://user-images.githubusercontent.com/11719160/38885275-5e8b69de-426a-11e8-8d24-3811df11e450.png)

![image](https://user-images.githubusercontent.com/11719160/38885228-31b932ec-426a-11e8-8c3f-9d2e44aa4d24.png)
