### PR TITLE
[do not merge] Import PullRequestStatusBarManager on Main thread

### DIFF
--- a/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
+++ b/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
@@ -29,9 +29,9 @@ namespace GitHub.InlineReviews
         {
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
             var exports = componentModel.DefaultExportProvider;
-            var barManager = exports.GetExportedValue<PullRequestStatusBarManager>();
 
             await JoinableTaskFactory.SwitchToMainThreadAsync();
+            var barManager = exports.GetExportedValue<PullRequestStatusBarManager>();
             barManager.StartShowingStatus();
         }
     }

--- a/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
@@ -32,8 +32,8 @@ namespace GitHub.InlineReviews.Services
 
         // At the moment these must be constructed on the main thread.
         // TeamExplorerContext needs to retrieve DTE using GetService.
-        readonly Lazy<IPullRequestSessionManager> pullRequestSessionManager;
-        readonly Lazy<ITeamExplorerContext> teamExplorerContext;
+        readonly IPullRequestSessionManager pullRequestSessionManager;
+        readonly ITeamExplorerContext teamExplorerContext;
 
         IDisposable currentSessionSubscription;
 
@@ -42,8 +42,8 @@ namespace GitHub.InlineReviews.Services
             IUsageTracker usageTracker,
             IOpenPullRequestsCommand openPullRequestsCommand,
             IShowCurrentPullRequestCommand showCurrentPullRequestCommand,
-            Lazy<IPullRequestSessionManager> pullRequestSessionManager,
-            Lazy<ITeamExplorerContext> teamExplorerContext)
+            IPullRequestSessionManager pullRequestSessionManager,
+            ITeamExplorerContext teamExplorerContext)
         {
             this.openPullRequestsCommand = new UsageTrackingCommand(openPullRequestsCommand,
                 usageTracker, x => x.NumberOfStatusBarOpenPullRequestList);
@@ -64,7 +64,7 @@ namespace GitHub.InlineReviews.Services
         {
             try
             {
-                teamExplorerContext.Value.WhenAnyValue(x => x.ActiveRepository)
+                teamExplorerContext.WhenAnyValue(x => x.ActiveRepository)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(x => RefreshActiveRepository(x));
             }
@@ -77,7 +77,7 @@ namespace GitHub.InlineReviews.Services
         void RefreshActiveRepository(ILocalRepositoryModel repository)
         {
             currentSessionSubscription?.Dispose();
-            currentSessionSubscription = pullRequestSessionManager.Value.WhenAnyValue(x => x.CurrentSession)
+            currentSessionSubscription = pullRequestSessionManager.WhenAnyValue(x => x.CurrentSession)
                 .Subscribe(x => RefreshCurrentSession(repository, x));
         }
 


### PR DESCRIPTION
### What this PR does

- Import `PullRequestStatusBarManager` on the Main thread (using `SwitchToMainThreadAsync`)
- This means that `IPullRequestSessionManager` / `ITeamExplorerContext` are also imported on Main thread

### Diagnosis ???

`IPullRequestSessionManager` was being lazy loaded by `RefreshActiveRepository` using the following Rx subscription:
```cs
                teamExplorerContext.WhenAnyValue(x => x.ActiveRepository)
                    .ObserveOn(RxApp.MainThreadScheduler)
                    .Subscribe(x => RefreshActiveRepository(x));
```

Is there something funny going on with the thread that the property changed event is invoked on or the `.ObserveOn(RxApp.MainThreadScheduler)`?  Not sure yet. 😕 

### Other possibilities

We could create our own `IScheduler` implementation like this:
```cs
        class JoinableTaskFactoryMainThreadScheduler : IScheduler, IDisposable
        {
            public DateTimeOffset Now => DateTime.Now;

            public IDisposable Schedule<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
            {
                MainAsync(state, action).Forget();
                return this;
            }

            async Task MainAsync<TState>(TState state, Func<IScheduler, TState, IDisposable> action)
            {
                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                action(this, state);
            }

            public IDisposable Schedule<TState>(TState state, TimeSpan dueTime, Func<IScheduler, TState, IDisposable> action)
            {
                throw new NotImplementedException();
            }

            public IDisposable Schedule<TState>(TState state, DateTimeOffset dueTime, Func<IScheduler, TState, IDisposable> action)
            {
                throw new NotImplementedException();
            }

            public void Dispose()
            {
            }
        }
```
This would be used in place of `RxApp.MainThreadScheduler`.

Something like:
```cs
                teamExplorerContext.WhenAnyValue(x => x.ActiveRepository)
                    .ObserveOn(new JoinableTaskFactoryMainThreadScheduler())
                    .Subscribe(x => RefreshActiveRepository(x));
```

Or maybe as an extension method?
```cs
                teamExplorerContext.WhenAnyValue(x => x.ActiveRepository)
                    .ObserveOn(ThreadHelper.JoinableTaskFactory.Scheduler())
                    .Subscribe(x => RefreshActiveRepository(x));
```

Fixes #1662