### PR TITLE
Fix standalone comment replies

### DIFF
--- a/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
+++ b/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
@@ -405,6 +405,9 @@
       <HintPath>..\..\packages\Rx-PlatformServices.2.2.5-custom\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -756,7 +756,6 @@ namespace GitHub.InlineReviews.Services
                     if (commentsByReplyId.TryGetValue(comment.ReplyTo, out thread))
                     {
                         thread.Add(comment);
-                        break;
                     }
                 }
             }

--- a/src/GitHub.InlineReviews/packages.config
+++ b/src/GitHub.InlineReviews/packages.config
@@ -42,6 +42,7 @@
   <package id="Rx-PlatformServices" version="2.2.5-custom" targetFramework="net461" />
   <package id="Serilog" version="2.5.0" targetFramework="net461" />
   <package id="SerilogAnalyzer" version="0.12.0.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
   <package id="VSSDK.ComponentModelHost" version="12.0.4" targetFramework="net461" />
   <package id="VSSDK.IDE.12" version="12.0.4" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
#1712 broke a couple of things with inline comments:

- It was using the pull request ID as a review ID, which obviously doesn't work. Added a `CreatePendingReviewCore` method which both `CreatePendingReview` and `PostStandaloneReviewCommentReply` can use, which exposes the info needed by both methods.
- It was breaking out of the loop to create threads after a single reply. D'oh. Not sure how that got there.

## Testing

Previously, leaving standalone comment replies didn't work. Should now work.