### PR TITLE
Allow IVSGitExt to be explicitly refreshed

### DIFF
--- a/src/GitHub.App/Services/TeamExplorerContext.cs
+++ b/src/GitHub.App/Services/TeamExplorerContext.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.ComponentModel.Composition;
 using GitHub.Models;
 using GitHub.Logging;
+using GitHub.Primitives;
 using Serilog;
 using EnvDTE;
 
@@ -31,6 +32,7 @@ namespace GitHub.Services
 
         string solutionPath;
         string repositoryPath;
+        UriString cloneUrl;
         string branchName;
         string headSha;
         string trackedSha;
@@ -70,11 +72,17 @@ namespace GitHub.Services
                 else
                 {
                     var newRepositoryPath = repo?.LocalPath;
+                    var newCloneUrl = repo?.CloneUrl;
                     var newBranchName = repo?.CurrentBranch?.Name;
                     var newHeadSha = repo?.CurrentBranch?.Sha;
                     var newTrackedSha = repo?.CurrentBranch?.TrackedSha;
 
                     if (newRepositoryPath != repositoryPath)
+                    {
+                        log.Debug("ActiveRepository changed to {CloneUrl} @ {Path}", repo?.CloneUrl, newRepositoryPath);
+                        ActiveRepository = repo;
+                    }
+                    else if (newCloneUrl != cloneUrl)
                     {
                         log.Debug("ActiveRepository changed to {CloneUrl} @ {Path}", repo?.CloneUrl, newRepositoryPath);
                         ActiveRepository = repo;
@@ -96,6 +104,7 @@ namespace GitHub.Services
                     }
 
                     repositoryPath = newRepositoryPath;
+                    cloneUrl = newCloneUrl;
                     branchName = newBranchName;
                     headSha = newHeadSha;
                     solutionPath = newSolutionPath;

--- a/src/GitHub.Exports/Services/IVSGitExt.cs
+++ b/src/GitHub.Exports/Services/IVSGitExt.cs
@@ -8,5 +8,6 @@ namespace GitHub.Services
     {
         IReadOnlyList<ILocalRepositoryModel> ActiveRepositories { get; }
         event Action ActiveRepositoriesChanged;
+        void RefreshActiveRepositories();
     }
 }

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -74,7 +74,7 @@ namespace GitHub.VisualStudio.Base
             }, TaskScheduler.Default);
         }
 
-        void RefreshActiveRepositories()
+        public void RefreshActiveRepositories()
         {
             try
             {


### PR DESCRIPTION
### What this PR does

- Expose `RefreshActiveRepositories` on `IVSGitExt` interface
- Refresh `TeamExplorerContext.ActiveRepository` when `CloneUrl` changes

### What this PR doesn't do

- It doesn't refresh the UI when origin URL is changed from the command line.

### Future PR

At the moment `IVSGitExt` spits out `ILocalRepositoryModel` objects, which I think are too high level for this class. Ideally it would be a thin wrapper on top of `IGitExt` (or rather the two `IGitExt` interfaces - one for each version of VS).

We'd have another service that listened to `IVSGitExt` and `FileSystemWatcher` and spits out `ILocalRepositoryModel` objects when either the repo directory changes or the remote URL changes. Our other services would listen to this as a drop in replacement for the current `IVSGitExt`.

Workaround for #1646 