### PR TITLE
PR list polish: Move comment count to the right 

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
@@ -77,7 +77,7 @@
                     Opacity="0.5">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition MinWidth="35" Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <TextBlock Grid.Column="0">
                     <Run Text="{Binding Number, Mode=OneWay, StringFormat=#{0}}"/>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
@@ -72,21 +72,24 @@
                        Text="{Binding Title}"
                        TextTrimming="CharacterEllipsis"/>
 
-            <StackPanel DockPanel.Dock="Top"
+            <Grid DockPanel.Dock="Top"
                     Margin="0,2,5,0"
-                    Orientation="Horizontal"
                     Opacity="0.5">
-                <TextBlock>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0">
                     <Run Text="{Binding Number, Mode=OneWay, StringFormat=#{0}}"/>
                     <Run Text="{Binding UpdatedAt, Converter={ghfvs:DurationToStringConverter}, Mode=OneWay}"/>
                     by
                     <Run Text="{Binding Author.Login, Mode=OneWay}"/>
                 </TextBlock>
-                <TextBlock Margin="4 0" Visibility="{Binding CommentCount, Converter={ghfvs:CountToVisibilityConverter}}">
-                <ghfvs:OcticonImage Icon="comment" Width="16" Height="16" Margin="0 0 0 -4"/>
-                <Run Text="{Binding CommentCount, Mode=OneWay}" BaselineAlignment="Top"/>
+                <TextBlock Grid.Column="1" Margin="4 0" HorizontalAlignment="Right" Visibility="{Binding CommentCount, Converter={ghfvs:CountToVisibilityConverter}}">
+                    <ghfvs:OcticonImage Icon="comment" Width="16" Height="16" Margin="0 0 0 -4"/>
+                    <Run Text="{Binding CommentCount, Mode=OneWay}" BaselineAlignment="Top" />
                 </TextBlock>
-            </StackPanel>
+            </Grid>
         </DockPanel>
     </Grid>
 </UserControl>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
@@ -58,12 +58,14 @@
                                    Height="30"
                                    VerticalAlignment="Top"/>
 
+            <!--
             <ghfvs:OcticonImage DockPanel.Dock="Right"
                                 Background="Transparent"
                                 Icon="git_pull_request"
                                 ToolTip="This is the current branch"
                                 VerticalAlignment="Stretch"
                                 Visibility="{Binding IsCurrent, Converter={ghfvs:BooleanToVisibilityConverter}}"/>
+                                -->
 
             <TextBlock DockPanel.Dock="Top"
                        Margin="0,-1,5,0"

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
@@ -69,9 +69,19 @@
 
             <TextBlock DockPanel.Dock="Top"
                        Margin="0,-1,5,0"
-                       Text="{Binding Title}"
-                       TextTrimming="CharacterEllipsis"/>
+                       TextTrimming="CharacterEllipsis">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsCurrent, Converter={ghfvs:BooleanToVisibilityConverter}, Mode=OneWay}" Value="True">
+                                <Setter Property="FontWeight" Value="Bold" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
 
+                <Run Text="{Binding Title}" />
+            </TextBlock>
             <Grid DockPanel.Dock="Top"
                     Margin="0,2,5,0"
                     Opacity="0.5">

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
@@ -58,30 +58,10 @@
                                    Height="30"
                                    VerticalAlignment="Top"/>
 
-            <!--
-            <ghfvs:OcticonImage DockPanel.Dock="Right"
-                                Background="Transparent"
-                                Icon="git_pull_request"
-                                ToolTip="This is the current branch"
-                                VerticalAlignment="Stretch"
-                                Visibility="{Binding IsCurrent, Converter={ghfvs:BooleanToVisibilityConverter}}"/>
-                                -->
-
             <TextBlock DockPanel.Dock="Top"
                        Margin="0,-1,5,0"
-                       TextTrimming="CharacterEllipsis">
-                <TextBlock.Style>
-                    <Style TargetType="TextBlock">
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsCurrent, Converter={ghfvs:BooleanToVisibilityConverter}, Mode=OneWay}" Value="True">
-                                <Setter Property="FontWeight" Value="Bold" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </TextBlock.Style>
-
-                <Run Text="{Binding Title}" />
-            </TextBlock>
+                       TextTrimming="CharacterEllipsis"
+                       Text="{Binding Title}" />
             <Grid DockPanel.Dock="Top"
                     Margin="0,2,5,0"
                     Opacity="0.5">

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
@@ -85,9 +85,9 @@
                     by
                     <Run Text="{Binding Author.Login, Mode=OneWay}"/>
                 </TextBlock>
-                <TextBlock Grid.Column="1" Margin="4 0" HorizontalAlignment="Right" Visibility="{Binding CommentCount, Converter={ghfvs:CountToVisibilityConverter}}">
-                    <ghfvs:OcticonImage Icon="comment" Width="16" Height="16" Margin="0 0 0 -4"/>
-                    <Run Text="{Binding CommentCount, Mode=OneWay}" BaselineAlignment="Top" />
+                <TextBlock Grid.Column="1" Margin="4 0" Visibility="{Binding CommentCount, Converter={ghfvs:CountToVisibilityConverter}}">
+                    <ghfvs:OcticonImage Icon="comment" Width="12" Height="12" Margin="0 0 0 -2"/>
+                    <Run Text="{Binding CommentCount, Mode=OneWay}" BaselineAlignment="Bottom"/>
                 </TextBlock>
             </Grid>
         </DockPanel>


### PR DESCRIPTION
_(Targets @grokys's `refactor/pr-list` branch (https://github.com/github/VisualStudio/pull/1737) but wanted to open this separately for discussion)_

The goal of this change is to make the information a little more scannable by having the comment counts of each pull request be vertically aligned. A way to test my attempt is to scan down the list of pull requests, be able to identify which ones have comments, and know which ones have a high level of activity/discussion.

 **Before:**

<img width="342" alt="screen shot 2018-06-29 at 10 09 59 am" src="https://user-images.githubusercontent.com/1174461/42105809-a3bceeb0-7b86-11e8-9056-59f68042248a.png">

 **After:**

<img width="342" alt="screen shot 2018-06-29 at 10 08 48 am" src="https://user-images.githubusercontent.com/1174461/42105830-b0dfed36-7b86-11e8-87e8-98a34696fda2.png">

/cc @simurai for 👀 and 💭(if you have any! 😄) 