### PR TITLE
Show errors in PR list.

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
@@ -126,6 +126,7 @@ namespace GitHub.ViewModels.GitHubPane
             LocalRepository = repository;
             SelectedState = States.FirstOrDefault();
             AuthorFilter = new UserFilterViewModel(LoadAuthors);
+            IsLoading = true;
 
             var parent = await repositoryService.FindParent(
                 HostAddress.Create(repository.CloneUrl),
@@ -159,7 +160,6 @@ namespace GitHub.ViewModels.GitHubPane
                 AuthorFilter.WhenAnyValue(x => x.Selected).Skip(1).SelectUnit())
                 .Subscribe(_ => FilterChanged());
 
-            IsLoading = true;
             await Refresh();
         }
 

--- a/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
@@ -9,10 +9,12 @@ using System.Threading.Tasks;
 using GitHub.Collections;
 using GitHub.Extensions;
 using GitHub.Extensions.Reactive;
+using GitHub.Logging;
 using GitHub.Models;
 using GitHub.Primitives;
 using GitHub.Services;
 using ReactiveUI;
+using Serilog;
 
 namespace GitHub.ViewModels.GitHubPane
 {
@@ -21,6 +23,7 @@ namespace GitHub.ViewModels.GitHubPane
     /// </summary>
     public abstract class IssueListViewModelBase : PanePageViewModelBase, IIssueListViewModelBase
     {
+        static readonly ILogger log = LogManager.ForContext<GitHubPaneViewModel>();
         readonly IRepositoryService repositoryService;
         IReadOnlyList<IIssueListItemViewModelBase> items;
         ICollectionView itemsView;
@@ -123,44 +126,53 @@ namespace GitHub.ViewModels.GitHubPane
         /// <inheritdoc/>
         public async Task InitializeAsync(ILocalRepositoryModel repository, IConnection connection)
         {
-            LocalRepository = repository;
-            SelectedState = States.FirstOrDefault();
-            AuthorFilter = new UserFilterViewModel(LoadAuthors);
-            IsLoading = true;
-
-            var parent = await repositoryService.FindParent(
-                HostAddress.Create(repository.CloneUrl),
-                repository.Owner,
-                repository.Name);
-
-            if (parent == null)
+            try
             {
-                RemoteRepository = repository;
-            }
-            else
-            {
-                // TODO: Handle forks with different names.
-                RemoteRepository = new RepositoryModel(
-                    repository.Name,
-                    UriString.ToUriString(repository.CloneUrl.ToRepositoryUrl(parent.Value.owner)));
+                LocalRepository = repository;
+                SelectedState = States.FirstOrDefault();
+                AuthorFilter = new UserFilterViewModel(LoadAuthors);
+                IsLoading = true;
 
-                Forks = new IRepositoryModel[]
+                var parent = await repositoryService.FindParent(
+                    HostAddress.Create(repository.CloneUrl),
+                    repository.Owner,
+                    repository.Name);
+
+                if (parent == null)
                 {
+                    RemoteRepository = repository;
+                }
+                else
+                {
+                    // TODO: Handle forks with different names.
+                    RemoteRepository = new RepositoryModel(
+                        repository.Name,
+                        UriString.ToUriString(repository.CloneUrl.ToRepositoryUrl(parent.Value.owner)));
+
+                    Forks = new IRepositoryModel[]
+                    {
                     RemoteRepository,
                     repository,
-                };
+                    };
+                }
+
+                this.WhenAnyValue(x => x.SelectedState, x => x.RemoteRepository)
+                    .Skip(1)
+                    .Subscribe(_ => Refresh().Forget());
+
+                Observable.Merge(
+                    this.WhenAnyValue(x => x.SearchQuery).Skip(1).SelectUnit(),
+                    AuthorFilter.WhenAnyValue(x => x.Selected).Skip(1).SelectUnit())
+                    .Subscribe(_ => FilterChanged());
+
+                await Refresh();
             }
-
-            this.WhenAnyValue(x => x.SelectedState, x => x.RemoteRepository)
-                .Skip(1)
-                .Subscribe(_ => Refresh().Forget());
-
-            Observable.Merge(
-                this.WhenAnyValue(x => x.SearchQuery).Skip(1).SelectUnit(),
-                AuthorFilter.WhenAnyValue(x => x.Selected).Skip(1).SelectUnit())
-                .Subscribe(_ => FilterChanged());
-
-            await Refresh();
+            catch (Exception ex)
+            {
+                Error = ex;
+                IsLoading = false;
+                log.Error(ex, "Error initializing IssueListViewModelBase");
+            }
         }
 
         /// <summary>
@@ -169,6 +181,12 @@ namespace GitHub.ViewModels.GitHubPane
         /// <returns>A task tracking the operation.</returns>
         public override Task Refresh()
         {
+            if (RemoteRepository == null)
+            {
+                // If an exception occurred reading the parent repository, do nothing.
+                return Task.CompletedTask;
+            }
+
             subscription?.Dispose();
 
             var dispose = new CompositeDisposable();


### PR DESCRIPTION
When an error occurs initializing the PR list (because for example a repository could not be found), handle the error correctly and display an error message. Previously was displaying an empty broken list.

## Testing

Alter the clone URL for a repository to a repository that does not exist. Previously showed a broken PR list, should now show an error.