### PR TITLE
Polish checks list in pull request details

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
@@ -29,13 +29,14 @@
         </ResourceDictionary>
     </Control.Resources>
 
+
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto" SharedSizeGroup="ColumnZero" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="ColumnOne" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="ColumnTwo" />
             <ColumnDefinition Width="*"/>
-            <ColumnDefinition MinWidth="50" Width="Auto"/>
+            <ColumnDefinition MinWidth="50" Width="Auto" SharedSizeGroup="ColumnFour" />
         </Grid.ColumnDefinitions>
 
         <Grid.RowDefinitions>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
@@ -35,11 +35,11 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition MinWidth="50" Width="Auto"/>
         </Grid.ColumnDefinitions>
 
         <Grid.RowDefinitions>
-            <RowDefinition Height="32"/>
+            <RowDefinition MaxHeight="32"/>
         </Grid.RowDefinitions>
 
         <ghfvs:OcticonImage Grid.Column="0" Icon="check" Foreground="#2cbe4e" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Success}}"/>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
@@ -42,9 +42,9 @@
             <RowDefinition MaxHeight="32"/>
         </Grid.RowDefinitions>
 
-        <ghfvs:OcticonImage Grid.Column="0" Icon="check" Foreground="#2cbe4e" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Success}}"/>
-        <ghfvs:OcticonImage Grid.Column="0" Icon="x" Foreground="#cb2431" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
-        <ghfvs:OcticonImage Grid.Column="0" Icon="primitive_dot" Foreground="#f1c647" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
+        <ghfvs:OcticonImage Grid.Column="0" Margin="0 0 4 0" Icon="check" Foreground="#2cbe4e" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Success}}"/>
+        <ghfvs:OcticonImage Grid.Column="0" Margin="0 0 4 0" Icon="x" Foreground="#cb2431" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
+        <ghfvs:OcticonImage Grid.Column="0" Margin="0 0 4 0" Icon="primitive_dot" Foreground="#f1c647" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
         <Image Grid.Column="1" Source="{Binding Avatar}" Height="16" Width="16" />
         <Label Grid.Column="2" Content="{Binding Title}"/>
         <!--

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
@@ -47,7 +47,9 @@
         <ghfvs:OcticonImage Grid.Column="0" Icon="clock" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
         <Image Grid.Column="1" Source="{Binding Avatar}" Height="16" Width="16" />
         <Label Grid.Column="2" Content="{Binding Title}"/>
-        <Label Grid.Column="3" HorizontalAlignment="Right" Content="{Binding Description}" ToolTip="{Binding Description}" />
+        <!--
+            <Label Grid.Column="3" HorizontalAlignment="Right" Content="{Binding Description}" ToolTip="{Binding Description}" />
+        -->
         <Label Grid.Column="4" HorizontalAlignment="Right">
             <Hyperlink ToolTip="{Binding DetailsUrl}"  Command="{Binding OpenDetailsUrl}">Details</Hyperlink>
         </Label>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
@@ -45,7 +45,7 @@
         <ghfvs:OcticonImage Grid.Column="0" Icon="check" Foreground="#2cbe4e" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Success}}"/>
         <ghfvs:OcticonImage Grid.Column="0" Icon="x" Foreground="#cb2431" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
         <ghfvs:OcticonImage Grid.Column="0" Icon="clock" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
-        <Image Grid.Column="1" Source="{Binding Avatar}"/>
+        <Image Grid.Column="1" Source="{Binding Avatar}" Height="16" Width="16" />
         <Label Grid.Column="2" Content="{Binding Title}"/>
         <Label Grid.Column="3" HorizontalAlignment="Right" Content="{Binding Description}" ToolTip="{Binding Description}" />
         <Label Grid.Column="4" HorizontalAlignment="Right">

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
@@ -46,7 +46,7 @@
         <ghfvs:OcticonImage Grid.Column="0" Margin="0 0 4 0" Icon="x" Foreground="#cb2431" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
         <ghfvs:OcticonImage Grid.Column="0" Margin="0 0 4 0" Icon="primitive_dot" Foreground="#f1c647" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
         <Image Grid.Column="1" Source="{Binding Avatar}" Height="16" Width="16" />
-        <Label Grid.Column="2" Content="{Binding Title}"/>
+        <Label Grid.Column="2" Foreground="{DynamicResource VsBrush.WindowText}" Content="{Binding Title}"/>
         <!--
             <Label Grid.Column="3" HorizontalAlignment="Right" Content="{Binding Description}" ToolTip="{Binding Description}" />
         -->

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
@@ -44,7 +44,7 @@
 
         <ghfvs:OcticonImage Grid.Column="0" Icon="check" Foreground="#2cbe4e" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Success}}"/>
         <ghfvs:OcticonImage Grid.Column="0" Icon="x" Foreground="#cb2431" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
-        <ghfvs:OcticonImage Grid.Column="0" Icon="clock" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
+        <ghfvs:OcticonImage Grid.Column="0" Icon="primitive_dot" Foreground="#f1c647" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
         <Image Grid.Column="1" Source="{Binding Avatar}" Height="16" Width="16" />
         <Label Grid.Column="2" Content="{Binding Title}"/>
         <!--

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestCheckView.xaml
@@ -29,7 +29,6 @@
         </ResourceDictionary>
     </Control.Resources>
 
-
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" SharedSizeGroup="ColumnZero" />

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -250,54 +250,18 @@
                                       IsExpanded="True"
                                       Margin="0 8 0 0"
                                       ghfvs:ScrollingVerticalStackPanel.IsFixed="true">
-                    <ListView ItemsSource="{Binding Checks}" Margin="0 4 12 4">
-                        <ListView.View>
-                            <GridView>
-                                <!-- Column for check status octicon -->
-                                <GridViewColumn>
-                                    <GridViewColumn.CellTemplate>
-                                        <DataTemplate>
-                                            <StackPanel>
-                                                <ghfvs:OcticonImage Margin="0 0 4 0" Icon="check" Foreground="#2cbe4e" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Success}}"/>
-                                                <ghfvs:OcticonImage Margin="0 0 4 0" Icon="x" Foreground="#cb2431" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
-                                                <ghfvs:OcticonImage Margin="0 0 4 0" Icon="primitive_dot" Foreground="#f1c647" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
-                                            </StackPanel>
-                                        </DataTemplate>
-                                    </GridViewColumn.CellTemplate>
-                                </GridViewColumn>
-
-                                <!-- Checks Logo -->
-                                <GridViewColumn>
-                                    <GridViewColumn.CellTemplate>
-                                        <DataTemplate>
-                                            <Image Source="{Binding Avatar}" Height="16" Width="16" />
-                                        </DataTemplate>
-                                    </GridViewColumn.CellTemplate>
-                                </GridViewColumn>
-
-                                <!-- Title -->
-                                <GridViewColumn DisplayMemberBinding="{Binding Title}" />
-
-                                <!-- Details -->
-                                <GridViewColumn>
-                                    <GridViewColumn.CellTemplate>
-                                        <DataTemplate>
-                                            <Label Grid.Column="4" HorizontalAlignment="Right">
-                                                <Hyperlink ToolTip="{Binding DetailsUrl}"  Command="{Binding OpenDetailsUrl}">Details</Hyperlink>
-                                            </Label>
-                                        </DataTemplate>
-                                    </GridViewColumn.CellTemplate>
-                                </GridViewColumn>
-                            </GridView>
-                        </ListView.View>
-                        <!--
+                    <ItemsControl ItemsSource="{Binding Checks}" Margin="0 4 12 4">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Grid.IsSharedSizeScope="True" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <local:PullRequestCheckView/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
-                        -->
-                    </ListView>
+                    </ItemsControl>
                 </ghfvs:SectionControl>
 
                 <!-- Files changed -->

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -250,13 +250,54 @@
                                       IsExpanded="True"
                                       Margin="0 8 0 0"
                                       ghfvs:ScrollingVerticalStackPanel.IsFixed="true">
-                    <ItemsControl ItemsSource="{Binding Checks}" Margin="0 4 12 4">
+                    <ListView ItemsSource="{Binding Checks}" Margin="0 4 12 4">
+                        <ListView.View>
+                            <GridView>
+                                <!-- Column for check status octicon -->
+                                <GridViewColumn>
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <StackPanel>
+                                                <ghfvs:OcticonImage Margin="0 0 4 0" Icon="check" Foreground="#2cbe4e" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Success}}"/>
+                                                <ghfvs:OcticonImage Margin="0 0 4 0" Icon="x" Foreground="#cb2431" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
+                                                <ghfvs:OcticonImage Margin="0 0 4 0" Icon="primitive_dot" Foreground="#f1c647" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
+
+                                <!-- Checks Logo -->
+                                <GridViewColumn>
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Image Source="{Binding Avatar}" Height="16" Width="16" />
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
+
+                                <!-- Title -->
+                                <GridViewColumn DisplayMemberBinding="{Binding Title}" />
+
+                                <!-- Details -->
+                                <GridViewColumn>
+                                    <GridViewColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Label Grid.Column="4" HorizontalAlignment="Right">
+                                                <Hyperlink ToolTip="{Binding DetailsUrl}"  Command="{Binding OpenDetailsUrl}">Details</Hyperlink>
+                                            </Label>
+                                        </DataTemplate>
+                                    </GridViewColumn.CellTemplate>
+                                </GridViewColumn>
+                            </GridView>
+                        </ListView.View>
+                        <!--
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <local:PullRequestCheckView/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                        -->
+                    </ListView>
                 </ghfvs:SectionControl>
 
                 <!-- Files changed -->

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestListItemView.xaml
@@ -100,7 +100,7 @@
                 </TextBlock>
                 <ghfvs:OcticonImage Icon="check" Foreground="#2cbe4e" Visibility="{Binding Checks, Converter={ghfvs:EqualsToVisibilityConverter Success}}"/>
                 <ghfvs:OcticonImage Icon="x" Foreground="#cb2431" Visibility="{Binding Checks, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
-                <ghfvs:OcticonImage Icon="clock" Visibility="{Binding Checks, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
+                <ghfvs:OcticonImage Icon="primitive_dot" Foreground="#f1c647" Visibility="{Binding Checks, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
             </StackPanel>
         </Grid>
     </Grid>


### PR DESCRIPTION
_Targets @StanleyGoldman's branch `stanley/check-suites-pull-request-model-1`_

----

This pull request tweaks the layout for the checks and status list inside of the pull request details view.

Specifically:

- Decrease the size of the avatars
- Have each item "share" the same grid using `SharedSizeGroup`
- Use the "primative dot" octicon for pending checks in 5c2c0f7 (this aligns us with how we communicate pending checks on dotcom)

![image](https://user-images.githubusercontent.com/1174461/43423506-78b78f70-9401-11e8-9793-2ce8cb1bf292.png)
