### PR TITLE
Remove hardcoded background color in fork dialog

### DIFF
--- a/src/GitHub.VisualStudio/Views/Dialog/ForkRepositoryExecuteView.xaml
+++ b/src/GitHub.VisualStudio/Views/Dialog/ForkRepositoryExecuteView.xaml
@@ -54,7 +54,7 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
 
-                        <ui:OcticonImage Grid.Column="0" Icon="repo_forked" Background="Red" Height="16" Width="16" />
+                        <ui:OcticonImage Grid.Column="0" Icon="repo_forked" Height="16" Width="16" />
                         <TextBlock Margin="8 0 0 0" Grid.Column="1" TextWrapping="Wrap">Fork the repository</TextBlock>
                     </Grid>
 


### PR DESCRIPTION
Fixes https://github.com/github/VisualStudio/issues/1816

I had the background red for debugging purposes and forgot to remove it before merging. :disappointed:

<img width="421" alt="screen shot 2018-07-31 at 9 56 04 am" src="https://user-images.githubusercontent.com/1174461/43474636-460df8aa-94a8-11e8-8e32-be5c8158af2b.png">

/cc @meaghanlewis for 👀 