### PR TITLE
Consistently name all VS commands

### DIFF
--- a/src/GitHub.InlineReviews/InlineReviewsPackage.vsct
+++ b/src/GitHub.InlineReviews/InlineReviewsPackage.vsct
@@ -49,6 +49,8 @@
         <Strings>
           <CommandName>GitHub.InlineReviews.NextInlineComment</CommandName>
           <ButtonText>Next Comment</ButtonText>
+          <CanonicalName>.GitHub.NextComment</CanonicalName>
+          <LocCanonicalName>.GitHub.NextComment</LocCanonicalName>
         </Strings>
       </Button>
       <Button guid="guidGitHubCommandSet" id="PreviousInlineCommentId" priority="0x0100" type="Button">
@@ -58,6 +60,8 @@
         <Strings>
           <CommandName>GitHub.InlineReviews.PreviousInlineComment</CommandName>
           <ButtonText>Previous Comment</ButtonText>
+          <CanonicalName>.GitHub.PreviousComment</CanonicalName>
+          <LocCanonicalName>.GitHub.PreviousComment</LocCanonicalName>
         </Strings>
       </Button>
     </Buttons>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.vsct
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.vsct
@@ -77,6 +77,8 @@
         <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>&amp;Connect to GitHub</ButtonText>
+          <CanonicalName>.GitHub.ConnectToGitHub</CanonicalName>
+          <LocCanonicalName>.GitHub.ConnectToGitHub</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -85,6 +87,8 @@
         <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>GitHub</ButtonText>
+          <CanonicalName>.GitHub.ShowGitHubPane</CanonicalName>
+          <LocCanonicalName>.GitHub.ShowGitHubPane</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -93,8 +97,8 @@
         <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>Show Current Pull Request</ButtonText>
-          <CanonicalName>GitHub.ShowCurrentPullRequest</CanonicalName>
-          <LocCanonicalName>GitHub.ShowCurrentPullRequest</LocCanonicalName>
+          <CanonicalName>.GitHub.ShowCurrentPullRequest</CanonicalName>
+          <LocCanonicalName>.GitHub.ShowCurrentPullRequest</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -105,6 +109,8 @@
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
           <ButtonText>Back</ButtonText>
+          <CanonicalName>.GitHub.Back</CanonicalName>
+          <LocCanonicalName>.GitHub.Back</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -114,6 +120,8 @@
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
           <ButtonText>Forward</ButtonText>
+          <CanonicalName>.GitHub.Forward</CanonicalName>
+          <LocCanonicalName>.GitHub.Forward</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -123,6 +131,8 @@
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
           <ButtonText>Pull Requests</ButtonText>
+          <CanonicalName>.GitHub.PullRequests</CanonicalName>
+          <LocCanonicalName>.GitHub.PullRequests</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -132,6 +142,8 @@
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
           <ButtonText>Refresh</ButtonText>
+          <CanonicalName>.GitHub.Refresh</CanonicalName>
+          <LocCanonicalName>.GitHub.Refresh</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -141,6 +153,8 @@
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
           <ButtonText>View on GitHub</ButtonText>
+          <CanonicalName>.GitHub.ViewOnGitHub</CanonicalName>
+          <LocCanonicalName>.GitHub.ViewOnGitHub</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -149,6 +163,8 @@
         <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>Help</ButtonText>
+          <CanonicalName>.GitHub.Help</CanonicalName>
+          <LocCanonicalName>.GitHub.Help</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -159,6 +175,8 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Create a GitHub Gist</ButtonText>
+          <CanonicalName>.GitHub.CreateGist</CanonicalName>
+          <LocCanonicalName>.GitHub.CreateGist</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -169,6 +187,8 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Open on GitHub</ButtonText>
+          <CanonicalName>.GitHub.OpenLink</CanonicalName>
+          <LocCanonicalName>.GitHub.OpenLink</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -179,6 +199,8 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Copy link to clipboard</ButtonText>
+          <CanonicalName>.GitHub.CopyLink</CanonicalName>
+          <LocCanonicalName>.GitHub.CopyLink</LocCanonicalName>
         </Strings>
       </Button>
 
@@ -189,9 +211,11 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Blame</ButtonText>
+          <CanonicalName>.GitHub.Blame</CanonicalName>
+          <LocCanonicalName>.GitHub.Blame</LocCanonicalName>
         </Strings>
       </Button>
-      
+
       <Button guid="guidContextMenuSet" id="openFileInSolutionCommand" type="Button">
         <Icon guid="guidImages" id="logo" />
         <CommandFlag>IconIsMoniker</CommandFlag>
@@ -199,6 +223,8 @@
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Open File in Solution</ButtonText>
+          <CanonicalName>.GitHub.OpenFileInSolution</CanonicalName>
+          <LocCanonicalName>.GitHub.OpenFileInSolution</LocCanonicalName>
         </Strings>
       </Button>
 


### PR DESCRIPTION
This PR uses a tip shared by @madskristensen to ensure that all commands have a consistent name.
https://twitter.com/jcansdale/status/991013150932729856
https://twitter.com/mkristensen/status/991018416222818306
> Ahh, there is a way and it is undocumented. Prefix the name in the .vsct file with a period. Eg: <ButtonText>.TestDriven.NET.Foo</BT>

### What this PR does

Previously our commands would appear on the shortcuts search dialog with inconsistent prefixes (some didn't even contain `GitHub` and were difficult to find).

![image](https://user-images.githubusercontent.com/11719160/39528868-335572e6-4e1d-11e8-8017-b6eba9c75b11.png)

- This PR gives them all a consistent prefix of `GitHub`.

![image](https://user-images.githubusercontent.com/11719160/39528855-29356866-4e1d-11e8-8cd2-bc0d32ea3da3.png)

- Specify a `CanonicalName` for all commands (this is used in the `Command Window`)

- Specify a `LocCanonicalName` for all commands (used in `Customize > Keyboard...` dialog)

- Our commands now appear as follows

```
GitHub.Back
GitHub.Forward
GitHub.Refresh
GitHub.PullRequests
GitHub.ViewOnGitHub
GitHub.Help
GitHub.ConnectToGitHub
GitHub.ShowGitHubPane
GitHub.ShowCurrentPullRequest
GitHub.OpenLink
GitHub.CopyLink
GitHub.OpenFileInSolution
GitHub.Blame
GitHub.CreateGist
GitHub.NextComment
GitHub.PreviousComment
```

Previously they appeared as in the screenshot above + the following:

```
EditorContextMenus.CodeWindow.OpenFileinSolution
Edit.NextComment
Edit.PreviousComment
```

### Reviewers

This PR is deliberately being kept simple. Is there any reason not to do this? 😉 

I hope having all of these commands consistently named will allow for faster and more stable automation testing. //paging @meaghanlewis 

### How to test

These commands names are surfaced in a few places

1. On the `Command Window` if you start typing `GitHub`.

![image](https://user-images.githubusercontent.com/11719160/39530013-ef8d0b52-4e1f-11e8-8fc6-8addf3b97ea7.png)

2. Right-click on a toolbar, `Customize...`, `Keyboard...` and start typing `GitHub` in `Show commands containing`.

![image](https://user-images.githubusercontent.com/11719160/39530196-5be04de6-4e20-11e8-8261-3c89024b1d67.png)

3. They can also be accessed programatically via automation.

```
        void ShowGitHubPane(DTE dte)
        {
            dte.ExecuteCommand("GitHub.ShowGitHubPane");
        }
```

### Future PRs

There is a bunch of functionality that is not being exposed as VS commands (e.g. show PR list of sync submodules). We should fix this but in separate PRs.

Fixes #1630