### PR TITLE
Hide difference viewer sides when empty

### DIFF
--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -187,6 +187,17 @@ namespace GitHub.Services
 
                 var diffViewer = GetDiffViewer(frame);
 
+                if (diffViewer.LeftView.TextBuffer.CurrentSnapshot.GetText() == string.Empty)
+                {
+                    // Don't show LeftView when empty.
+                    diffViewer.ViewMode = DifferenceViewMode.RightViewOnly;
+                }
+                else if (diffViewer.RightView.TextBuffer.CurrentSnapshot.GetText() == string.Empty)
+                {
+                    // Don't show RightView when empty.
+                    diffViewer.ViewMode = DifferenceViewMode.LeftViewOnly;
+                }
+
                 AddBufferTag(diffViewer.LeftView.TextBuffer, session, leftPath, mergeBase, DiffSide.Left);
 
                 if (!workingDirectory)


### PR DESCRIPTION
When diff LeftView is empty, automatically set to show RightViewOnly.
When diff RightView is empty, automatically set to show LeftViewOnly.

Fixes #1624