### PR TITLE
Fix submit button in PullRequestReviewAuthoringView.

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestReviewAuthoringView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestReviewAuthoringView.xaml
@@ -50,7 +50,8 @@
                      SpellCheck.IsEnabled="True"/>
             
             <StackPanel Margin="0 4" Orientation="Horizontal">
-                <ui:DropDownButton AutoCloseOnClick="True" Content="Submit review">
+                <ui:DropDownButton AutoCloseOnClick="True" Foreground="{DynamicResource GHBlueLinkButtonTextBrush}">
+                    <ui:GitHubActionLink>Submit review</ui:GitHubActionLink>
                     <ui:DropDownButton.DropDownContent>
                         <Border Background="{DynamicResource GitHubVsToolWindowBackground}"
                                 BorderBrush="{DynamicResource GitHubComboBoxBorderBrush}"


### PR DESCRIPTION
The submit button in `PullRequestReviewAuthoringView` was previously not styled as a hyperlink. This makes it so that it is.

Before:

![image](https://user-images.githubusercontent.com/1775141/43006207-6417af4c-8c35-11e8-8f66-9c66ea14f7e2.png)

After:

![image](https://user-images.githubusercontent.com/1775141/43006178-50c5a9a8-8c35-11e8-8c74-c02da65c864a.png)
