### PR TITLE
Commenting out the edit/delete functionality from the view

### DIFF
--- a/src/GitHub.InlineReviews/Views/CommentView.xaml
+++ b/src/GitHub.InlineReviews/Views/CommentView.xaml
@@ -71,6 +71,7 @@
                 </Border>
               </StackPanel>
 
+              <!--
               <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right"
                           Visibility="{Binding CanDelete, Converter={ui:BooleanToVisibilityConverter}}">
                 <ui:OcticonButton Command="{Binding BeginEdit}"
@@ -88,6 +89,7 @@
                                   Foreground="{DynamicResource GitHubVsToolWindowText}"
                                   Icon="x"/>
               </StackPanel>
+              -->
             </DockPanel>
 
             <markdig:MarkdownViewer Grid.Column="1" Grid.Row="1" 

--- a/src/GitHub.InlineReviews/Views/CommentView.xaml
+++ b/src/GitHub.InlineReviews/Views/CommentView.xaml
@@ -71,7 +71,11 @@
                 </Border>
               </StackPanel>
 
-              <!--
+              <!-- 
+                Temporarily removed because the REST API doesn't yet support deleting pending comments
+                and there's no GraphQL API for deleting comments at all. Can re-enable once the REST API
+                is fixed.
+                
               <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right"
                           Visibility="{Binding CanDelete, Converter={ui:BooleanToVisibilityConverter}}">
                 <ui:OcticonButton Command="{Binding BeginEdit}"


### PR DESCRIPTION
Due to an issue where pending review comments cannot be deleted using the GitHub REST API, we are disabling the functionality until we have a proper API to perform the function.