### PR TITLE
Fix `View on GitHub` when on fork repository

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
@@ -328,7 +329,7 @@ namespace GitHub.ViewModels.GitHubPane
                 LocalRepository = localRepository;
                 RemoteRepositoryOwner = owner;
                 Number = number;
-                WebUrl = LocalRepository.CloneUrl.ToRepositoryUrl().Append("pull/" + number);
+                WebUrl = ToPullRequestUrl(localRepository.CloneUrl.Host, owner, localRepository.Name, number);
                 modelService = await modelServiceFactory.CreateAsync(connection);
 
                 await Refresh();
@@ -342,6 +343,12 @@ namespace GitHub.ViewModels.GitHubPane
             {
                 IsLoading = false;
             }
+        }
+
+        static Uri ToPullRequestUrl(string host, string owner, string repositoryName, int number)
+        {
+            var url = string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/{2}/pull/{3}", host, owner, repositoryName, number);
+            return new Uri(url);
         }
 
         void RefreshIfActive(object sender, EventArgs e)

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml.cs
@@ -41,15 +41,7 @@ namespace GitHub.VisualStudio.Views.GitHubPane
         void DoOpenOnGitHub()
         {
             var browser = VisualStudioBrowser;
-            var cloneUrl = ViewModel.LocalRepository.CloneUrl;
-            var url = ToPullRequestUrl(cloneUrl.Host, ViewModel.RemoteRepositoryOwner, ViewModel.LocalRepository.Name, ViewModel.Model.Number);
-            browser.OpenUrl(url);
-        }
-
-        static Uri ToPullRequestUrl(string host, string owner, string repositoryName, int number)
-        {
-            var url = string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/{2}/pull/{3}", host, owner, repositoryName, number);
-            return new Uri(url);
+            browser.OpenUrl(ViewModel.WebUrl);
         }
 
         void OpenHyperlink(object sender, ExecutedRoutedEventArgs e)


### PR DESCRIPTION
### What this PR does

Don't assume that the repository owner is the same as the local repository. When viewing PRs from upstream, the upstream owner should be used.

- Use owner from viewed PR not local repository
- Reuse `WebUrl` property in `OpenOnGitHub` command

Fixes #1692