### PR TITLE
Trim project references to GitHub.VisualStudio

### DIFF
--- a/test/GitHub.Api.UnitTests/GitHub.Api.UnitTests.csproj
+++ b/test/GitHub.Api.UnitTests/GitHub.Api.UnitTests.csproj
@@ -113,10 +113,6 @@
       <Project>{7f5ed78b-74a3-4406-a299-70cfb5885b8b}</Project>
       <Name>GitHub.InlineReviews</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.VisualStudio\GitHub.VisualStudio.csproj">
-      <Project>{11569514-5ae5-4b5b-92a2-f10b0967de5f}</Project>
-      <Name>GitHub.VisualStudio</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/test/GitHub.Api.UnitTests/SimpleApiClientFactoryTests.cs
+++ b/test/GitHub.Api.UnitTests/SimpleApiClientFactoryTests.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using GitHub.Api;
 using GitHub.Primitives;
 using GitHub.Services;
-using GitHub.VisualStudio;
+using GitHub.Models;
 using NSubstitute;
 using Octokit;
 using NUnit.Framework;
@@ -16,7 +16,7 @@ public class SimpleApiClientFactoryTests
         public async Task CreatesNewInstanceOfSimpleApiClient()
         {
             const string url = "https://github.com/github/CreatesNewInstanceOfSimpleApiClient";
-            var program = new Program();
+            var program = Substitute.For<IProgram>();
             var keychain = Substitute.For<IKeychain>();
             var enterpriseProbe = Substitute.For<IEnterpriseProbe>();
             var wikiProbe = Substitute.For<IWikiProbe>();
@@ -30,7 +30,7 @@ public class SimpleApiClientFactoryTests
 
             Assert.That(url, Is.EqualTo(client.OriginalUrl));
             Assert.That(HostAddress.GitHubDotComHostAddress, Is.EqualTo(client.HostAddress));
-            Assert.That(client,Is.SameAs(await factory.Create(url))); // Tests caching.
+            Assert.That(client, Is.SameAs(await factory.Create(url))); // Tests caching.
         }
     }
 
@@ -40,7 +40,7 @@ public class SimpleApiClientFactoryTests
         public async Task RemovesClientFromCache()
         {
             const string url = "https://github.com/github/RemovesClientFromCache";
-            var program = new Program();
+            var program = Substitute.For<IProgram>();
             var enterpriseProbe = Substitute.For<IEnterpriseProbe>();
             var wikiProbe = Substitute.For<IWikiProbe>();
             var factory = new SimpleApiClientFactory(

--- a/test/GitHub.Api.UnitTests/SimpleApiClientFactoryTests.cs
+++ b/test/GitHub.Api.UnitTests/SimpleApiClientFactoryTests.cs
@@ -16,7 +16,7 @@ public class SimpleApiClientFactoryTests
         public async Task CreatesNewInstanceOfSimpleApiClient()
         {
             const string url = "https://github.com/github/CreatesNewInstanceOfSimpleApiClient";
-            var program = Substitute.For<IProgram>();
+            var program = CreateProgram();
             var keychain = Substitute.For<IKeychain>();
             var enterpriseProbe = Substitute.For<IEnterpriseProbe>();
             var wikiProbe = Substitute.For<IWikiProbe>();
@@ -40,7 +40,7 @@ public class SimpleApiClientFactoryTests
         public async Task RemovesClientFromCache()
         {
             const string url = "https://github.com/github/RemovesClientFromCache";
-            var program = Substitute.For<IProgram>();
+            var program = CreateProgram();
             var enterpriseProbe = Substitute.For<IEnterpriseProbe>();
             var wikiProbe = Substitute.For<IWikiProbe>();
             var factory = new SimpleApiClientFactory(
@@ -54,6 +54,13 @@ public class SimpleApiClientFactoryTests
 
             Assert.That(client, Is.Not.SameAs(factory.Create(url)));
         }
+    }
+
+    static IProgram CreateProgram()
+    {
+        var program = Substitute.For<IProgram>();
+        program.ProductHeader.Returns(new ProductHeaderValue("ProductName"));
+        return program;
     }
 
     static IKeychain CreateKeychain()

--- a/test/GitHub.Exports.Reactive.UnitTests/GitHub.Exports.Reactive.UnitTests.csproj
+++ b/test/GitHub.Exports.Reactive.UnitTests/GitHub.Exports.Reactive.UnitTests.csproj
@@ -203,10 +203,6 @@
       <Project>{9AEA02DB-02B5-409C-B0CA-115D05331A6B}</Project>
       <Name>GitHub.Exports</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.InlineReviews\GitHub.InlineReviews.csproj">
-      <Project>{7f5ed78b-74a3-4406-a299-70cfb5885b8b}</Project>
-      <Name>GitHub.InlineReviews</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/GitHub.Exports.Reactive.UnitTests/GitHub.Exports.Reactive.UnitTests.csproj
+++ b/test/GitHub.Exports.Reactive.UnitTests/GitHub.Exports.Reactive.UnitTests.csproj
@@ -207,10 +207,6 @@
       <Project>{7f5ed78b-74a3-4406-a299-70cfb5885b8b}</Project>
       <Name>GitHub.InlineReviews</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.VisualStudio\GitHub.VisualStudio.csproj">
-      <Project>{11569514-5ae5-4b5b-92a2-f10b0967de5f}</Project>
-      <Name>GitHub.VisualStudio</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/GitHub.Exports.UnitTests/GitHub.Exports.UnitTests.csproj
+++ b/test/GitHub.Exports.UnitTests/GitHub.Exports.UnitTests.csproj
@@ -188,10 +188,6 @@
       <Project>{252ce1c2-027a-4445-a3c2-e4d6c80a935a}</Project>
       <Name>Splat-Net45</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.Api\GitHub.Api.csproj">
-      <Project>{b389adaf-62cc-486e-85b4-2d8b078df763}</Project>
-      <Name>GitHub.Api</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\GitHub.App\GitHub.App.csproj">
       <Project>{1A1DA411-8D1F-4578-80A6-04576BEA2DC5}</Project>
       <Name>GitHub.App</Name>

--- a/test/GitHub.Extensions.UnitTests/GitHub.Extensions.UnitTests.csproj
+++ b/test/GitHub.Extensions.UnitTests/GitHub.Extensions.UnitTests.csproj
@@ -109,10 +109,6 @@
       <Project>{7f5ed78b-74a3-4406-a299-70cfb5885b8b}</Project>
       <Name>GitHub.InlineReviews</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.VisualStudio\GitHub.VisualStudio.csproj">
-      <Project>{11569514-5ae5-4b5b-92a2-f10b0967de5f}</Project>
-      <Name>GitHub.VisualStudio</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/test/GitHub.Extensions.UnitTests/GitHub.Extensions.UnitTests.csproj
+++ b/test/GitHub.Extensions.UnitTests/GitHub.Extensions.UnitTests.csproj
@@ -97,17 +97,9 @@
       <Project>{252ce1c2-027a-4445-a3c2-e4d6c80a935a}</Project>
       <Name>Splat-Net45</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.App\GitHub.App.csproj">
-      <Project>{1A1DA411-8D1F-4578-80A6-04576BEA2DC5}</Project>
-      <Name>GitHub.App</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\GitHub.Extensions\GitHub.Extensions.csproj">
       <Project>{6afe2e2d-6db0-4430-a2ea-f5f5388d2f78}</Project>
       <Name>GitHub.Extensions</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.InlineReviews\GitHub.InlineReviews.csproj">
-      <Project>{7f5ed78b-74a3-4406-a299-70cfb5885b8b}</Project>
-      <Name>GitHub.InlineReviews</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/GitHub.Primitives.UnitTests/GitHub.Primitives.UnitTests.csproj
+++ b/test/GitHub.Primitives.UnitTests/GitHub.Primitives.UnitTests.csproj
@@ -101,10 +101,6 @@
       <Project>{7f5ed78b-74a3-4406-a299-70cfb5885b8b}</Project>
       <Name>GitHub.InlineReviews</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.VisualStudio\GitHub.VisualStudio.csproj">
-      <Project>{11569514-5ae5-4b5b-92a2-f10b0967de5f}</Project>
-      <Name>GitHub.VisualStudio</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/test/GitHub.Primitives.UnitTests/GitHub.Primitives.UnitTests.csproj
+++ b/test/GitHub.Primitives.UnitTests/GitHub.Primitives.UnitTests.csproj
@@ -41,40 +41,14 @@
       <HintPath>..\..\packages\LibGit2Sharp.0.23.1\lib\net40\LibGit2Sharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Reactive.Testing, Version=2.2.5.0, Culture=neutral, PublicKeyToken=62aa029873c516b4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Testing.2.2.5-custom\lib\net45\Microsoft.Reactive.Testing.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=62aa029873c516b4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Core.2.2.5-custom\lib\net45\System.Reactive.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=62aa029873c516b4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Interfaces.2.2.5-custom\lib\net45\System.Reactive.Interfaces.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=62aa029873c516b4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-Linq.2.2.5-custom\lib\net45\System.Reactive.Linq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=62aa029873c516b4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-PlatformServices.2.2.5-custom\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reactive.Windows.Threading, Version=2.2.5.0, Culture=neutral, PublicKeyToken=62aa029873c516b4, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Rx-XAML.2.2.5-custom\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Helpers\SplatModeDetectorSetUp.cs">
@@ -96,10 +70,6 @@
     <ProjectReference Include="..\..\src\GitHub.Exports\GitHub.Exports.csproj">
       <Project>{9AEA02DB-02B5-409C-B0CA-115D05331A6B}</Project>
       <Name>GitHub.Exports</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.InlineReviews\GitHub.InlineReviews.csproj">
-      <Project>{7f5ed78b-74a3-4406-a299-70cfb5885b8b}</Project>
-      <Name>GitHub.InlineReviews</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/GitHub.Primitives.UnitTests/packages.config
+++ b/test/GitHub.Primitives.UnitTests/packages.config
@@ -3,11 +3,4 @@
   <package id="LibGit2Sharp" version="0.23.1" targetFramework="net461" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.164" targetFramework="net461" />
   <package id="NUnit" version="3.9.0" targetFramework="net461" />
-  <package id="Rx-Core" version="2.2.5-custom" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.5-custom" targetFramework="net45" />
-  <package id="Rx-Linq" version="2.2.5-custom" targetFramework="net45" />
-  <package id="Rx-Main" version="2.2.5-custom" targetFramework="net45" />
-  <package id="Rx-PlatformServices" version="2.2.5-custom" targetFramework="net45" />
-  <package id="Rx-Testing" version="2.2.5-custom" targetFramework="net45" />
-  <package id="Rx-XAML" version="2.2.5-custom" targetFramework="net45" />
 </packages>

--- a/test/GitHub.TeamFoundation.UnitTests/GitHub.TeamFoundation.UnitTests.csproj
+++ b/test/GitHub.TeamFoundation.UnitTests/GitHub.TeamFoundation.UnitTests.csproj
@@ -191,10 +191,6 @@
       <Project>{9AEA02DB-02B5-409C-B0CA-115D05331A6B}</Project>
       <Name>GitHub.Exports</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.InlineReviews\GitHub.InlineReviews.csproj">
-      <Project>{7f5ed78b-74a3-4406-a299-70cfb5885b8b}</Project>
-      <Name>GitHub.InlineReviews</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\GitHub.TeamFoundation.14\GitHub.TeamFoundation.14.csproj">
       <Project>{161DBF01-1DBF-4B00-8551-C5C00F26720D}</Project>
       <Name>GitHub.TeamFoundation.14</Name>

--- a/test/GitHub.TeamFoundation.UnitTests/GitHub.TeamFoundation.UnitTests.csproj
+++ b/test/GitHub.TeamFoundation.UnitTests/GitHub.TeamFoundation.UnitTests.csproj
@@ -199,10 +199,6 @@
       <Project>{161DBF01-1DBF-4B00-8551-C5C00F26720D}</Project>
       <Name>GitHub.TeamFoundation.14</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.VisualStudio\GitHub.VisualStudio.csproj">
-      <Project>{11569514-5ae5-4b5b-92a2-f10b0967de5f}</Project>
-      <Name>GitHub.VisualStudio</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/test/GitHub.UI.UnitTests/GitHub.UI.UnitTests.csproj
+++ b/test/GitHub.UI.UnitTests/GitHub.UI.UnitTests.csproj
@@ -77,6 +77,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\GitHub.VisualStudio.UI\GitHub.VisualStudio.UI.csproj">
+      <Project>{d1dfbb0c-b570-4302-8f1e-2e3a19c41961}</Project>
+      <Name>GitHub.VisualStudio.UI</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\submodules\octokit.net\Octokit\Octokit.csproj">
       <Project>{08dd4305-7787-4823-a53f-4d0f725a07f3}</Project>
       <Name>Octokit</Name>

--- a/test/GitHub.UI.UnitTests/GitHub.UI.UnitTests.csproj
+++ b/test/GitHub.UI.UnitTests/GitHub.UI.UnitTests.csproj
@@ -93,10 +93,6 @@
       <Project>{346384dd-2445-4a28-af22-b45f3957bd89}</Project>
       <Name>GitHub.UI</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.VisualStudio\GitHub.VisualStudio.csproj">
-      <Project>{11569514-5ae5-4b5b-92a2-f10b0967de5f}</Project>
-      <Name>GitHub.VisualStudio</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Page Include="Helpers\SharedDictionary.xaml">

--- a/test/GitHub.VisualStudio.UnitTests/GitHub.VisualStudio.UnitTests.csproj
+++ b/test/GitHub.VisualStudio.UnitTests/GitHub.VisualStudio.UnitTests.csproj
@@ -243,10 +243,6 @@
       <Project>{9AEA02DB-02B5-409C-B0CA-115D05331A6B}</Project>
       <Name>GitHub.Exports</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\GitHub.InlineReviews\GitHub.InlineReviews.csproj">
-      <Project>{7f5ed78b-74a3-4406-a299-70cfb5885b8b}</Project>
-      <Name>GitHub.InlineReviews</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\GitHub.Extensions\GitHub.Extensions.csproj">
       <Project>{6afe2e2d-6db0-4430-a2ea-f5f5388d2f78}</Project>
       <Name>GitHub.Extensions</Name>


### PR DESCRIPTION
### What this PR does

- Remote test project references to `GitHub.VisualStudio` (except `GitHub.VisualStudio.UnitTests`
- Remote test project references to `GitHub.InlineReviews` (except `GitHub.InlineReviews.UnitTests`
- Remove `GitHub.Primitives.UnitTests` references to `System.Reactive.*`
- Substitute for `Program` from the `GitHub.VisualStudio` assembly

This should speed up unit testing a bunch! 🎉 