### PR TITLE
Fix icon background in PullRequestReviewAuthoringView.

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestReviewAuthoringView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestReviewAuthoringView.xaml
@@ -10,8 +10,10 @@
                                              xmlns:c="clr-namespace:GitHub.VisualStudio.UI.Controls;assembly=GitHub.VisualStudio.UI"
                                              xmlns:models="clr-namespace:GitHub.Models;assembly=GitHub.App"
                                              xmlns:sampleData="clr-namespace:GitHub.SampleData;assembly=GitHub.App"
+                                             xmlns:theming="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
                                              Background="{DynamicResource GitHubVsToolWindowBackground}"
                                              Foreground="{DynamicResource GitHubVsWindowText}"
+                                             theming:ImageThemingUtilities.ImageBackgroundColor="{Binding RelativeSource={RelativeSource Self}, Path=Background.Color}"
                                              mc:Ignorable="d" d:DesignWidth="356" d:DesignHeight="800">
     <d:DesignProperties.DataContext>
         <sampleData:PullRequestReviewAuthoringViewModelDesigner/>


### PR DESCRIPTION
Previously the icon background in the PR review authoring view was wrong.

Before:

![image](https://user-images.githubusercontent.com/1775141/43007548-f0b3d9d2-8c38-11e8-96dd-385ab9c62670.png)

After:

![image](https://user-images.githubusercontent.com/1775141/43007563-fa97267a-8c38-11e8-8a98-813d6144f247.png)

See https://github.com/github/VisualStudio/pull/1744#discussion_r195910090 for information on why this needs to be done here and not in `PullRequestFilesView`.