### PR TITLE
Missing buttons and errors when deleting or editing a comment

### DIFF
--- a/src/GitHub.Exports.Reactive/Services/IPullRequestSession.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestSession.cs
@@ -109,12 +109,10 @@ namespace GitHub.Services
         /// Posts a PR review comment reply.
         /// </summary>
         /// <param name="body">The comment body.</param>
-        /// <param name="inReplyTo">The REST ID of the comment to reply to.</param>
         /// <param name="inReplyToNodeId">The GraphQL ID of the comment to reply to.</param>
         /// <returns>A comment model.</returns>
         Task<IPullRequestReviewCommentModel> PostReviewComment(
             string body,
-            int inReplyTo,
             string inReplyToNodeId);
 
         /// <summary>

--- a/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
@@ -261,7 +261,7 @@ namespace GitHub.InlineReviews.Services
         /// </summary>
         /// <param name="localRepository">The local repository.</param>
         /// <param name="user">The user posting the comment.</param>
-        /// <param name="pullRequestId">The pull request number.</param>
+        /// <param name="pullRequestNodeId">The pull request node id.</param>
         /// <param name="body">The comment body.</param>
         /// <param name="commitId">THe SHA of the commit to comment on.</param>
         /// <param name="path">The relative path of the file to comment on.</param>
@@ -273,7 +273,7 @@ namespace GitHub.InlineReviews.Services
         /// </remarks>
         Task<IPullRequestReviewCommentModel> PostStandaloneReviewComment(ILocalRepositoryModel localRepository,
             IAccount user,
-            int pullRequestId,
+            string pullRequestNodeId,
             string body,
             string commitId,
             string path,
@@ -284,13 +284,13 @@ namespace GitHub.InlineReviews.Services
         /// </summary>
         /// <param name="localRepository">The local repository.</param>
         /// <param name="user">The user posting the comment.</param>
-        /// <param name="pullRequestId">The pull request number.</param>
+        /// <param name="pullRequestNodeId">The pull request node id.</param>
         /// <param name="body">The comment body.</param>
         /// <param name="inReplyTo">The comment ID to reply to.</param>
         /// <returns>A model representing the posted comment.</returns>
         Task<IPullRequestReviewCommentModel> PostStandaloneReviewCommentReply(ILocalRepositoryModel localRepository,
             IAccount user,
-            int pullRequestId,
+            string pullRequestNodeId,
             string body,
             int inReplyTo);
 

--- a/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
@@ -286,13 +286,13 @@ namespace GitHub.InlineReviews.Services
         /// <param name="user">The user posting the comment.</param>
         /// <param name="pullRequestNodeId">The pull request node id.</param>
         /// <param name="body">The comment body.</param>
-        /// <param name="inReplyTo">The comment ID to reply to.</param>
+        /// <param name="inReplyToNodeId">The comment node id to reply to.</param>
         /// <returns>A model representing the posted comment.</returns>
         Task<IPullRequestReviewCommentModel> PostStandaloneReviewCommentReply(ILocalRepositoryModel localRepository,
             IAccount user,
             string pullRequestNodeId,
             string body,
-            int inReplyTo);
+            string inReplyToNodeId);
 
         /// <summary>
         /// Delete a PR review comment.

--- a/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/IPullRequestSessionService.cs
@@ -260,9 +260,8 @@ namespace GitHub.InlineReviews.Services
         /// Posts a new standalone PR review comment.
         /// </summary>
         /// <param name="localRepository">The local repository.</param>
-        /// <param name="remoteRepositoryOwner">The owner of the repository fork to post to.</param>
         /// <param name="user">The user posting the comment.</param>
-        /// <param name="number">The pull request number.</param>
+        /// <param name="pullRequestId">The pull request number.</param>
         /// <param name="body">The comment body.</param>
         /// <param name="commitId">THe SHA of the commit to comment on.</param>
         /// <param name="path">The relative path of the file to comment on.</param>
@@ -272,11 +271,9 @@ namespace GitHub.InlineReviews.Services
         /// The method posts a new standalone pull request comment that is not attached to a pending
         /// pull request review.
         /// </remarks>
-        Task<IPullRequestReviewCommentModel> PostStandaloneReviewComment(
-            ILocalRepositoryModel localRepository,
-            string remoteRepositoryOwner,
+        Task<IPullRequestReviewCommentModel> PostStandaloneReviewComment(ILocalRepositoryModel localRepository,
             IAccount user,
-            int number,
+            int pullRequestId,
             string body,
             string commitId,
             string path,
@@ -286,17 +283,14 @@ namespace GitHub.InlineReviews.Services
         /// Posts a PR review comment reply.
         /// </summary>
         /// <param name="localRepository">The local repository.</param>
-        /// <param name="remoteRepositoryOwner">The owner of the repository fork to post to.</param>
         /// <param name="user">The user posting the comment.</param>
-        /// <param name="number">The pull request number.</param>
+        /// <param name="pullRequestId">The pull request number.</param>
         /// <param name="body">The comment body.</param>
         /// <param name="inReplyTo">The comment ID to reply to.</param>
         /// <returns>A model representing the posted comment.</returns>
-        Task<IPullRequestReviewCommentModel> PostStandaloneReviewCommentReply(
-            ILocalRepositoryModel localRepository,
-            string remoteRepositoryOwner,
+        Task<IPullRequestReviewCommentModel> PostStandaloneReviewCommentReply(ILocalRepositoryModel localRepository,
             IAccount user,
-            int number,
+            int pullRequestId,
             string body,
             int inReplyTo);
 

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -200,6 +200,7 @@ namespace GitHub.InlineReviews.Services
 
             if (!HasPendingReview)
             {
+                var pullRequestNodeId = await GetPullRequestNodeId();
                 model = await service.PostStandaloneReviewCommentReply(
                     LocalRepository,
                     User,

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -194,20 +194,18 @@ namespace GitHub.InlineReviews.Services
         /// <inheritdoc/>
         public async Task<IPullRequestReviewCommentModel> PostReviewComment(
             string body,
-            int inReplyTo,
             string inReplyToNodeId)
         {
             IPullRequestReviewCommentModel model;
 
             if (!HasPendingReview)
             {
-                var pullRequestNodeId = await GetPullRequestNodeId();
                 model = await service.PostStandaloneReviewCommentReply(
                     LocalRepository,
                     User,
                     pullRequestNodeId,
                     body,
-                    inReplyTo);
+                    inReplyToNodeId);
             }
             else
             {

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -140,7 +140,6 @@ namespace GitHub.InlineReviews.Services
             {
                 model = await service.PostStandaloneReviewComment(
                     LocalRepository,
-                    RepositoryOwner,
                     User,
                     PullRequest.Number,
                     body,
@@ -203,7 +202,6 @@ namespace GitHub.InlineReviews.Services
             {
                 model = await service.PostStandaloneReviewCommentReply(
                     LocalRepository,
-                    RepositoryOwner,
                     User,
                     PullRequest.Number,
                     body,

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -138,10 +138,11 @@ namespace GitHub.InlineReviews.Services
 
             if (!HasPendingReview)
             {
+                var pullRequestNodeId = await GetPullRequestNodeId();
                 model = await service.PostStandaloneReviewComment(
                     LocalRepository,
                     User,
-                    PullRequest.Number,
+                    pullRequestNodeId,
                     body,
                     commitId,
                     path,
@@ -200,10 +201,11 @@ namespace GitHub.InlineReviews.Services
 
             if (!HasPendingReview)
             {
+                var pullRequestNodeId = await GetPullRequestNodeId();
                 model = await service.PostStandaloneReviewCommentReply(
                     LocalRepository,
                     User,
-                    PullRequest.Number,
+                    pullRequestNodeId,
                     body,
                     inReplyTo);
             }

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -529,7 +529,7 @@ namespace GitHub.InlineReviews.Services
         public async Task<IPullRequestReviewCommentModel> PostStandaloneReviewComment(
             ILocalRepositoryModel localRepository,
             IAccount user,
-            int pullRequestId,
+            string pullRequestNodeId,
             string body,
             string commitId,
             string path,
@@ -543,7 +543,7 @@ namespace GitHub.InlineReviews.Services
                 Body = body,
                 CommitOID = commitId,
                 Event = Octokit.GraphQL.Model.PullRequestReviewEvent.Comment,
-                PullRequestId = pullRequestId.ToString(),
+                PullRequestId = pullRequestNodeId,
                 Comments = new[]
                 {
                     new DraftPullRequestReviewComment
@@ -586,11 +586,11 @@ namespace GitHub.InlineReviews.Services
         public async Task<IPullRequestReviewCommentModel> PostStandaloneReviewCommentReply(
             ILocalRepositoryModel localRepository,
             IAccount user,
-            int pullRequestId,
+            string pullRequestNodeId,
             string body,
             int inReplyTo)
         {
-            var review = await CreatePendingReview(localRepository, user, pullRequestId.ToString());
+            var review = await CreatePendingReview(localRepository, user, pullRequestNodeId);
             var comment = await PostPendingReviewCommentReply(localRepository, user, review.Id.ToString(), body, inReplyTo.ToString());
             return comment;
         }

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -517,7 +517,7 @@ namespace GitHub.InlineReviews.Services
                     OriginalCommitId = x.Comment.OriginalCommit.Oid,
                     PullRequestReviewId = x.Comment.PullRequestReview.DatabaseId.Value,
                     User = user,
-                    IsPending = false,
+                    IsPending = true,
                 });
 
             var result = await graphql.Run(addComment);
@@ -593,6 +593,7 @@ namespace GitHub.InlineReviews.Services
             var review = await CreatePendingReview(localRepository, user, pullRequestNodeId);
             var comment = await PostPendingReviewCommentReply(localRepository, user, review.NodeId, body, inReplyToNodeId);
             await SubmitPendingReview(localRepository, user, review.NodeId, null, PullRequestReviewEvent.Comment);
+            comment.IsPending = false;
             return comment;
         }
 

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -574,7 +574,7 @@ namespace GitHub.InlineReviews.Services
                             OriginalCommitId = x.OriginalCommit.Oid,
                             PullRequestReviewId = x.PullRequestReview.DatabaseId.Value,
                             User = user,
-                            IsPending = true,
+                            IsPending = false
                         }));
 
             var result = (await graphql.Run(mutation)).First();
@@ -588,10 +588,11 @@ namespace GitHub.InlineReviews.Services
             IAccount user,
             string pullRequestNodeId,
             string body,
-            int inReplyTo)
+            string inReplyToNodeId)
         {
             var review = await CreatePendingReview(localRepository, user, pullRequestNodeId);
-            var comment = await PostPendingReviewCommentReply(localRepository, user, review.Id.ToString(), body, inReplyTo.ToString());
+            var comment = await PostPendingReviewCommentReply(localRepository, user, review.NodeId, body, inReplyToNodeId);
+            await SubmitPendingReview(localRepository, user, review.NodeId, null, PullRequestReviewEvent.Comment);
             return comment;
         }
 

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -517,7 +517,7 @@ namespace GitHub.InlineReviews.Services
                     OriginalCommitId = x.Comment.OriginalCommit.Oid,
                     PullRequestReviewId = x.Comment.PullRequestReview.DatabaseId.Value,
                     User = user,
-                    IsPending = true,
+                    IsPending = false,
                 });
 
             var result = await graphql.Run(addComment);

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -556,6 +556,8 @@ namespace GitHub.InlineReviews.Services
                 CommitId = result.CommitId,
                 DiffHunk = result.DiffHunk,
                 Id = result.Id,
+                //TODO: Populate this
+                NodeId = string.Empty,
                 OriginalCommitId = result.OriginalCommitId,
                 OriginalPosition = result.OriginalPosition,
                 Path = result.Path,
@@ -592,6 +594,8 @@ namespace GitHub.InlineReviews.Services
                 CommitId = result.CommitId,
                 DiffHunk = result.DiffHunk,
                 Id = result.Id,
+                //TODO: Populate this
+                NodeId = string.Empty,
                 OriginalCommitId = result.OriginalCommitId,
                 OriginalPosition = result.OriginalPosition,
                 Path = result.Path,

--- a/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
@@ -137,6 +137,7 @@ namespace GitHub.InlineReviews.ViewModels
         {
             if (state != CommentEditState.Editing)
             {
+                ErrorMessage = null;
                 undoBody = Body;
                 EditState = CommentEditState.Editing;
             }

--- a/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
@@ -24,7 +24,7 @@ namespace GitHub.InlineReviews.ViewModels
         CommentEditState state;
         DateTimeOffset updatedAt;
         string undoBody;
-        bool canDelete;
+        ObservableAsPropertyHelper<bool> canDelete;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommentViewModel"/> class.
@@ -61,13 +61,13 @@ namespace GitHub.InlineReviews.ViewModels
             User = user;
             UpdatedAt = updatedAt;
 
-            var canDelete = this.WhenAnyValue(
+            var canDeleteObservable = this.WhenAnyValue(
                 x => x.EditState,
                 x => x == CommentEditState.None && user.Login.Equals(currentUser.Login));
 
-            canDelete.ToProperty(this, x => x.CanDelete);
+            canDelete = canDeleteObservable.ToProperty(this, x => x.CanDelete);
 
-            Delete = ReactiveCommand.CreateAsyncTask(canDelete, DoDelete);
+            Delete = ReactiveCommand.CreateAsyncTask(canDeleteObservable, DoDelete);
 
             var canEdit = this.WhenAnyValue(
                 x => x.EditState,
@@ -231,8 +231,7 @@ namespace GitHub.InlineReviews.ViewModels
 
         public bool CanDelete
         {
-            get { return canDelete; }
-            private set { this.RaiseAndSetIfChanged(ref canDelete, value); }
+            get { return canDelete.Value; }
         }
 
         /// <inheritdoc/>

--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentThreadViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentThreadViewModel.cs
@@ -72,9 +72,8 @@ namespace GitHub.InlineReviews.ViewModels
             Guard.ArgumentNotNull(parameter, nameof(parameter));
 
             var body = (string)parameter;
-            var replyId = Comments[0].Id;
             var nodeId = Comments[0].NodeId;
-            return await Session.PostReviewComment(body, replyId, nodeId);
+            return await Session.PostReviewComment(body, nodeId);
         }
 
         async Task<ICommentModel> DoEditComment(object parameter)

--- a/src/GitHub.InlineReviews/Views/CommentView.xaml
+++ b/src/GitHub.InlineReviews/Views/CommentView.xaml
@@ -94,6 +94,23 @@
                                     Margin="0 2 0 0"
                                     Foreground="{DynamicResource VsBrush.WindowText}"
                                     Markdown="{Binding Body}"/>
+
+            <DockPanel Grid.Column="1" Grid.Row="2"
+                       Margin="0 4"
+                       HorizontalAlignment="Left" 
+                       TextBlock.Foreground="Red">
+                <DockPanel.Style>
+                    <Style TargetType="FrameworkElement">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding ErrorMessage}" Value="{x:Null}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </DockPanel.Style>
+                <ui:OcticonImage DockPanel.Dock="Left" Icon="alert" Margin="0 0 4 0"/>
+                <TextBlock Text="{Binding ErrorMessage}" TextWrapping="Wrap"/>
+            </DockPanel>
         </StackPanel>
 
         <!-- Displays edit view or a reply placeholder-->

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
@@ -536,14 +536,14 @@ Line 4";
                 var service = CreateService();
                 var target = CreateTarget(service, "fork", "owner", false);
 
-                await target.PostReviewComment("New Comment", 1, "node1");
+                await target.PostReviewComment("New Comment", "node1");
 
                 await service.Received(1).PostStandaloneReviewCommentReply(
                     target.LocalRepository,
                     target.User,
                     PullRequestNodeId,
                     "New Comment",
-                    1);
+                    "node1");
             }
 
             [Test]
@@ -570,7 +570,7 @@ Line 4";
                 var service = CreateService();
                 var target = CreateTarget(service, "fork", "owner", true);
 
-                await target.PostReviewComment("New Comment", 1, "node1");
+                await target.PostReviewComment("New Comment", "node1");
 
                 await service.Received(1).PostPendingReviewCommentReply(
                     target.LocalRepository,

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
@@ -20,6 +20,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
     public class PullRequestSessionTests
     {
         const int PullRequestNumber = 5;
+        const string PullRequestNodeId = "pull_request_id";
         const string RepoUrl = "https://foo.bar/owner/repo";
         const string FilePath = "test.cs";
 
@@ -514,16 +515,15 @@ Line 4";
             [Test]
             public async Task PostsToCorrectForkWithNoPendingReview()
             {
-                var service = Substitute.For<IPullRequestSessionService>();
+                var service = CreateService();
                 var target = CreateTarget(service, "fork", "owner", false);
 
                 await target.PostReviewComment("New Comment", "COMMIT_ID", "file.cs", new DiffChunk[0], 1);
 
                 await service.Received(1).PostStandaloneReviewComment(
                     target.LocalRepository,
-                    "owner",
                     target.User,
-                    PullRequestNumber,
+                    PullRequestNodeId,
                     "New Comment",
                     "COMMIT_ID",
                     "file.cs",
@@ -533,16 +533,15 @@ Line 4";
             [Test]
             public async Task PostsReplyToCorrectForkWithNoPendingReview()
             {
-                var service = Substitute.For<IPullRequestSessionService>();
+                var service = CreateService();
                 var target = CreateTarget(service, "fork", "owner", false);
 
                 await target.PostReviewComment("New Comment", 1, "node1");
 
                 await service.Received(1).PostStandaloneReviewCommentReply(
                     target.LocalRepository,
-                    "owner",
                     target.User,
-                    PullRequestNumber,
+                    PullRequestNodeId,
                     "New Comment",
                     1);
             }
@@ -550,7 +549,7 @@ Line 4";
             [Test]
             public async Task PostsToCorrectForkWithPendingReview()
             {
-                var service = Substitute.For<IPullRequestSessionService>();
+                var service = CreateService();
                 var target = CreateTarget(service, "fork", "owner", true);
 
                 await target.PostReviewComment("New Comment", "COMMIT_ID", "file.cs", new DiffChunk[0], 1);
@@ -568,7 +567,7 @@ Line 4";
             [Test]
             public async Task PostsReplyToCorrectForkWithPendingReview()
             {
-                var service = Substitute.For<IPullRequestSessionService>();
+                var service = CreateService();
                 var target = CreateTarget(service, "fork", "owner", true);
 
                 await target.PostReviewComment("New Comment", 1, "node1");
@@ -579,6 +578,16 @@ Line 4";
                     "pendingReviewId",
                     "New Comment",
                     "node1");
+            }
+
+            static IPullRequestSessionService CreateService()
+            {
+                var service = Substitute.For<IPullRequestSessionService>();
+
+                service.GetGraphQLPullRequestId(Arg.Any<ILocalRepositoryModel>(), Arg.Any<string>(), Arg.Any<int>())
+                    .Returns(PullRequestNodeId);
+
+                return service;
             }
 
             PullRequestSession CreateTarget(

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentPeekViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentPeekViewModelTests.cs
@@ -210,7 +210,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             Assert.That(2, Is.EqualTo(target.Thread.Comments.Count));
 
-            sessionManager.CurrentSession.PostReviewComment(null, 0, null)
+            sessionManager.CurrentSession.PostReviewComment(null, null)
                 .ReturnsForAnyArgs(async x =>
                 {
                     var file = await sessionManager.GetLiveFile(

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentThreadViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentThreadViewModelTests.cs
@@ -65,7 +65,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             target.Comments[2].Body = "New Comment";
             target.Comments[2].CommitEdit.Execute(null);
 
-            session.Received(1).PostReviewComment("New Comment", 1, "node1");
+            session.Received(1).PostReviewComment("New Comment", "node1");
         }
 
         IApiClient CreateApiClient()


### PR DESCRIPTION
- Correctly utilizing an ObservableAsPropertyHelper
  - As part of a last minute fix to #1701 I attempted to use `ToProperty` but I completely failed on the follow through.
- Standalone comments made by the rest api do not return a node Id, the lack of this data results in the deletion or editing of standalone comments fail in error, in some cases.
  - We need to use Graphql to make standalone comments. In order to fix that some code from #1712 was ported over