### PR TITLE
Reduce extension footprint when not in repository context

### DIFF
--- a/src/GitHub.InlineReviews/Margins/InlineCommentMarginProvider.cs
+++ b/src/GitHub.InlineReviews/Margins/InlineCommentMarginProvider.cs
@@ -27,15 +27,15 @@ namespace GitHub.InlineReviews.Margins
 
         [ImportingConstructor]
         public InlineCommentMarginProvider(
-            Lazy<IGitHubServiceProvider> serviceProvider,
+            Lazy<IPullRequestSessionManager> sessionManager,
             Lazy<IEditorFormatMapService> editorFormatMapService,
             Lazy<IViewTagAggregatorFactoryService> tagAggregatorFactory,
             Lazy<IInlineCommentPeekService> peekService)
         {
+            this.sessionManager = sessionManager;
             this.editorFormatMapService = editorFormatMapService;
             this.tagAggregatorFactory = tagAggregatorFactory;
             this.peekService = peekService;
-            sessionManager = new Lazy<IPullRequestSessionManager>(() => serviceProvider.Value.GetService<IPullRequestSessionManager>());
 
             uiContext = UIContext.FromUIContextGuid(new Guid(Guids.UIContext_Git));
         }

--- a/src/GitHub.InlineReviews/Margins/InlineCommentMarginProvider.cs
+++ b/src/GitHub.InlineReviews/Margins/InlineCommentMarginProvider.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Text.Classification;
-using GitHub.InlineReviews.Services;
 using GitHub.Services;
+using GitHub.VisualStudio;
+using GitHub.InlineReviews.Services;
 
 namespace GitHub.InlineReviews.Margins
 {
@@ -17,28 +19,41 @@ namespace GitHub.InlineReviews.Margins
     [TextViewRole(PredefinedTextViewRoles.Interactive)]
     internal sealed class InlineCommentMarginProvider : IWpfTextViewMarginProvider
     {
-        readonly IEditorFormatMapService editorFormatMapService;
-        readonly IViewTagAggregatorFactoryService tagAggregatorFactory;
-        readonly IInlineCommentPeekService peekService;
+        readonly Lazy<IEditorFormatMapService> editorFormatMapService;
+        readonly Lazy<IViewTagAggregatorFactoryService> tagAggregatorFactory;
+        readonly Lazy<IInlineCommentPeekService> peekService;
         readonly Lazy<IPullRequestSessionManager> sessionManager;
+        readonly UIContext uiContext;
 
         [ImportingConstructor]
         public InlineCommentMarginProvider(
-            IGitHubServiceProvider serviceProvider,
-            IEditorFormatMapService editorFormatMapService,
-            IViewTagAggregatorFactoryService tagAggregatorFactory,
-            IInlineCommentPeekService peekService)
+            Lazy<IGitHubServiceProvider> serviceProvider,
+            Lazy<IEditorFormatMapService> editorFormatMapService,
+            Lazy<IViewTagAggregatorFactoryService> tagAggregatorFactory,
+            Lazy<IInlineCommentPeekService> peekService)
         {
             this.editorFormatMapService = editorFormatMapService;
             this.tagAggregatorFactory = tagAggregatorFactory;
             this.peekService = peekService;
-            sessionManager = new Lazy<IPullRequestSessionManager>(() => serviceProvider.GetService<IPullRequestSessionManager>());
+            sessionManager = new Lazy<IPullRequestSessionManager>(() => serviceProvider.Value.GetService<IPullRequestSessionManager>());
+
+            uiContext = UIContext.FromUIContextGuid(new Guid(Guids.UIContext_Git));
         }
 
         public IWpfTextViewMargin CreateMargin(IWpfTextViewHost wpfTextViewHost, IWpfTextViewMargin parent)
         {
+            if (!uiContext.IsActive)
+            {
+                // Only create margin when in the context of a Git repository
+                return null;
+            }
+
             return new InlineCommentMargin(
-                wpfTextViewHost, peekService, editorFormatMapService, tagAggregatorFactory, sessionManager);
+                wpfTextViewHost,
+                peekService.Value,
+                editorFormatMapService.Value,
+                tagAggregatorFactory.Value,
+                sessionManager);
         }
     }
 }

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
 using Task = System.Threading.Tasks.Task;
+using static Microsoft.VisualStudio.VSConstants;
 
 namespace GitHub.VisualStudio.Base
 {
@@ -51,9 +52,8 @@ namespace GitHub.VisualStudio.Base
             // Start with empty array until we have a chance to initialize.
             ActiveRepositories = Array.Empty<ILocalRepositoryModel>();
 
-            // The IGitExt service isn't available when a TFS based solution is opened directly.
-            // It will become available when moving to a Git based solution (and cause a UIContext event to fire).
-            var context = factory.GetUIContext(new Guid(Guids.GitSccProviderId));
+            // Initialize when we enter the context of a Git repository
+            var context = factory.GetUIContext(UICONTEXT.RepositoryOpen_guid);
             context.WhenActivated(() => JoinableTaskFactory.RunAsync(InitializeAsync).Task.Forget(log));
         }
 

--- a/src/GitHub.VisualStudio/GitContextPackage.cs
+++ b/src/GitHub.VisualStudio/GitContextPackage.cs
@@ -5,17 +5,18 @@ using GitHub.Exports;
 using GitHub.Services;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
+using static Microsoft.VisualStudio.VSConstants;
 
 namespace GitHub.VisualStudio
 {
     /// <summary>
     /// This package creates a custom UIContext <see cref="Guids.UIContext_Git"/> that is activated when a
-    /// repository is active in <see cref="IVSGitExt"/>.
+    /// repository is active in <see cref="IVSGitExt"/> and the current process is Visual Studio (not Blend).
     /// </summary>
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [Guid(Guids.UIContext_Git)]
-    // this is the Git service GUID, so we load whenever it loads
-    [ProvideAutoLoad(Guids.GitSccProviderId, PackageAutoLoadFlags.BackgroundLoad)]
+    // Initialize when we enter the context of a Git repository
+    [ProvideAutoLoad(UICONTEXT.RepositoryOpen_string, PackageAutoLoadFlags.BackgroundLoad)]
     public class GitContextPackage : AsyncPackage
     {
         protected async override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)

--- a/src/GitHub.VisualStudio/GitContextPackage.cs
+++ b/src/GitHub.VisualStudio/GitContextPackage.cs
@@ -2,10 +2,8 @@
 using System.Threading;
 using System.Runtime.InteropServices;
 using GitHub.Exports;
-using GitHub.Logging;
 using GitHub.Services;
 using Microsoft.VisualStudio.Shell;
-using Serilog;
 using Task = System.Threading.Tasks.Task;
 
 namespace GitHub.VisualStudio
@@ -20,13 +18,11 @@ namespace GitHub.VisualStudio
     [ProvideAutoLoad(Guids.GitSccProviderId, PackageAutoLoadFlags.BackgroundLoad)]
     public class GitContextPackage : AsyncPackage
     {
-        static readonly ILogger log = LogManager.ForContext<GitContextPackage>();
-
         protected async override Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
             if (!ExportForVisualStudioProcessAttribute.IsVisualStudioProcess())
             {
-                log.Warning("Don't activate 'UIContext_Git' for non-Visual Studio process");
+                // Don't activate 'UIContext_Git' for non-Visual Studio process
                 return;
             }
 

--- a/src/GitHub.VisualStudio/Resources/icons/mark_github.xaml
+++ b/src/GitHub.VisualStudio/Resources/icons/mark_github.xaml
@@ -1,17 +1,20 @@
-﻿<Viewbox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-         Width="1024" Height="1024">
+﻿<Viewbox
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:PresentationOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+        Width="1024" Height="1024">
+
+    <Viewbox.Resources>
+        <ResourceDictionary>
+            <Color x:Key="GitHubContextMenuIconColor">#424242</Color>
+            <SolidColorBrush x:Key="GitHubContextMenuIconBrush" Color="{StaticResource GitHubContextMenuIconColor}" PresentationOptions:Freeze="true" />
+        </ResourceDictionary>
+    </Viewbox.Resources>
+
     <Border BorderBrush="Transparent" BorderThickness="1">
-        <ghfvs:OcticonImage xmlns:ghfvs="https://github.com/github/VisualStudio"
-                     Foreground="{DynamicResource GitHubContextMenuIconBrush}"
-                     Icon="mark_github">
-            <ghfvs:OcticonImage.Resources>
-                <ResourceDictionary>
-                    <ResourceDictionary.MergedDictionaries>
-                        <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
-                        <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.UI;component/SharedDictionary.xaml" />
-                    </ResourceDictionary.MergedDictionaries>
-                </ResourceDictionary>
-            </ghfvs:OcticonImage.Resources>
-        </ghfvs:OcticonImage>
+        <StackPanel>
+            <!-- TODO: Can we replace this with an inline GitHub logo? -->
+            <Ellipse Fill="{StaticResource GitHubContextMenuIconBrush}" Height="100" Width="100"/>
+        </StackPanel>
     </Border>
 </Viewbox>

--- a/test/GitHub.TeamFoundation.UnitTests/VSGitExtTests.cs
+++ b/test/GitHub.TeamFoundation.UnitTests/VSGitExtTests.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.TeamFoundation.Git.Extensibility;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Task = System.Threading.Tasks.Task;
+using static Microsoft.VisualStudio.VSConstants;
 
 public class VSGitExtTests
 {
@@ -20,7 +21,7 @@ public class VSGitExtTests
     {
         [TestCase(true, 1)]
         [TestCase(false, 0)]
-        public void GetServiceIGitExt_WhenSccProviderContextIsActive(bool isActive, int expectCalls)
+        public void GetServiceIGitExt_WhenRepositoryOpenIsActive(bool isActive, int expectCalls)
         {
             var context = CreateVSUIContext(isActive);
             var sp = Substitute.For<IAsyncServiceProvider>();
@@ -135,7 +136,7 @@ public class VSGitExtTests
     public class TheActiveRepositoriesProperty : TestBaseClass
     {
         [Test]
-        public void SccProviderContextNotActive_IsEmpty()
+        public void RepositoryOpenContextNotActive_IsEmpty()
         {
             var context = CreateVSUIContext(false);
             var target = CreateVSGitExt(context);
@@ -144,7 +145,7 @@ public class VSGitExtTests
         }
 
         [Test]
-        public void SccProviderContextIsActive_InitializeWithActiveRepositories()
+        public void RepositoryOpenIsActive_InitializeWithActiveRepositories()
         {
             var repoPath = "repoPath";
             var repoFactory = Substitute.For<ILocalRepositoryModelFactory>();
@@ -217,8 +218,7 @@ public class VSGitExtTests
         repoFactory = repoFactory ?? Substitute.For<ILocalRepositoryModelFactory>();
         joinableTaskContext = joinableTaskContext ?? new JoinableTaskContext();
         var factory = Substitute.For<IVSUIContextFactory>();
-        var contextGuid = new Guid(Guids.GitSccProviderId);
-        factory.GetUIContext(contextGuid).Returns(context);
+        factory.GetUIContext(UICONTEXT.RepositoryOpen_guid).Returns(context);
         sp.GetServiceAsync(typeof(IGitExt)).Returns(gitExt);
         var vsGitExt = new VSGitExt(sp, factory, repoFactory, joinableTaskContext);
         vsGitExt.JoinTillEmpty();


### PR DESCRIPTION
## The problem

@PooyaZv (Writing from VS platform team) wrote:

> GitHub extension reads in 2.5 MB off of disk when I create a basic C# app (with just an empty Main method) that doesn't use GitHub. This is with a full install of Visual Studio 15.8 Preview 3.0 (all workloads/packages installed). Disk access especially during solution load can be costly. Therefore, it should be avoided if the project doesn't use a feature.

We appear to be loading 22 assemblies, even when a project isn't using GitHub (see #1799 for a breakdown).

## What this PR does

1. Only create text view margins when in the context of a Git repository
Change `InlineCommentMarginProvider` and `PullRequestFileMarginProvider` to lazy load their MEF dependencies and only return a margin when in the context of a Git repository.


2. Remove dependency on `LogManager` from `GitContextPackage`
`GitContextPackage` is our custom UI context and is loaded whenever we're in the context of a Git repository. This a low level package and doesn't really need logging (which requires a few assemblies).

3. Change `GitContextPackage` and `VSGitExt` to use `UICONTEXT.RepositoryOpen` instead of `GitSccProvider`
It appears there is a UIContext for when a Git repository is open (`UICONTEXT.RepositoryOpen`). Previously we were using `GitSccProvider`, which loads whenever the Git SCC provider is available (which is most of the time).

4. Stop using `SharedDictionary.xaml` for GitHub logo
The GitHub logo used on `View > Other Windows > GitHub` and `StartPage > GitHub`  was causing a cascade of assembly loads when the `StartPage` or `GitHub` command was visible. I've replaced the `SharedDictionary.xaml` reference with a plain XAML placeholder. This causes only the containing assembly to load.

### Questions

Our custom UIContext is now the same as `UICONTEXT.RepositoryOpen`, but with the added restriction that the host process is Visual Studio (not Blend). I don't know if there is a built in UIContext that would allow us to do the same thing? @PooyaZv do you know?

## To do

- [x] Replace placeholder XAML with proper GitHub logo

## How to test

1. Open Visual Studio with `StartPage` visible and the `GitHub` pane hidden
2. Open the modules window (`Ctrl D + M`) and search for `github`
- Expect only `GitHub.VisualStudio.dll` to have loaded (it contains the GitHub icon)
3. Open a project that isn't under Git version control and open a source file
- Expect `GitHub.InlineReviews.dll`, `GitHub.Exports.dll` and `GitHub.Exports.Reactive.dll` to have loaded (these contain our MEF margin providers and MEF interfaces)
- No other assemblies should have loaded under the extension directory

![image](https://user-images.githubusercontent.com/11719160/43211547-ad7ecd8a-9029-11e8-801b-42e7dfc55900.png)

Fixes #1799 