### PR TITLE
Avoid overlapping writes to metrics.json

### DIFF
--- a/src/GitHub.VisualStudio/Services/UsageService.cs
+++ b/src/GitHub.VisualStudio/Services/UsageService.cs
@@ -16,7 +16,7 @@ using Task = System.Threading.Tasks.Task;
 namespace GitHub.Services
 {
     [Export(typeof(IUsageService))]
-    public class UsageService : IUsageService
+    public sealed class UsageService : IUsageService, IDisposable
     {
         const string StoreFileName = "metrics.json";
         const string UserStoreFileName = "user.json";
@@ -35,6 +35,11 @@ namespace GitHub.Services
         {
             this.serviceProvider = serviceProvider;
             this.environment = environment;
+        }
+
+        public void Dispose()
+        {
+            writeSemaphoreSlim.Dispose();
         }
 
         public async Task<Guid> GetUserGuid()


### PR DESCRIPTION
### What this PR does

- Guard WriteAllTextAsync using a SemaphoreSlim

### Testing

`metrics.json` is now getting updated correctly. No more exceptions in log.

![image](https://user-images.githubusercontent.com/11719160/40136525-0a60d97e-5940-11e8-8096-94f4459131a3.png)

### Unit tests?

Sorry. 🕐 😢  

Fixes #1670