### PR TITLE
Make PR list handle errors more gracefully.

### DIFF
--- a/src/GitHub.App/Collections/SequentialListSource.cs
+++ b/src/GitHub.App/Collections/SequentialListSource.cs
@@ -155,7 +155,9 @@ namespace GitHub.Collections
 
                 if (pageLoaded.IsCompleted)
                 {
-                    return pages[pageNumber];
+                    // A previous waiting task may have already returned the page. If so, return null.
+                    pages.TryGetValue(pageNumber, out var result);
+                    return result;
                 }
             }
 

--- a/src/GitHub.App/Collections/SequentialListSource.cs
+++ b/src/GitHub.App/Collections/SequentialListSource.cs
@@ -182,13 +182,18 @@ namespace GitHub.Collections
         {
             OnBeginLoading();
 
-            while (nextPage <= loadTo && !disposed)
+            try
             {
-                await LoadNextPage().ConfigureAwait(false);
-                PageLoaded?.Invoke(this, EventArgs.Empty);
+                while (nextPage <= loadTo && !disposed)
+                {
+                    await LoadNextPage().ConfigureAwait(false);
+                    PageLoaded?.Invoke(this, EventArgs.Empty);
+                }
             }
-
-            OnEndLoading();
+            finally
+            {
+                OnEndLoading();
+            }
         }
 
         async Task LoadNextPage()

--- a/src/GitHub.App/Collections/SequentialListSource.cs
+++ b/src/GitHub.App/Collections/SequentialListSource.cs
@@ -146,7 +146,12 @@ namespace GitHub.Collections
                     }
                 }
 
-                await Task.WhenAny(loading, pageLoaded).ConfigureAwait(false);
+                var completed = await Task.WhenAny(loading, pageLoaded).ConfigureAwait(false);
+
+                if (completed.IsFaulted)
+                {
+                    throw completed.Exception;
+                }
 
                 if (pageLoaded.IsCompleted)
                 {

--- a/src/GitHub.App/Collections/VirtualizingList.cs
+++ b/src/GitHub.App/Collections/VirtualizingList.cs
@@ -206,6 +206,7 @@ namespace GitHub.Collections
             catch (Exception ex)
             {
                 log.Error(ex, "Error loading virtualizing list page {Number}", number);
+                pages.Remove(number);
             }
         }
 

--- a/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
@@ -126,6 +126,7 @@ namespace GitHub.ViewModels.GitHubPane
             LocalRepository = repository;
             SelectedState = States.FirstOrDefault();
             AuthorFilter = new UserFilterViewModel(LoadAuthors);
+            IsLoading = true;
 
             var parent = await repositoryService.FindParent(
                 HostAddress.Create(repository.CloneUrl),
@@ -159,7 +160,6 @@ namespace GitHub.ViewModels.GitHubPane
                 AuthorFilter.WhenAnyValue(x => x.Selected).Skip(1).SelectUnit())
                 .Subscribe(_ => FilterChanged());
 
-            IsLoading = true;
             await Refresh();
         }
 

--- a/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
@@ -197,6 +198,7 @@ namespace GitHub.ViewModels.GitHubPane
             view.Filter = FilterItem;
             Items = items;
             ItemsView = view;
+            Error = null;
 
             dispose.Add(itemSource);
             dispose.Add(
@@ -208,6 +210,11 @@ namespace GitHub.ViewModels.GitHubPane
                     this.WhenAnyValue(x => x.AuthorFilter.Selected),
                     (loading, count, _, __, ___) => Tuple.Create(loading, count))
                 .Subscribe(x => UpdateState(x.Item1, x.Item2)));
+            dispose.Add(
+                Observable.FromEventPattern<ErrorEventArgs>(
+                    x => items.InitializationError += x,
+                    x => items.InitializationError -= x)
+                .Subscribe(x => Error = x.EventArgs.GetException()));
             subscription = dispose;
 
             return Task.CompletedTask;

--- a/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
@@ -9,10 +9,12 @@ using System.Threading.Tasks;
 using GitHub.Collections;
 using GitHub.Extensions;
 using GitHub.Extensions.Reactive;
+using GitHub.Logging;
 using GitHub.Models;
 using GitHub.Primitives;
 using GitHub.Services;
 using ReactiveUI;
+using Serilog;
 
 namespace GitHub.ViewModels.GitHubPane
 {
@@ -21,6 +23,7 @@ namespace GitHub.ViewModels.GitHubPane
     /// </summary>
     public abstract class IssueListViewModelBase : PanePageViewModelBase, IIssueListViewModelBase
     {
+        static readonly ILogger log = LogManager.ForContext<GitHubPaneViewModel>();
         readonly IRepositoryService repositoryService;
         IReadOnlyList<IIssueListItemViewModelBase> items;
         ICollectionView itemsView;
@@ -123,44 +126,53 @@ namespace GitHub.ViewModels.GitHubPane
         /// <inheritdoc/>
         public async Task InitializeAsync(ILocalRepositoryModel repository, IConnection connection)
         {
-            LocalRepository = repository;
-            SelectedState = States.FirstOrDefault();
-            AuthorFilter = new UserFilterViewModel(LoadAuthors);
-            IsLoading = true;
-
-            var parent = await repositoryService.FindParent(
-                HostAddress.Create(repository.CloneUrl),
-                repository.Owner,
-                repository.Name);
-
-            if (parent == null)
+            try
             {
-                RemoteRepository = repository;
-            }
-            else
-            {
-                // TODO: Handle forks with different names.
-                RemoteRepository = new RepositoryModel(
-                    repository.Name,
-                    UriString.ToUriString(repository.CloneUrl.ToRepositoryUrl(parent.Value.owner)));
+                LocalRepository = repository;
+                SelectedState = States.FirstOrDefault();
+                AuthorFilter = new UserFilterViewModel(LoadAuthors);
+                IsLoading = true;
 
-                Forks = new IRepositoryModel[]
+                var parent = await repositoryService.FindParent(
+                    HostAddress.Create(repository.CloneUrl),
+                    repository.Owner,
+                    repository.Name);
+
+                if (parent == null)
                 {
+                    RemoteRepository = repository;
+                }
+                else
+                {
+                    // TODO: Handle forks with different names.
+                    RemoteRepository = new RepositoryModel(
+                        repository.Name,
+                        UriString.ToUriString(repository.CloneUrl.ToRepositoryUrl(parent.Value.owner)));
+
+                    Forks = new IRepositoryModel[]
+                    {
                     RemoteRepository,
                     repository,
-                };
+                    };
+                }
+
+                this.WhenAnyValue(x => x.SelectedState, x => x.RemoteRepository)
+                    .Skip(1)
+                    .Subscribe(_ => Refresh().Forget());
+
+                Observable.Merge(
+                    this.WhenAnyValue(x => x.SearchQuery).Skip(1).SelectUnit(),
+                    AuthorFilter.WhenAnyValue(x => x.Selected).Skip(1).SelectUnit())
+                    .Subscribe(_ => FilterChanged());
+
+                await Refresh();
             }
-
-            this.WhenAnyValue(x => x.SelectedState, x => x.RemoteRepository)
-                .Skip(1)
-                .Subscribe(_ => Refresh().Forget());
-
-            Observable.Merge(
-                this.WhenAnyValue(x => x.SearchQuery).Skip(1).SelectUnit(),
-                AuthorFilter.WhenAnyValue(x => x.Selected).Skip(1).SelectUnit())
-                .Subscribe(_ => FilterChanged());
-
-            await Refresh();
+            catch (Exception ex)
+            {
+                Error = ex;
+                IsLoading = false;
+                log.Error(ex, "Error initializing IssueListViewModelBase");
+            }
         }
 
         /// <summary>
@@ -169,6 +181,12 @@ namespace GitHub.ViewModels.GitHubPane
         /// <returns>A task tracking the operation.</returns>
         public override Task Refresh()
         {
+            if (RemoteRepository == null)
+            {
+                // If an exception occurred reading the parent repository, do nothing.
+                return Task.CompletedTask;
+            }
+
             subscription?.Dispose();
 
             var dispose = new CompositeDisposable();

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestListViewModel.cs
@@ -122,7 +122,7 @@ namespace GitHub.ViewModels.GitHubPane
                 return result;
             }
 
-            protected override Task<Page<PullRequestListItemModel>> LoadPage(string after)
+            protected override async Task<Page<PullRequestListItemModel>> LoadPage(string after)
             {
                 PullRequestStateEnum[] states;
 
@@ -139,15 +139,12 @@ namespace GitHub.ViewModels.GitHubPane
                         break;
                 }
 
-                var sw = Stopwatch.StartNew();
-                var result = owner.service.ReadPullRequests(
+                var result = await owner.service.ReadPullRequests(
                     HostAddress.Create(owner.RemoteRepository.CloneUrl),
                     owner.RemoteRepository.Owner,
                     owner.RemoteRepository.Name,
                     after,
-                    states);
-                sw.Stop();
-                System.Diagnostics.Debug.WriteLine("Read PR page in " + sw.Elapsed);
+                    states).ConfigureAwait(false);
                 return result;
             }
         }

--- a/src/GitHub.App/ViewModels/UserFilterViewModel.cs
+++ b/src/GitHub.App/ViewModels/UserFilterViewModel.cs
@@ -120,7 +120,13 @@ namespace GitHub.ViewModels
             while (true)
             {
                 var page = await load(after);
-                users.AddRange(page.Items.Select(x => new ActorViewModel(x)));
+
+                foreach (var item in page.Items)
+                {
+                    var vm = new ActorViewModel(item);
+                    users.Add(vm);
+                }
+
                 after = page.EndCursor;
                 if (!page.HasNextPage) break;
             }

--- a/test/GitHub.App.UnitTests/Collections/SequentialListSourceTests.cs
+++ b/test/GitHub.App.UnitTests/Collections/SequentialListSourceTests.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GitHub.Collections;
+using GitHub.Models;
+using NUnit.Framework;
+
+namespace GitHub.App.UnitTests.Collections
+{
+    public class SequentialListSourceTests
+    {
+        [Test]
+        public async Task GetCount_Should_Load_First_Page()
+        {
+            var target = new TestSource();
+
+            Assert.That(target.PagesLoaded, Is.Empty);
+
+            var count = await target.GetCount();
+
+            Assert.That(count, Is.EqualTo(100));
+            Assert.That(target.PagesLoaded, Is.EqualTo(new[] { 0 }));
+        }
+
+        [Test]
+        public async Task GetPage_Should_Load_Pages()
+        {
+            var target = new TestSource();
+
+            Assert.That(target.PagesLoaded, Is.Empty);
+
+            var count = await target.GetPage(3);
+
+            Assert.That(target.PagesLoaded, Is.EqualTo(new[] { 0, 1, 2, 3 }));
+        }
+
+        class TestSource : SequentialListSource<string, string>
+        {
+            const int PageCount = 10;
+            readonly int? throwAtPage;
+
+            public TestSource(int? throwAtPage = null)
+            {
+                this.throwAtPage = throwAtPage;
+            }
+
+            public override int PageSize => 10;
+            public List<int> PagesLoaded { get; private set; } = new List<int>();
+
+            protected override string CreateViewModel(string model)
+            {
+                return model + " loaded";
+            }
+
+            protected override Task<Page<string>> LoadPage(string after)
+            {
+                var page = after != null ? int.Parse(after) : 0;
+
+                if (page == throwAtPage)
+                {
+                    throw new GitHubLogicException("Thrown.");
+                }
+
+                PagesLoaded.Add(page);
+
+                return Task.FromResult(new Page<string>
+                {
+                    EndCursor = (page + 1).ToString(),
+                    HasNextPage = page < PageCount,
+                    Items = Enumerable.Range(page * PageSize, PageSize).Select(x => "Item " + x).ToList(),
+                    TotalCount = PageSize * PageCount,
+                });
+            }
+        }
+    }
+}

--- a/test/GitHub.App.UnitTests/Collections/SequentialListSourceTests.cs
+++ b/test/GitHub.App.UnitTests/Collections/SequentialListSourceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GitHub.Collections;
@@ -32,6 +33,17 @@ namespace GitHub.App.UnitTests.Collections
             var count = await target.GetPage(3);
 
             Assert.That(target.PagesLoaded, Is.EqualTo(new[] { 0, 1, 2, 3 }));
+        }
+
+        [Test]
+        public void GetPage_Should_Stop_Loading_Pages_When_LoadPage_Throws()
+        {
+            var target = new TestSource(2);
+
+            Assert.That(target.PagesLoaded, Is.Empty);
+
+            Assert.ThrowsAsync<AggregateException>(() => target.GetPage(3));
+            Assert.That(target.PagesLoaded, Is.EqualTo(new[] { 0, 1 }));
         }
 
         class TestSource : SequentialListSource<string, string>

--- a/test/GitHub.App.UnitTests/Collections/SequentialListSourceTests.cs
+++ b/test/GitHub.App.UnitTests/Collections/SequentialListSourceTests.cs
@@ -46,6 +46,17 @@ namespace GitHub.App.UnitTests.Collections
             Assert.That(target.PagesLoaded, Is.EqualTo(new[] { 0, 1 }));
         }
 
+        [Test]
+        public void IsLoading_Should_Be_Set_To_False_When_LoadPage_Throws()
+        {
+            var target = new TestSource(2);
+
+            Assert.That(target.PagesLoaded, Is.Empty);
+
+            Assert.ThrowsAsync<AggregateException>(() => target.GetPage(3));
+            Assert.That(target.IsLoading, Is.False);
+        }
+
         class TestSource : SequentialListSource<string, string>
         {
             const int PageCount = 10;

--- a/test/GitHub.App.UnitTests/GitHub.App.UnitTests.csproj
+++ b/test/GitHub.App.UnitTests/GitHub.App.UnitTests.csproj
@@ -157,6 +157,7 @@
     <Compile Include="..\Helpers\TestSharedCache.cs" />
     <Compile Include="Args.cs" />
     <Compile Include="Caches\ImageCacheTests.cs" />
+    <Compile Include="Collections\SequentialListSourceTests.cs" />
     <Compile Include="Factories\ModelServiceFactoryTests.cs" />
     <Compile Include="Models\AccountModelTests.cs" />
     <Compile Include="Models\ModelServiceTests.cs" />


### PR DESCRIPTION
This PR improves the error handling of the new PR list. It's still not perfect, but better than before. Before, the list continued forever to make requests to the server if a request failed (!).

Also added some unit tests.

## Testing

The best way to test this is to install Fiddler https://www.telerik.com/download/fiddler and use its Autoresponder to return error codes from `https://api.github.com`. Then toggle the autoresponder on/off at various times in the loading of the PR list.

The main thing that should not happen is that the PR list shouldn't repeatedly send the same failing request over and over. The second thing that should happen is that an error message should be displayed; disabling the autoresponder and clicking Refresh should load the list.

There is one place where refreshing the list fails, and you're stuck with the error - if the error occurs early enough in the load. This will require a bit more work, so I will address in another PR to keep things in reviewable-pieces.

Depends on #1773 