### PR TITLE
Make PR# link work in authoring view.

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModel.cs
@@ -12,6 +12,7 @@ using GitHub.Models;
 using GitHub.Services;
 using ReactiveUI;
 using Serilog;
+using static System.FormattableString;
 
 namespace GitHub.ViewModels.GitHubPane
 {
@@ -71,6 +72,8 @@ namespace GitHub.ViewModels.GitHubPane
                 hasBodyOrComments,
                 _ => DoSubmit(Octokit.PullRequestReviewEvent.RequestChanges));
             Cancel = ReactiveCommand.CreateAsyncTask(DoCancel);
+            NavigateToPullRequest = ReactiveCommand.Create().OnExecuteCompleted(_ =>
+                NavigateTo(Invariant($"{LocalRepository.Owner}/{LocalRepository.Name}/pull/{PullRequestModel.Number}")));
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Add the missing command to navigate back to the Pull Request after clicking the PR# link in the header of the PR authoring view.

![image](https://user-images.githubusercontent.com/417571/39841616-5bbec860-53b1-11e8-8747-e94f6f6be7a7.png)

Fixes #1654.