### PR TITLE
Bring the GitHub mark back into the menu (and start page)

### DIFF
--- a/src/GitHub.VisualStudio/Resources/icons/mark_github.xaml
+++ b/src/GitHub.VisualStudio/Resources/icons/mark_github.xaml
@@ -13,10 +13,6 @@
 
     <Border BorderBrush="Transparent" BorderThickness="1">
         <Canvas xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Width="16" Height="16">
-            <Canvas.RenderTransform>
-                <TranslateTransform X="0" Y="0"/>
-            </Canvas.RenderTransform>
-            <Canvas.Resources/>
             <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Fill="{StaticResource GitHubContextMenuIconBrush}" Data="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
         </Canvas>
     </Border>

--- a/src/GitHub.VisualStudio/Resources/icons/mark_github.xaml
+++ b/src/GitHub.VisualStudio/Resources/icons/mark_github.xaml
@@ -12,9 +12,12 @@
     </Viewbox.Resources>
 
     <Border BorderBrush="Transparent" BorderThickness="1">
-        <StackPanel>
-            <!-- TODO: Can we replace this with an inline GitHub logo? -->
-            <Ellipse Fill="{StaticResource GitHubContextMenuIconBrush}" Height="100" Width="100"/>
-        </StackPanel>
+        <Canvas xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Width="16" Height="16">
+            <Canvas.RenderTransform>
+                <TranslateTransform X="0" Y="0"/>
+            </Canvas.RenderTransform>
+            <Canvas.Resources/>
+            <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Fill="{StaticResource GitHubContextMenuIconBrush}" Data="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+        </Canvas>
     </Border>
 </Viewbox>


### PR DESCRIPTION
This pull request brings back the GitHub logo without all the assemblies!

Screenshots for proof 😄:

<img width="346" alt="screen shot 2018-07-25 at 10 13 09 am" src="https://user-images.githubusercontent.com/1174461/43216724-8fdb2448-8ff4-11e8-94c9-4f9a746cb214.png">

<img width="301" alt="screen shot 2018-07-25 at 10 12 57 am" src="https://user-images.githubusercontent.com/1174461/43216726-90064060-8ff4-11e8-80af-bc5a1c34ab55.png">

I'll use this place to walk through how I ported over the svg to xaml. I referred to this [blog post](https://liftcodeplay.com/2015/09/14/converting-vectorsvg-images-into-xaml/) when I was bringing it back in.

----

### Starting with a hunch

It started off with @jcansdale mentioning in chat:

> i found this:
`M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17 0.55-0.38 0-0.19-0.01-0.82-0.01-1.49-2.01 0.37-2.53-0.49-2.69-0.94-0.09-0.23-0.48-0.94-0.82-1.13-0.28-0.15-0.68-0.52-0.01-0.53 0.63-0.01 1.08 0.58 1.23 0.82 0.72 1.21 1.87 0.87 2.33 0.66 0.07-0.52 0.28-0.87 0.51-1.07-1.78-0.2-3.64-0.89-3.64-3.95 0-0.87 0.31-1.59 0.82-2.15-0.08-0.2-0.36-1.02 0.08-2.12 0 0 0.67-0.21 2.2 0.82 0.64-0.18 1.32-0.27 2-0.27 0.68 0 1.36 0.09 2 0.27 1.53-1.04 2.2-0.82 2.2-0.82 0.44 1.1 0.16 1.92 0.08 2.12 0.51 0.56 0.82 1.27 0.82 2.15 0 3.07-1.87 3.75-3.65 3.95 0.29 0.25 0.54 0.73 0.54 1.48 0 1.07-0.01 1.93-0.01 2.2 0 0.21 0.15 0.46 0.55 0.38C13.71 14.53 16 11.53 16 8 16 3.58 12.42 0 8 0z`
> but i'm not quite sure where it stick it
> is there some kind of WPF shape that will take this?

The `M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59 0.4 0.07 0.55-0.17` looked familiar to me since I've worked with svg files before and had a hunch that this would be the xaml equivalent of:

```svg
<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" ... />
</svg>
```

I figured that I probably will need to find a way to bring svgs into xaml, so I googled "svg in xaml" and ran into the [blog post](https://liftcodeplay.com/2015/09/14/converting-vectorsvg-images-into-xaml/) which gave some details on how to convert an svg into xaml markup using Inkscape.

I thought I could figure out how to port it manually, but decided having an app do it for me was better. 😉 

### "Bottled at the source"

In order to convert the svg github mark into xaml, I needed the original svg source to open in Inkscape. While I already had the file on my computer, you could grab the exact svg code from the [Octicons page](https://octicons.github.com/icon/mark-github/) with the element inspector

<img width="1086" alt="screen shot 2018-07-25 at 1 31 25 pm" src="https://user-images.githubusercontent.com/1174461/43225864-128e65a2-900f-11e8-8ce4-bd62013448e4.png">

And paste it into your editor of choice:

<img width="467" alt="screen shot 2018-07-25 at 1 28 58 pm" src="https://user-images.githubusercontent.com/1174461/43225739-baaa59fe-900e-11e8-9d33-0902421b7760.png">

### Converting with Inkscape

Next I opened the file in Inkscape and resaved the file as `*.xaml`:

<img width="805" alt="screen shot 2018-07-25 at 1 37 22 pm" src="https://user-images.githubusercontent.com/1174461/43226364-88188ae0-9010-11e8-97f6-5b307510a72f.png">

And made it Silverlight compatible (per the recommendation in the blog post):

<img width="206" alt="screen shot 2018-07-25 at 1 37 48 pm" src="https://user-images.githubusercontent.com/1174461/43226389-947b6c80-9010-11e8-9bd8-b52e9c667c70.png">

### Getting xaml ready!

This produced the output:

```xaml
<?xml version="2.0" encoding="UTF-8"?>
<!--This file is compatible with Silverlight-->
<Canvas xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Name="svg3352" Width="16" Height="16">
  <Canvas.RenderTransform>
    <TranslateTransform X="0" Y="0"/>
  </Canvas.RenderTransform>
  <Canvas.Resources/>
  <!--Unknown tag: metadata-->
  <!--Unknown tag: sodipodi:namedview-->
  <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Name="path3354" Fill="#000000" Data="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
</Canvas>
```

The output has a lot of cruft, so I ended up removing things that I didn't think was needed (almost everything but the `<Path />`):

```xaml
<Canvas xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Width="16" Height="16">
  <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Fill="{StaticResource GitHubContextMenuIconBrush}" Data="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
</Canvas>
```
(Note: I replaced the `Fill` value to our own color)

Finally, I replaced the placeholder shape with the final xaml.

The end! Hope this was helpful.

