### PR TITLE
Fixing incorrect casing in the clone url owner issues

### DIFF
--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -524,7 +524,7 @@ namespace GitHub.Services
 
         public bool IsPullRequestFromRepository(ILocalRepositoryModel repository, PullRequestDetailModel pullRequest)
         {
-            return pullRequest.HeadRepositoryOwner == repository.CloneUrl.Owner;
+            return pullRequest.HeadRepositoryOwner.ToLowerInvariant() == repository.CloneUrl.Owner.ToLowerInvariant();
         }
 
         public IObservable<Unit> SwitchToBranch(ILocalRepositoryModel repository, PullRequestDetailModel pullRequest)

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -524,7 +524,7 @@ namespace GitHub.Services
 
         public bool IsPullRequestFromRepository(ILocalRepositoryModel repository, PullRequestDetailModel pullRequest)
         {
-            return pullRequest.HeadRepositoryOwner.ToLowerInvariant() == repository.CloneUrl.Owner.ToLowerInvariant();
+            return string.Equals(repository?.CloneUrl.Owner, pullRequest.HeadRepositoryOwner, StringComparison.OrdinalIgnoreCase);
         }
 
         public IObservable<Unit> SwitchToBranch(ILocalRepositoryModel repository, PullRequestDetailModel pullRequest)

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -392,7 +392,7 @@ namespace GitHub.Services
                     {
                         await gitClient.Checkout(repo, localBranchName);
                     }
-                    else if (repository.CloneUrl.Owner == pullRequest.HeadRepositoryOwner)
+                    else if (string.Equals(repository.CloneUrl.Owner, pullRequest.HeadRepositoryOwner, StringComparison.OrdinalIgnoreCase))
                     {
                         var remote = await gitClient.GetHttpRemote(repo, "origin");
                         await gitClient.Fetch(repo, remote.Name);
@@ -524,7 +524,7 @@ namespace GitHub.Services
 
         public bool IsPullRequestFromRepository(ILocalRepositoryModel repository, PullRequestDetailModel pullRequest)
         {
-            return string.Equals(repository?.CloneUrl.Owner, pullRequest.HeadRepositoryOwner, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(repository.CloneUrl?.Owner, pullRequest.HeadRepositoryOwner, StringComparison.OrdinalIgnoreCase);
         }
 
         public IObservable<Unit> SwitchToBranch(ILocalRepositoryModel repository, PullRequestDetailModel pullRequest)

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionManager.cs
@@ -225,7 +225,7 @@ namespace GitHub.InlineReviews.Services
         {
             PullRequestSession session = null;
             WeakReference<PullRequestSession> weakSession;
-            var key = Tuple.Create(owner, number);
+            var key = Tuple.Create(owner.ToLowerInvariant(), number);
 
             if (sessions.TryGetValue(key, out weakSession))
             {

--- a/test/GitHub.App.UnitTests/Services/PullRequestServiceTests.cs
+++ b/test/GitHub.App.UnitTests/Services/PullRequestServiceTests.cs
@@ -900,6 +900,19 @@ public class PullRequestServiceTests : TestBaseClass
         }
 
         [Test]
+        public async Task ShouldReturnPullRequestBranchForPullRequestFromSameRepositoryOwnerCaseMismatchAsync()
+        {
+            var service = CreateTarget(MockGitClient(), MockGitService());
+
+            var localRepo = Substitute.For<ILocalRepositoryModel>();
+            localRepo.CloneUrl.Returns(new UriString("https://github.com/Foo/bar"));
+
+            var result = await service.GetLocalBranches(localRepo, CreatePullRequest(fromFork: false));
+
+            Assert.That("source", Is.EqualTo(result.Name));
+        }
+
+        [Test]
         public async Task ShouldReturnMarkedBranchForPullRequestFromForkAsync()
         {
             var repo = Substitute.For<IRepository>();

--- a/test/GitHub.App.UnitTests/Services/PullRequestServiceTests.cs
+++ b/test/GitHub.App.UnitTests/Services/PullRequestServiceTests.cs
@@ -778,6 +778,35 @@ public class PullRequestServiceTests : TestBaseClass
         }
 
         [Test]
+        public async Task ShouldCheckoutLocalBranchOwnerCaseMismatchAsync()
+        {
+            var gitClient = MockGitClient();
+            var service = CreateTarget(gitClient, MockGitService());
+
+            var localRepo = Substitute.For<ILocalRepositoryModel>();
+            localRepo.CloneUrl.Returns(new UriString("https://foo.bar/Owner/repo"));
+
+            var pr = new PullRequestDetailModel
+            {
+                Number = 5,
+                BaseRefName = "master",
+                BaseRefSha = "123",
+                BaseRepositoryOwner = "owner",
+                HeadRefName = "prbranch",
+                HeadRefSha = "123",
+                HeadRepositoryOwner = "owner",
+            };
+
+            await service.Checkout(localRepo, pr, "prbranch");
+
+            gitClient.Received().Fetch(Arg.Any<IRepository>(), "origin").Forget();
+            gitClient.Received().Checkout(Arg.Any<IRepository>(), "prbranch").Forget();
+            gitClient.Received().SetConfig(Arg.Any<IRepository>(), "branch.prbranch.ghfvs-pr-owner-number", "owner#5").Forget();
+
+            Assert.That(4, Is.EqualTo(gitClient.ReceivedCalls().Count()));
+        }
+
+        [Test]
         public async Task ShouldCheckoutBranchFromForkAsync()
         {
             var gitClient = MockGitClient();

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionManagerTests.cs
@@ -771,6 +771,19 @@ Line 4";
             }
 
             [Test]
+            public async Task GetSessionReturnsSameSessionForSamePullRequestOwnerCaseMismatch()
+            {
+                var target = CreateTarget();
+                var newModel = CreatePullRequestModel(NotCurrentBranchPullRequestNumber);
+                var result1 = await target.GetSession("owner", "repo", 5);
+                var result2 = await target.GetSession("Owner", "repo", 5);
+                var result3 = await target.GetSession("owner", "repo", 6);
+
+                Assert.That(result1, Is.SameAs(result2));
+                Assert.That(result1, Is.Not.SameAs(result3));
+            }
+
+            [Test]
             public async Task SessionCanBeCollected()
             {
                 WeakReference<IPullRequestSession> weakSession = null;


### PR DESCRIPTION
Fixes #1804 

1. Using a case-insensitive comparison when..
   1. attempting to determine if (the current displayed pull request == the current branch)
   1. checking out a pull request
1. Invariant lowercasing the owner name when..
   1. Finding/Creating a `PullRequestSession`