### PR TITLE
Don't pass null to GetPullRequestForCurrentBranch

### DIFF
--- a/src/GitHub.App/Services/TeamExplorerContext.cs
+++ b/src/GitHub.App/Services/TeamExplorerContext.cs
@@ -78,7 +78,7 @@ namespace GitHub.Services
                     var newBranchName = repo?.CurrentBranch?.Name;
                     var newHeadSha = repo?.CurrentBranch?.Sha;
                     var newTrackedSha = repo?.CurrentBranch?.TrackedSha;
-                    var newPullRequest = await pullRequestService.GetPullRequestForCurrentBranch(repo);
+                    var newPullRequest = repo != null ? await pullRequestService.GetPullRequestForCurrentBranch(repo) : null;
 
                     if (newRepositoryPath != repositoryPath)
                     {


### PR DESCRIPTION
This fixes a null ref exception in #1687 when there is no active repository.