### PR TITLE
[spike] Infer PR associated with current branch

### DIFF
--- a/src/GitHub.App/SampleData/LocalRepositoryModelDesigner.cs
+++ b/src/GitHub.App/SampleData/LocalRepositoryModelDesigner.cs
@@ -11,7 +11,7 @@ namespace GitHub.App.SampleData
     public class LocalRepositoryModelDesigner : ILocalRepositoryModel
     {
         public UriString CloneUrl { get; set; }
-        public IBranch CurrentBranch { get; set; }
+        public ILocalBranch CurrentBranch { get; set; }
         public Octicon Icon { get; set; }
         public string LocalPath { get; set; }
         public string Name { get; set; }

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Extensions\ConnectionManagerExtensions.cs" />
     <Compile Include="GitHubLogicException.cs" />
     <Compile Include="Models\ActorModel.cs" />
+    <Compile Include="Models\ILocalBranch.cs" />
     <Compile Include="Models\LocalBranchModel.cs" />
     <Compile Include="Models\CommitMessage.cs" />
     <Compile Include="Models\DiffChangeType.cs" />

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Extensions\ConnectionManagerExtensions.cs" />
     <Compile Include="GitHubLogicException.cs" />
     <Compile Include="Models\ActorModel.cs" />
+    <Compile Include="Models\LocalBranchModel.cs" />
     <Compile Include="Models\CommitMessage.cs" />
     <Compile Include="Models\DiffChangeType.cs" />
     <Compile Include="Models\DiffChunk.cs" />

--- a/src/GitHub.Exports/Models/BranchModel.cs
+++ b/src/GitHub.Exports/Models/BranchModel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Globalization;
 using GitHub.Primitives;
-using GitHub.Services;
 
 namespace GitHub.Models
 {
@@ -27,35 +26,16 @@ namespace GitHub.Models
             Id = String.Format(CultureInfo.InvariantCulture, "{0}/{1}", Repository.Owner, Name);
         }
 
-        public BranchModel(LibGit2Sharp.Branch branch, IRepositoryModel repo, IGitService gitService)
-        {
-            Extensions.Guard.ArgumentNotNull(branch, nameof(branch));
-            Extensions.Guard.ArgumentNotNull(repo, nameof(repo));
-            Name = DisplayName = branch.FriendlyName;
-            Repository = repo;
-            Sha = branch.Tip?.Sha;
-            Id = String.Format(CultureInfo.InvariantCulture, "{0}/{1}", Repository.Owner, Name);
-
-            if(IsTracking = branch.IsTracking)
-            {
-                var trackedBranch = branch.TrackedBranch;
-                TrackedSha = trackedBranch.Tip?.Sha;
-#pragma warning disable 0618 // TODO: Replace `Branch.Remote` with `Repository.Network.Remotes[branch.RemoteName]`.
-                TrackedRemoteUrl = new UriString(trackedBranch.Remote.Url);
-#pragma warning restore 0618
-                TrackedRemoteCanonicalName = trackedBranch.UpstreamBranchCanonicalName;
-            }
-        }
-
         public string Id { get; private set; }
         public string Name { get; private set; }
         public IRepositoryModel Repository { get; private set; }
         public string DisplayName { get; set; }
-        public string Sha { get; private set; }
-        public bool IsTracking { get; private set; }
-        public string TrackedSha { get; private set; }
-        public UriString TrackedRemoteUrl { get; private set; }
-        public string TrackedRemoteCanonicalName { get; private set; }
+
+        public string Sha { get; protected set; }
+        public bool IsTracking { get; protected set; }
+        public string TrackedSha { get; protected set; }
+        public UriString TrackedRemoteUrl { get; protected set; }
+        public string TrackedRemoteCanonicalName { get; protected set; }
 
         #region Equality things
         public void CopyFrom(IBranch other)

--- a/src/GitHub.Exports/Models/BranchModel.cs
+++ b/src/GitHub.Exports/Models/BranchModel.cs
@@ -32,9 +32,7 @@ namespace GitHub.Models
             Extensions.Guard.ArgumentNotNull(branch, nameof(branch));
             Extensions.Guard.ArgumentNotNull(repo, nameof(repo));
             Name = DisplayName = branch.FriendlyName;
-#pragma warning disable 0618 // TODO: Replace `Branch.Remote` with `Repository.Network.Remotes[branch.RemoteName]`.
-            Repository = branch.IsRemote ? new LocalRepositoryModel(branch.Remote.Url, gitService) : repo;
-#pragma warning restore 0618
+            Repository = repo;
             Sha = branch.Tip?.Sha;
             Id = String.Format(CultureInfo.InvariantCulture, "{0}/{1}", Repository.Owner, Name);
 

--- a/src/GitHub.Exports/Models/BranchModel.cs
+++ b/src/GitHub.Exports/Models/BranchModel.cs
@@ -31,12 +31,6 @@ namespace GitHub.Models
         public IRepositoryModel Repository { get; private set; }
         public string DisplayName { get; set; }
 
-        public string Sha { get; protected set; }
-        public bool IsTracking { get; protected set; }
-        public string TrackedSha { get; protected set; }
-        public UriString TrackedRemoteUrl { get; protected set; }
-        public string TrackedRemoteCanonicalName { get; protected set; }
-
         #region Equality things
         public void CopyFrom(IBranch other)
         {
@@ -46,7 +40,6 @@ namespace GitHub.Models
             Name = other.Name;
             Repository = other.Repository;
             DisplayName = other.DisplayName;
-            IsTracking = other.IsTracking;
         }
 
         public override bool Equals(object obj)

--- a/src/GitHub.Exports/Models/BranchModel.cs
+++ b/src/GitHub.Exports/Models/BranchModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using GitHub.Primitives;
 using GitHub.Services;
 
 namespace GitHub.Models
@@ -34,19 +35,29 @@ namespace GitHub.Models
 #pragma warning disable 0618 // TODO: Replace `Branch.Remote` with `Repository.Network.Remotes[branch.RemoteName]`.
             Repository = branch.IsRemote ? new LocalRepositoryModel(branch.Remote.Url, gitService) : repo;
 #pragma warning restore 0618
-            IsTracking = branch.IsTracking;
             Sha = branch.Tip?.Sha;
-            TrackedSha = branch.TrackedBranch?.Tip?.Sha;
             Id = String.Format(CultureInfo.InvariantCulture, "{0}/{1}", Repository.Owner, Name);
+
+            if(IsTracking = branch.IsTracking)
+            {
+                var trackedBranch = branch.TrackedBranch;
+                TrackedSha = trackedBranch.Tip?.Sha;
+#pragma warning disable 0618 // TODO: Replace `Branch.Remote` with `Repository.Network.Remotes[branch.RemoteName]`.
+                TrackedRemoteUrl = new UriString(trackedBranch.Remote.Url);
+#pragma warning restore 0618
+                TrackedRemoteCanonicalName = trackedBranch.UpstreamBranchCanonicalName;
+            }
         }
 
         public string Id { get; private set; }
         public string Name { get; private set; }
         public IRepositoryModel Repository { get; private set; }
-        public bool IsTracking { get; private set; }
         public string DisplayName { get; set; }
         public string Sha { get; private set; }
+        public bool IsTracking { get; private set; }
         public string TrackedSha { get; private set; }
+        public UriString TrackedRemoteUrl { get; private set; }
+        public string TrackedRemoteCanonicalName { get; private set; }
 
         #region Equality things
         public void CopyFrom(IBranch other)

--- a/src/GitHub.Exports/Models/IBranch.cs
+++ b/src/GitHub.Exports/Models/IBranch.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GitHub.Primitives;
 using GitHub.Collections;
 
 namespace GitHub.Models
@@ -11,10 +10,5 @@ namespace GitHub.Models
         string Name { get; }
         IRepositoryModel Repository { get; }
         string DisplayName { get; set; }
-        string Sha { get; }
-        bool IsTracking { get; }
-        string TrackedSha { get; }
-        UriString TrackedRemoteUrl { get; }
-        string TrackedRemoteCanonicalName { get; }
     }
 }

--- a/src/GitHub.Exports/Models/IBranch.cs
+++ b/src/GitHub.Exports/Models/IBranch.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using GitHub.Primitives;
 using GitHub.Collections;
 
 namespace GitHub.Models
@@ -9,9 +10,11 @@ namespace GitHub.Models
         string Id { get; }
         string Name { get; }
         IRepositoryModel Repository { get; }
-        bool IsTracking { get; }
         string DisplayName { get; set; }
         string Sha { get; }
+        bool IsTracking { get; }
         string TrackedSha { get; }
+        UriString TrackedRemoteUrl { get; }
+        string TrackedRemoteCanonicalName { get; }
     }
 }

--- a/src/GitHub.Exports/Models/ILocalBranch.cs
+++ b/src/GitHub.Exports/Models/ILocalBranch.cs
@@ -1,0 +1,13 @@
+﻿using GitHub.Primitives;
+
+namespace GitHub.Models
+{
+    public interface ILocalBranch : IBranch
+    {
+        string Sha { get; }
+        bool IsTracking { get; }
+        string TrackedSha { get; }
+        UriString TrackedRemoteUrl { get; }
+        string TrackedRemoteCanonicalName { get; }
+    }
+}

--- a/src/GitHub.Exports/Models/ILocalRepositoryModel.cs
+++ b/src/GitHub.Exports/Models/ILocalRepositoryModel.cs
@@ -18,7 +18,7 @@ namespace GitHub.Models
         /// <summary>
         /// Gets the current branch.
         /// </summary>
-        IBranch CurrentBranch { get; }
+        ILocalBranch CurrentBranch { get; }
 
         /// <summary>
         /// Updates the url information based on the local path

--- a/src/GitHub.Exports/Models/LocalBranchModel.cs
+++ b/src/GitHub.Exports/Models/LocalBranchModel.cs
@@ -6,18 +6,17 @@ namespace GitHub.Models
 {
     public class LocalBranchModel : BranchModel, IBranch
     {
-        public LocalBranchModel(Branch branch, IRepositoryModel repo, IGitService gitService)
+        public LocalBranchModel(IRepository repository, Branch branch, IRepositoryModel repo, IGitService gitService)
             : base(branch?.FriendlyName, repo)
         {
             Sha = branch.Tip?.Sha;
 
-            if(IsTracking = branch.IsTracking)
+            if (IsTracking = branch.IsTracking)
             {
                 var trackedBranch = branch.TrackedBranch;
                 TrackedSha = trackedBranch.Tip?.Sha;
-#pragma warning disable 0618 // TODO: Replace `Branch.Remote` with `Repository.Network.Remotes[branch.RemoteName]`.
-                TrackedRemoteUrl = new UriString(trackedBranch.Remote.Url);
-#pragma warning restore 0618
+                var trackedRemote = repository.Network.Remotes[trackedBranch.RemoteName];
+                TrackedRemoteUrl = trackedRemote != null ? new UriString(trackedRemote.Url) : null;
                 TrackedRemoteCanonicalName = trackedBranch.UpstreamBranchCanonicalName;
             }
         }

--- a/src/GitHub.Exports/Models/LocalBranchModel.cs
+++ b/src/GitHub.Exports/Models/LocalBranchModel.cs
@@ -6,7 +6,7 @@ namespace GitHub.Models
 {
     public class LocalBranchModel : BranchModel, ILocalBranch
     {
-        public LocalBranchModel(IRepository repository, Branch branch, IRepositoryModel repo, IGitService gitService)
+        public LocalBranchModel(IRepository repository, Branch branch, IRepositoryModel repo)
             : base(branch?.FriendlyName, repo)
         {
             Sha = branch.Tip?.Sha;

--- a/src/GitHub.Exports/Models/LocalBranchModel.cs
+++ b/src/GitHub.Exports/Models/LocalBranchModel.cs
@@ -4,7 +4,7 @@ using LibGit2Sharp;
 
 namespace GitHub.Models
 {
-    public class LocalBranchModel : BranchModel, IBranch
+    public class LocalBranchModel : BranchModel, ILocalBranch
     {
         public LocalBranchModel(IRepository repository, Branch branch, IRepositoryModel repo, IGitService gitService)
             : base(branch?.FriendlyName, repo)
@@ -20,5 +20,11 @@ namespace GitHub.Models
                 TrackedRemoteCanonicalName = trackedBranch.UpstreamBranchCanonicalName;
             }
         }
+
+        public string Sha { get; }
+        public bool IsTracking { get; }
+        public string TrackedSha { get; }
+        public UriString TrackedRemoteUrl { get; }
+        public string TrackedRemoteCanonicalName { get; }
     }
 }

--- a/src/GitHub.Exports/Models/LocalBranchModel.cs
+++ b/src/GitHub.Exports/Models/LocalBranchModel.cs
@@ -1,0 +1,25 @@
+﻿using GitHub.Services;
+using GitHub.Primitives;
+using LibGit2Sharp;
+
+namespace GitHub.Models
+{
+    public class LocalBranchModel : BranchModel, IBranch
+    {
+        public LocalBranchModel(Branch branch, IRepositoryModel repo, IGitService gitService)
+            : base(branch?.FriendlyName, repo)
+        {
+            Sha = branch.Tip?.Sha;
+
+            if(IsTracking = branch.IsTracking)
+            {
+                var trackedBranch = branch.TrackedBranch;
+                TrackedSha = trackedBranch.Tip?.Sha;
+#pragma warning disable 0618 // TODO: Replace `Branch.Remote` with `Repository.Network.Remotes[branch.RemoteName]`.
+                TrackedRemoteUrl = new UriString(trackedBranch.Remote.Url);
+#pragma warning restore 0618
+                TrackedRemoteCanonicalName = trackedBranch.UpstreamBranchCanonicalName;
+            }
+        }
+    }
+}

--- a/src/GitHub.Exports/Models/LocalRepositoryModel.cs
+++ b/src/GitHub.Exports/Models/LocalRepositoryModel.cs
@@ -183,7 +183,7 @@ namespace GitHub.Models
                 // BranchModel doesn't keep a reference to Repository
                 using (var repo = gitService.GetRepository(LocalPath))
                 {
-                    return new LocalBranchModel(repo?.Head, this, gitService);
+                    return new LocalBranchModel(repo, repo?.Head, this, gitService);
                 }
             }
         }

--- a/src/GitHub.Exports/Models/LocalRepositoryModel.cs
+++ b/src/GitHub.Exports/Models/LocalRepositoryModel.cs
@@ -183,7 +183,7 @@ namespace GitHub.Models
                 // BranchModel doesn't keep a reference to Repository
                 using (var repo = gitService.GetRepository(LocalPath))
                 {
-                    return new LocalBranchModel(repo, repo?.Head, this, gitService);
+                    return new LocalBranchModel(repo, repo?.Head, this);
                 }
             }
         }

--- a/src/GitHub.Exports/Models/LocalRepositoryModel.cs
+++ b/src/GitHub.Exports/Models/LocalRepositoryModel.cs
@@ -183,7 +183,7 @@ namespace GitHub.Models
                 // BranchModel doesn't keep a reference to Repository
                 using (var repo = gitService.GetRepository(LocalPath))
                 {
-                    return new BranchModel(repo?.Head, this, gitService);
+                    return new LocalBranchModel(repo?.Head, this, gitService);
                 }
             }
         }

--- a/src/GitHub.Exports/Models/LocalRepositoryModel.cs
+++ b/src/GitHub.Exports/Models/LocalRepositoryModel.cs
@@ -176,7 +176,7 @@ namespace GitHub.Models
         /// <summary>
         /// Gets the current branch of the repository.
         /// </summary>
-        public IBranch CurrentBranch
+        public ILocalBranch CurrentBranch
         {
             get
             {

--- a/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
@@ -136,11 +136,12 @@ namespace GitHub.InlineReviews.Services
         Task<byte[]> ReadFileAsync(string path);
 
         /// <summary>
-        /// Infer the PR that is most likely to be associated with the current branch.
+        /// Find the first PR (if any) associated with a ref.
         /// </summary>
-        /// <param name="repository">The local repository.</param>
+        /// <param name="repositoryUrl">The repository the ref is from.</param>
+        /// <param name="refQualifiedName">The fully qualified ref name.</param>
         /// <returns>A pull request qualifed by its target owner and number.</returns>
-        Task<Tuple<string, int>> InferPullRequestForCurrentBranch(ILocalRepositoryModel repository);
+        Task<Tuple<string, int>> FindPullRequestForRef(UriString repositoryUrl, string refQualifiedName);
 
         /// <summary>
         /// Reads a <see cref="PullRequestDetailModel"/> for a specified pull request.

--- a/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
@@ -136,6 +136,13 @@ namespace GitHub.InlineReviews.Services
         Task<byte[]> ReadFileAsync(string path);
 
         /// <summary>
+        /// Infer the PR that is most likely to be associated with the current branch.
+        /// </summary>
+        /// <param name="repository">The local repository.</param>
+        /// <returns>A pull request qualifed by its target owner and number.</returns>
+        Task<Tuple<string, int>> InferPullRequestForCurrentBranch(ILocalRepositoryModel repository);
+
+        /// <summary>
         /// Reads a <see cref="PullRequestDetailModel"/> for a specified pull request.
         /// </summary>
         /// <param name="address">The host address.</param>

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
@@ -203,6 +203,19 @@ namespace GitHub.InlineReviews.Services
                 var session = CurrentSession;
 
                 var pr = await service.GetPullRequestForCurrentBranch(repository).FirstOrDefaultAsync();
+                if(pr == null)
+                {
+                    try
+                    {
+                        // If the branch hasn't been tagged, try inferring the associated PR
+                        pr = await sessionService.InferPullRequestForCurrentBranch(repository);
+                    }
+                    catch(Exception e)
+                    {
+                        log.Error(e, nameof(sessionService.InferPullRequestForCurrentBranch));
+                    }
+                }
+
                 if (pr != null)
                 {
                     var changePR =

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
@@ -202,17 +202,23 @@ namespace GitHub.InlineReviews.Services
             {
                 var session = CurrentSession;
 
-                var pr = await service.GetPullRequestForCurrentBranch(repository).FirstOrDefaultAsync();
+
+                Tuple<string, int> pr = null;
+
+                // HACK: Don't use tagged branch info when testing.
+                // pr = await service.GetPullRequestForCurrentBranch(repository).FirstOrDefaultAsync();
+
                 if(pr == null)
                 {
                     try
                     {
                         // If the branch hasn't been tagged, try inferring the associated PR
-                        pr = await sessionService.InferPullRequestForCurrentBranch(repository);
+                        var branch = repository.CurrentBranch;
+                        pr = await sessionService.FindPullRequestForRef(branch.TrackedRemoteUrl, branch.TrackedRemoteCanonicalName);
                     }
-                    catch(Exception e)
+                    catch (Exception e)
                     {
-                        log.Error(e, nameof(sessionService.InferPullRequestForCurrentBranch));
+                        log.Error(e, nameof(sessionService.FindPullRequestForRef));
                     }
                 }
 

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
@@ -205,10 +205,10 @@ namespace GitHub.InlineReviews.Services
 
                 Tuple<string, int> pr = null;
 
-                // HACK: Don't use tagged branch info when testing.
-                // pr = await service.GetPullRequestForCurrentBranch(repository).FirstOrDefaultAsync();
+                // Use tagged branch info when available
+                 pr = await service.GetPullRequestForCurrentBranch(repository).FirstOrDefaultAsync();
 
-                if(pr == null)
+                if (pr == null)
                 {
                     try
                     {

--- a/test/UnitTests/GitHub.App/Services/TeamExplorerContextTests.cs
+++ b/test/UnitTests/GitHub.App/Services/TeamExplorerContextTests.cs
@@ -227,7 +227,7 @@ namespace GitHub.App.UnitTests.Services
         {
             var repo = Substitute.For<ILocalRepositoryModel>();
             repo.LocalPath.Returns(path);
-            var currentBranch = Substitute.For<IBranch>();
+            var currentBranch = Substitute.For<ILocalBranch>();
             currentBranch.Name.Returns(branchName);
             currentBranch.Sha.Returns(headSha);
             currentBranch.TrackedSha.Returns(trackedSha);

--- a/test/UnitTests/GitHub.App/ViewModels/Dialog/PullRequestCreationViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/Dialog/PullRequestCreationViewModelTests.cs
@@ -91,7 +91,7 @@ public class PullRequestCreationViewModelTests : TestBaseClass
         if (repoIsFork)
             githubRepoParent = CreateRepository(targetRepoOwner, repoName, id: 1);
         var githubRepo = CreateRepository(sourceRepoOwner, repoName, id: 2, parent: githubRepoParent);
-        var sourceBranch = new BranchModel(sourceBranchName, activeRepo);
+        var sourceBranch = CreateLocalBranch(sourceBranchName, activeRepo);
         var sourceRepo = new RemoteRepositoryModel(githubRepo);
         var targetRepo = targetRepoOwner == sourceRepoOwner ? sourceRepo : sourceRepo.Parent;
         var targetBranch = targetBranchName != targetRepo.DefaultBranch.Name ? new BranchModel(targetBranchName, targetRepo) : targetRepo.DefaultBranch;
@@ -208,5 +208,15 @@ public class PullRequestCreationViewModelTests : TestBaseClass
         vm.InitializeAsync(data.ActiveRepo, data.Connection).Wait();
 
         Assert.That("Test PR template", Is.EqualTo(vm.Description));
+    }
+
+    static ILocalBranch CreateLocalBranch(string sourceBranchName, ILocalRepositoryModel activeRepo)
+    {
+        var branch = Substitute.For<ILocalBranch>();
+        branch.DisplayName.Returns(sourceBranchName);
+        branch.Name.Returns(sourceBranchName);
+        branch.Id.Returns(activeRepo.Name + "/" + sourceBranchName);
+        branch.Repository.Returns(activeRepo);
+        return branch;
     }
 }

--- a/test/UnitTests/GitHub.App/ViewModels/Dialog/PullRequestCreationViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/Dialog/PullRequestCreationViewModelTests.cs
@@ -210,13 +210,13 @@ public class PullRequestCreationViewModelTests : TestBaseClass
         Assert.That("Test PR template", Is.EqualTo(vm.Description));
     }
 
-    static ILocalBranch CreateLocalBranch(string sourceBranchName, ILocalRepositoryModel activeRepo)
+    static ILocalBranch CreateLocalBranch(string sourceBranchName, ILocalRepositoryModel parentRepo)
     {
-        var branch = Substitute.For<ILocalBranch>();
-        branch.DisplayName.Returns(sourceBranchName);
-        branch.Name.Returns(sourceBranchName);
-        branch.Id.Returns(activeRepo.Name + "/" + sourceBranchName);
-        branch.Repository.Returns(activeRepo);
-        return branch;
+        var repository = Substitute.For<LibGit2Sharp.IRepository>();
+        var branch = Substitute.For<LibGit2Sharp.Branch>();
+        branch.FriendlyName.Returns(sourceBranchName);
+        branch.IsTracking.Returns(false);
+        var localBranch = new LocalBranchModel(repository, branch, parentRepo);
+        return localBranch;
     }
 }

--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModelTests.cs
@@ -613,14 +613,14 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
             };
         }
 
-        static ILocalBranch CreateLocalBranch(string sourceBranchName, ILocalRepositoryModel activeRepo)
+        static ILocalBranch CreateLocalBranch(string sourceBranchName, ILocalRepositoryModel parentRepo)
         {
-            var branch = Substitute.For<ILocalBranch>();
-            branch.DisplayName.Returns(sourceBranchName);
-            branch.Name.Returns(sourceBranchName);
-            branch.Id.Returns(activeRepo.Name + "/" + sourceBranchName);
-            branch.Repository.Returns(activeRepo);
-            return branch;
+            var repository = Substitute.For<LibGit2Sharp.IRepository>();
+            var branch = Substitute.For<LibGit2Sharp.Branch>();
+            branch.FriendlyName.Returns(sourceBranchName);
+            branch.IsTracking.Returns(false);
+            var localBranch = new LocalBranchModel(repository, branch, parentRepo);
+            return localBranch;
         }
 
         static IObservable<Unit> Throws(string message)

--- a/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModelTests.cs
+++ b/test/UnitTests/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModelTests.cs
@@ -526,7 +526,7 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
             IPullRequestSessionManager sessionManager = null)
         {
             var repository = Substitute.For<ILocalRepositoryModel>();
-            var currentBranchModel = new BranchModel(currentBranch, repository);
+            var currentBranchModel = CreateLocalBranch(currentBranch, repository);
             repository.CurrentBranch.Returns(currentBranchModel);
             repository.CloneUrl.Returns(new UriString(Uri.ToString()));
             repository.LocalPath.Returns(@"C:\projects\ThisRepo");
@@ -611,6 +611,16 @@ namespace UnitTests.GitHub.App.ViewModels.GitHubPane
                 UpdatedAt = DateTimeOffset.Now,
                 Reviews = reviews.ToList(),
             };
+        }
+
+        static ILocalBranch CreateLocalBranch(string sourceBranchName, ILocalRepositoryModel activeRepo)
+        {
+            var branch = Substitute.For<ILocalBranch>();
+            branch.DisplayName.Returns(sourceBranchName);
+            branch.Name.Returns(sourceBranchName);
+            branch.Id.Returns(activeRepo.Name + "/" + sourceBranchName);
+            branch.Repository.Returns(activeRepo);
+            return branch;
         }
 
         static IObservable<Unit> Throws(string message)


### PR DESCRIPTION
This is a spike to experiment with infering the PR associated with the current branch.

### What this PR does

- Search current and parent repos for a PR with the same HEAD branch name as the current branch

### TODO

Use `associatedPullRequests` property of `ref`.

### Findings

There can be multiple PRs that use the same branch as their HEAD. Can we could up with a conservative strategy that minimizes false positives but that still works in most cases?

For example, say a user creates a PR using their `master` branch. They probably won't want this PR associated with their `master` branch forever!

There are attributes associated with a PR that we could take into account to infer when a PR is likely stale and shouldn't be automatically associated with the current branch. For example:

- If the SHA a branch is different to the PR it might be stale
- If a PR has been closed it is likely to be of less interest to a user to an open one

Fixes #1591