### PR TITLE
Fix extension when running in SafeMode / Expression Blend

### DIFF
--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerServiceHolder.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerServiceHolder.cs
@@ -35,7 +35,10 @@ namespace GitHub.VisualStudio.Base
             syncContext = SynchronizationContext.Current;
 
             UpdateActiveRepo();
-            gitService.ActiveRepositoriesChanged += UpdateActiveRepo;
+            if (gitService != null)
+            {
+                gitService.ActiveRepositoriesChanged += UpdateActiveRepo;
+            }
         }
 
 

--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerServiceHolder.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerServiceHolder.cs
@@ -135,7 +135,9 @@ namespace GitHub.VisualStudio.Base
 
         void UpdateActiveRepo()
         {
-            var repo = gitService.ActiveRepositories.FirstOrDefault();
+            // NOTE: gitService will be null in Expression Blend or Safe Mode
+            var repo = gitService?.ActiveRepositories.FirstOrDefault();
+
             if (!Equals(repo, ActiveRepo))
                 // so annoying that this is on the wrong thread
                 syncContext.Post(r => ActiveRepo = r as ILocalRepositoryModel, repo);


### PR DESCRIPTION
Prevent the following exception when running in SafeMode / Expression Blend:
```
Microsoft.VisualStudio.Composition.CompositionFailedException: An exception was thrown while initializing part "GitHub.VisualStudio.Base.TeamExplorerServiceHolder". ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at GitHub.VisualStudio.Base.TeamExplorerServiceHolder.UpdateActiveRepo() in C:\projects\visualstudio\src\GitHub.TeamFoundation.14\Base\TeamExplorerServiceHolder.cs:line 138
   at GitHub.VisualStudio.Base.TeamExplorerServiceHolder..ctor(IVSGitExt gitService) in C:\projects\visualstudio\src\GitHub.TeamFoundation.14\Base\TeamExplorerServiceHolder.cs:line 37
```

Fixes #1620