### PR TITLE
Don't block checkout when a file appears to have been deleted

### DIFF
--- a/test/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
+++ b/test/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
@@ -208,7 +208,7 @@ public class PullRequestServiceTests : TestBaseClass
         }
 
         [Test]
-        public async Task RenamedInWorkingDirFile_False()
+        public async Task RenamedInWorkingDirFile_True()
         {
             using (var tempDir = new TempDirectory())
             using (var repo = CreateRepository(tempDir))
@@ -225,11 +225,11 @@ public class PullRequestServiceTests : TestBaseClass
                 File.Move(file, renamedFile);
 
                 // NOTE: `RetrieveStatus(new StatusOptions { DetectRenamesInWorkDir = true })` would need to be used
-                // for renamed files to appear as `RenamedInWorkingDir` rather than `Missing` and `Untracked`.
+                // for renamed files to appear as `RenamedInWorkingDir` rather than `DeletedFromWorkdir` and `NewInWorkdir`.
                 // This isn't required in the current implementation.
                 var isClean = await service.IsWorkingDirectoryClean(repositoryModel).FirstAsync();
 
-                Assert.False(isClean);
+                Assert.True(isClean);
             }
         }
 

--- a/test/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
+++ b/test/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs
@@ -134,8 +134,13 @@ public class PullRequestServiceTests : TestBaseClass
             }
         }
 
+        // Files can sometimes show up as DeletedFromWorkdir but not appear on Team Explorer or when `git status` is executed.
+        // https://github.com/github/VisualStudio/issues/1691
+        //
+        // Since there is no reason to block a checkout when a file is missing, IsWorkingDirectoryClean should return true
+        // when a file has been deleted.
         [Test]
-        public async Task MissingFile_False()
+        public async Task DeletedFromWorkdir_True()
         {
             using (var tempDir = new TempDirectory())
             using (var repo = CreateRepository(tempDir))
@@ -151,7 +156,7 @@ public class PullRequestServiceTests : TestBaseClass
 
                 var isClean = await service.IsWorkingDirectoryClean(repositoryModel).FirstAsync();
 
-                Assert.False(isClean);
+                Assert.True(isClean);
             }
         }
 


### PR DESCRIPTION
### Why this PR

Sometimes files can appear as `DeletedFromWorkdir` that that aren't visible on Team Explorer or when `git status` is executed. When this happens there is no obvious solution.

![image](https://user-images.githubusercontent.com/11719160/40543008-70849b2e-601a-11e8-9810-08fe02a288a4.png)

Since restoring a deleted file is non-destructive, there is no reason that I can think of to block a user from checking out another PR when a file has been deleted.

### What this PR does

- Don't block checkout when a file has been deleted (`DeletedFromWorkdir`)
- Don't block checkout when a file has been renamed
  - This appears as a combined `RenamedInWorkingDir` and `DeletedFromWorkdir`

### How to test

This PR fixes an issue a user was seeing where files appeared to be missing after a fresh clone that weren't visible to `git status` or Team Explorer changes. See #1691. This PR allows a checkout when a file is missing, so these phantom missing files are no longer a blocker.

1. Check our a clean branch
2. Delete a file that is part of the repo
3. Checkout a PR branch

Expect the `Checkout ...` link to be visible and for the PR branch to checkout successfully.

User has also confirmed the fix https://github.com/github/VisualStudio/issues/1691#issuecomment-392776846.

### What this PR doesn't do

We don't currently allow a checkout to be attempted in any circumstance. @grokys considers having implemented this check to have been a mistake.

A future PR could always allow checkouts to be attempted, but warn the user when they'd be taking changes with them to another PR branch (this might or might not we what they want - but it's impotent they know what's going on).

### Questions

*I've gone with not blocking checkout when a file has been renamed. We want to move in the direction of being more relaxed about checkouts.*

What should we do if a repository file has been renamed? By default this will appear as a missing (`FileStatus.DeletedFromWorkdir`) and an untracked (`FileStatus.NewInWorkdir`) file. After this change the user will be able to checkout a new PR, leaving the renamed file in the working directory. This isn't necessarily a bad thing since they would be able to do this from the command line anyway.

The alternative is to use `new StatusOptions { DetectRenamesInWorkDir = true }` and continue to block checkouts when it appears that a repository file has been renamed. See [here](https://github.com/jcansdale/VisualStudio/blob/e0896810c2ff1d55607fdf751440a46d6d524c79/test/UnitTests/GitHub.App/Services/PullRequestServiceTests.cs#L227).

### Related

- Don't block checking out a PR if there are untracked files: #1302
- [SPIKE] Don't do "clean" check before attempting to check-out PR: #1304

Fixes #1691 
