### PR TITLE
Enable navigation from historical file to solution

### DIFF
--- a/src/GitHub.Exports/Services/IGitHubContextService.cs
+++ b/src/GitHub.Exports/Services/IGitHubContextService.cs
@@ -72,6 +72,30 @@ namespace GitHub.Services
         (string commitish, string path, string commitSha) ResolveBlob(string repositoryDir, GitHubContext context, string remoteName = "origin");
 
         /// <summary>
+        /// Find the object-ish (first 8 chars of a blob SHA) from the path to historical blob created by Team Explorer.
+        /// </summary>
+        /// <remarks>
+        /// Team Explorer creates temporary blob files in the following format:
+        /// C:\Users\me\AppData\Local\Temp\TFSTemp\vctmp21996_181282.IOpenFromClipboardCommand.783ac965.cs
+        /// The object-ish appears immediately before the file extension and the path contains the folder "TFSTemp".
+        /// <remarks>
+        /// <param name="tempFile">The path to a possible Team Explorer temporary blob file.</param>
+        /// <returns>The target file's object-ish (blob SHA fragment) or null if the path isn't recognized as a Team Explorer blob file.</returns>
+        string FindObjectishForTFSTempFile(string tempFile);
+
+        /// <summary>
+        /// Find a tree entry in the commit log where a blob appears and return its commit SHA and path.
+        /// </summary>
+        /// <remarks>
+        /// Search back through the commit log for the first tree entry where a blob appears. This operation only takes
+        /// a fraction of a seond on the `github/VisualStudio` repository even if a tree entry casn't be found.
+        /// </remarks>
+        /// <param name="repositoryDir">The target repository directory.</param>
+        /// <param name="objectish">The fragment of a blob SHA to find.</param>
+        /// <returns>The commit SHA and blob path or null if the blob can't be found.</returns>
+        (string commitSha, string blobPath) ResolveBlobFromHistory(string repositoryDir, string objectish);
+
+        /// <summary>
         /// Check if a file in the working directory has changed since a specified commit-ish.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
### What this PR does

Extend the `GoToSolutionOrPullRequestFile` command to support navigation from a file opened using the history view to the same file in the users solution/working directory.

## How to test

### The history of a file

1. Right click on a source file from a repository and `Code context > View History...`
![image](https://user-images.githubusercontent.com/11719160/42823894-9dcd2534-89d6-11e8-83a1-cd1a17642d2b.png)

2. Double click on a revision in the history
![image](https://user-images.githubusercontent.com/11719160/42823954-c0d72f98-89d6-11e8-80f6-41339949a875.png)

3. Right click on the read-only historical file and `Open File in Solution`
![image](https://user-images.githubusercontent.com/11719160/42824061-ed6a4f9a-89d6-11e8-9e9a-6b58a0a49bde.png)

4. It should navigate to the equivalent position in your solution / working directory

### The commit history

1. Select `View History...` from the status bar
![image](https://user-images.githubusercontent.com/11719160/42824539-f239a768-89d7-11e8-93cf-a3d07b4b6cb4.png)

2. Double click on a commit in the history
![image](https://user-images.githubusercontent.com/11719160/42824688-39022c7e-89d8-11e8-82e9-53879c6fe654.png)

3. Double click on a changed file in the commit
![image](https://user-images.githubusercontent.com/11719160/42824736-57359a0a-89d8-11e8-9103-17b6f4612542.png)

4. Right click on the commit diff view and `Open File in Solution`
![image](https://user-images.githubusercontent.com/11719160/42824837-95bce8d2-89d8-11e8-8acd-b2710bd8abdb.png)

4. It should navigate to the equivalent position in your solution / working directory
