### PR TITLE
Handle child HorizontalAlignment in ScrollingVerticalStackPanel

### DIFF
--- a/src/GitHub.UI/Controls/ScrollingVerticalStackPanel.cs
+++ b/src/GitHub.UI/Controls/ScrollingVerticalStackPanel.cs
@@ -179,7 +179,25 @@ namespace GitHub.UI.Controls
             {
                 var isFixed = GetIsFixed(child);
                 var x = isFixed ? 0 : -HorizontalOffset;
-                var childRect = new Rect(x, y, child.DesiredSize.Width, child.DesiredSize.Height);
+                var width = child.DesiredSize.Width;
+
+                if (isFixed)
+                {
+                    switch (child.HorizontalAlignment)
+                    {
+                        case HorizontalAlignment.Stretch:
+                            width = finalSize.Width;
+                            break;
+                        case HorizontalAlignment.Right:
+                            x = finalSize.Width - child.DesiredSize.Width;
+                            break;
+                        case HorizontalAlignment.Center:
+                            x = (finalSize.Width - child.DesiredSize.Width) / 2;
+                            break;
+                    }
+                }
+
+                var childRect = new Rect(x, y, width, child.DesiredSize.Height);
                 child.Arrange(childRect);
                 y += child.DesiredSize.Height;
 


### PR DESCRIPTION
The `ScrollingVerticalStackPanel` introduced in #1699 wasn't correctly handling the `HorizontalAlignment` of fixed child controls, resulting in the "Reviewers" section being left-aligned instead of stretched:

![image](https://user-images.githubusercontent.com/1775141/40356523-93ce885a-5db9-11e8-992f-a9866b695f12.png)

This PR makes the control handle the `HorizontalAlignement` correctly:

![image](https://user-images.githubusercontent.com/1775141/40356637-f077e3da-5db9-11e8-831b-a2a073382bf9.png)
