### PR TITLE
[spike] Make MEF constructors free-threaded

### DIFF
--- a/src/GitHub.TeamFoundation.14/GitHub.TeamFoundation.14.csproj
+++ b/src/GitHub.TeamFoundation.14/GitHub.TeamFoundation.14.csproj
@@ -112,6 +112,14 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.14.1.131\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -2,13 +2,13 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using GitHub.Models;
 using GitHub.Services;
 using GitHub.Logging;
 using GitHub.TeamFoundation.Services;
 using Serilog;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
 using Task = System.Threading.Tasks.Task;
 
@@ -32,14 +32,18 @@ namespace GitHub.VisualStudio.Base
         IGitExt gitService;
         IReadOnlyList<ILocalRepositoryModel> activeRepositories;
 
-        [ImportingConstructor]
         public VSGitExt(IAsyncServiceProvider asyncServiceProvider)
-            : this(asyncServiceProvider, new VSUIContextFactory(), new LocalRepositoryModelFactory())
+            : this(asyncServiceProvider, new VSUIContextFactory(), new LocalRepositoryModelFactory(), ThreadHelper.JoinableTaskContext)
         {
         }
 
-        public VSGitExt(IAsyncServiceProvider asyncServiceProvider, IVSUIContextFactory factory, ILocalRepositoryModelFactory repositoryFactory)
+        public VSGitExt(IAsyncServiceProvider asyncServiceProvider, IVSUIContextFactory factory, ILocalRepositoryModelFactory repositoryFactory,
+            JoinableTaskContext joinableTaskContext = null)
         {
+            joinableTaskContext = joinableTaskContext ?? new JoinableTaskContext();
+            JoinableTaskCollection = joinableTaskContext.CreateCollection();
+            JoinableTaskFactory = joinableTaskContext.CreateFactory(JoinableTaskCollection);
+
             this.asyncServiceProvider = asyncServiceProvider;
             this.repositoryFactory = repositoryFactory;
 
@@ -49,29 +53,28 @@ namespace GitHub.VisualStudio.Base
             // The IGitExt service isn't available when a TFS based solution is opened directly.
             // It will become available when moving to a Git based solution (and cause a UIContext event to fire).
             var context = factory.GetUIContext(new Guid(Guids.GitSccProviderId));
-            context.WhenActivated(() => Initialize());
+            context.WhenActivated(() => JoinableTaskFactory.RunAsync(InitializeAsync));
         }
 
-        void Initialize()
+        async Task InitializeAsync()
         {
-            PendingTasks = asyncServiceProvider.GetServiceAsync(typeof(IGitExt)).ContinueWith(t =>
+            gitService = await GetServiceAsync<IGitExt>();
+            if (gitService == null)
             {
-                gitService = (IGitExt)t.Result;
-                if (gitService == null)
-                {
-                    log.Error("Couldn't find IGitExt service");
-                    return;
-                }
+                log.Error("Couldn't find IGitExt service");
+                return;
+            }
 
-                RefreshActiveRepositories();
-                gitService.PropertyChanged += (s, e) =>
+            // Refresh on background thread
+            await Task.Run(() => RefreshActiveRepositories());
+
+            gitService.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(gitService.ActiveRepositories))
                 {
-                    if (e.PropertyName == nameof(gitService.ActiveRepositories))
-                    {
-                        RefreshActiveRepositories();
-                    }
-                };
-            }, TaskScheduler.Default);
+                    RefreshActiveRepositories();
+                }
+            };
         }
 
         public void RefreshActiveRepositories()
@@ -113,11 +116,20 @@ namespace GitHub.VisualStudio.Base
             }
         }
 
+        async Task<T> GetServiceAsync<T>()
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync();
+            return (T)await asyncServiceProvider.GetServiceAsync(typeof(T));
+        }
+
         public event Action ActiveRepositoriesChanged;
 
         /// <summary>
         /// Tasks that are pending execution on the thread pool.
         /// </summary>
-        public Task PendingTasks { get; private set; } = Task.CompletedTask;
+        //public Task PendingTasks { get; private set; } = Task.CompletedTask;
+
+        public JoinableTaskFactory JoinableTaskFactory { get; }
+        public JoinableTaskCollection JoinableTaskCollection { get; }
     }
 }

--- a/src/GitHub.TeamFoundation.14/packages.config
+++ b/src/GitHub.TeamFoundation.14/packages.config
@@ -11,6 +11,8 @@
   <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading" version="14.1.131" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net461" />
   <package id="Rx-Core" version="2.2.5-custom" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5-custom" targetFramework="net45" />
   <package id="Serilog" version="2.5.0" targetFramework="net461" />

--- a/test/UnitTests/GitHub.App/Services/TeamExplorerContextTests.cs
+++ b/test/UnitTests/GitHub.App/Services/TeamExplorerContextTests.cs
@@ -214,8 +214,8 @@ namespace GitHub.App.UnitTests.Services
         static TeamExplorerContext CreateTeamExplorerContext(IVSGitExt gitExt, DTE dte = null)
         {
             dte = dte ?? Substitute.For<DTE>();
-            var sp = Substitute.For<IGitHubServiceProvider>();
-            sp.GetService<DTE>().Returns(dte);
+            var sp = Substitute.For<IServiceProvider>();
+            sp.GetService(typeof(DTE)).Returns(dte);
             return new TeamExplorerContext(gitExt, sp);
         }
 

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -166,6 +166,14 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.14.1.131\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/test/UnitTests/packages.config
+++ b/test/UnitTests/packages.config
@@ -26,6 +26,8 @@
   <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="14.3.25407" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading" version="14.1.131" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net461" />
   <package id="NUnit" version="3.9.0" targetFramework="net461" />


### PR DESCRIPTION
### What this PR does

- Use JoinableTaskFactory to make MEF constructors free-threaded
- Fire TeamExplorerContext events on Main thread
