### PR TITLE
Don't only show `Open File in Solution` / `Open Code View` options when on PR branch

### DIFF
--- a/src/GitHub.VisualStudio/Commands/GoToSolutionOrPullRequestFileCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/GoToSolutionOrPullRequestFileCommand.cs
@@ -150,14 +150,6 @@ namespace GitHub.Commands
         {
             try
             {
-                var session = sessionManager.Value.CurrentSession;
-                if (session == null)
-                {
-                    // No active pull request session
-                    Visible = false;
-                    return;
-                }
-
                 var sourceView = pullRequestEditorService.Value.FindActiveView();
                 if (sourceView == null)
                 {
@@ -185,13 +177,17 @@ namespace GitHub.Commands
                     return;
                 }
 
-                var relativePath = sessionManager.Value.GetRelativePath(textView.TextBuffer);
-                if (relativePath != null)
+                var session = sessionManager.Value.CurrentSession;
+                if (session != null)
                 {
-                    // Active text view is part of a repository
-                    Text = "View Changes in #" + session.PullRequest.Number;
-                    Visible = true;
-                    return;
+                    var relativePath = sessionManager.Value.GetRelativePath(textView.TextBuffer);
+                    if (relativePath != null)
+                    {
+                        // Active text view is part of a repository
+                        Text = "View Changes in #" + session.PullRequest.Number;
+                        Visible = true;
+                        return;
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
### What this PR does

There was some code that hid all `GoToSolutionOrPullRequestFileCommand` options when not on a PR branch.

```cs
var session = sessionManager.Value.CurrentSession;
if (session == null)
{
     // No active pull request session
     Visible = false;
     return;
}
```

Only the `View Changes in PR` command option should be hidden when not on a PR branch.

- Make the `Open File in Solution` option visible when viewing a PR file diff
- Make the `Open File in Code View` option visible when viewing a writable diff file

Fixes #1679