### PR TITLE
Exclude GitHub.TeamFoundation.14 Asset from VS2017

### DIFF
--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -29,8 +29,8 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Exports.Reactive" Path="|GitHub.Exports.Reactive|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.App" Path="|GitHub.App|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Services.Vssdk" Path="|GitHub.Services.Vssdk|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.TeamFoundation.14" Path="|GitHub.TeamFoundation.14|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.TeamFoundation.15" Path="|GitHub.TeamFoundation.15|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.TeamFoundation.14" TargetVersion="[14.0,15.0)" Path="|GitHub.TeamFoundation.14|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.TeamFoundation.15" TargetVersion="[15.0,16.0)" Path="|GitHub.TeamFoundation.15|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitHub.InlineReviewsPackage" Path="|GitHub.InlineReviews;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitHub.StartPage" Path="|GitHub.StartPage;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.InlineReviews" Path="|GitHub.InlineReviews|" />


### PR DESCRIPTION
### What this PR does

Clean up MEF log when extension installed in Visual Studio 2017

- Use `TargetVersion="[14.0,15.0)"` to exclude `GitHub.TeamFoundation.14`
MEF component from VS2017

The `source.extension.vsixmanifest` now includes this:
```xml
    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" 
        d:ProjectName="GitHub.TeamFoundation.14"
        TargetVersion="[14.0,15.0)" Path="|GitHub.TeamFoundation.14|" />
    <Asset Type="Microsoft.VisualStudio.MefComponent" 
        d:Source="Project" d:ProjectName="GitHub.TeamFoundation.15"
        TargetVersion="[15.0,16.0)" Path="|GitHub.TeamFoundation.15|" />
```

Unfortunately the `TargetVersion="[15.0,16.0)"` won't be understood by Visual Studio 2015 (so its MEF log will remain dirty).

### How to test

Install in Visual Studio 2017 and use the `Clear MEF Component Cache` extension to `Show MEF Errors` (it's on the `Tools` menu). This should now be empty in Visual Studio 2017.

Errors will still appear in Visual Studio 2015 (it doesn't support the `TargetVersion` attribute).

Fixes #1704