### PR TITLE
Prevent opening PR in browser multiple times.

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListView.xaml.cs
@@ -27,6 +27,7 @@ namespace GitHub.VisualStudio.Views.GitHubPane
         public PullRequestListView()
         {
             InitializeComponent();
+
             DataContextChanged += (s, e) =>
             {
                 var vm = DataContext as IPullRequestListViewModel;
@@ -41,6 +42,12 @@ namespace GitHub.VisualStudio.Views.GitHubPane
                             .Subscribe(_ => authorFilterDropDown.IsOpen = false),
                         vm.OpenItemInBrowser.Subscribe(x => OpenInBrowser((IPullRequestListItemViewModel)x)));
                 }
+            };
+
+            Unloaded += (s, e) =>
+            {
+                subscription?.Dispose();
+                subscription = null;
             };
         }
 


### PR DESCRIPTION
When "Open in Browser" is selected in the PR list, if the user has navigated multiple times to the PR list, then multiple tabs will be opened.

Ensure the PR list unsubscribes when it is unloaded.