### PR TITLE
Move IGitHubToolWindowManager into GitHub.Exports

### DIFF
--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Services\IUsageService.cs" />
     <Compile Include="Settings\PkgCmdID.cs" />
     <Compile Include="ViewModels\GitHubPane\IGitHubPaneViewModel.cs" />
+    <Compile Include="ViewModels\GitHubPane\IGitHubToolWindowManager.cs" />
     <Compile Include="ViewModels\IConnectionInitializedViewModel.cs" />
     <Compile Include="ViewModels\IInfoPanel.cs" />
     <Compile Include="ViewModels\IViewModel.cs" />

--- a/src/GitHub.Exports/ViewModels/GitHubPane/IGitHubToolWindowManager.cs
+++ b/src/GitHub.Exports/ViewModels/GitHubPane/IGitHubToolWindowManager.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+namespace GitHub.ViewModels.GitHubPane
+{
+    /// <summary>
+    /// The Visual Studio service interface for accessing the GitHub Pane.
+    /// </summary>
+    [Guid("FC9EC5B5-C297-4548-A229-F8E16365543C")]
+    [ComVisible(true)]
+    public interface IGitHubToolWindowManager
+    {
+        /// <summary>
+        /// Ensure that the GitHub pane is created and visible.
+        /// </summary>
+        /// <returns>The view model for the GitHub Pane.</returns>
+        Task<IGitHubPaneViewModel> ShowGitHubPane();
+    }
+}

--- a/src/GitHub.VisualStudio/Commands/OpenFromUrlCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/OpenFromUrlCommand.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.IO;
-using System.Windows;
 using System.Threading.Tasks;
 using System.ComponentModel.Composition;
 using GitHub.Commands;
 using GitHub.Services;
+using GitHub.ViewModels.GitHubPane;
 using GitHub.Services.Vssdk.Commands;
 using EnvDTE;
 using Microsoft.VisualStudio;

--- a/src/GitHub.VisualStudio/Commands/OpenPullRequestsCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/OpenPullRequestsCommand.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using GitHub.Commands;
 using GitHub.Logging;
 using GitHub.Services;
+using GitHub.ViewModels.GitHubPane;
 using GitHub.Services.Vssdk.Commands;
 using Serilog;
 

--- a/src/GitHub.VisualStudio/Commands/ShowCurrentPullRequestCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/ShowCurrentPullRequestCommand.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using GitHub.Commands;
 using GitHub.Logging;
 using GitHub.Services;
-using GitHub.Extensions;
+using GitHub.ViewModels.GitHubPane;
 using GitHub.Services.Vssdk.Commands;
 using Serilog;
 

--- a/src/GitHub.VisualStudio/Commands/ShowGitHubPaneCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/ShowGitHubPaneCommand.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using GitHub.Commands;
 using GitHub.Logging;
 using GitHub.Services;
+using GitHub.ViewModels.GitHubPane;
 using GitHub.Services.Vssdk.Commands;
 using Serilog;
 

--- a/src/GitHub.VisualStudio/IServiceProviderPackage.cs
+++ b/src/GitHub.VisualStudio/IServiceProviderPackage.cs
@@ -1,18 +1,8 @@
 ﻿using System;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
-using GitHub.ViewModels.GitHubPane;
 
 namespace GitHub.VisualStudio
 {
     public interface IServiceProviderPackage : IServiceProvider, Microsoft.VisualStudio.Shell.IAsyncServiceProvider
     {
-    }
-
-    [Guid("FC9EC5B5-C297-4548-A229-F8E16365543C")]
-    [ComVisible(true)]
-    public interface IGitHubToolWindowManager
-    {
-        Task<IGitHubPaneViewModel> ShowGitHubPane();
     }
 }


### PR DESCRIPTION
### What this PR does

The `IGitHubToolWindowManager` was previously in the `GitHub.VisualStudio` assembly. This meant that any commands that needed to show the GitHub pane also had to be in the `GitHub.VisualStudio` assembly.

- Move`IGitHubToolWindowManager` into our `GitHub.Exports` interfaces assembly.