### PR TITLE
Show a confirmation when attempting to delete a comment

### DIFF
--- a/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
+++ b/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
@@ -84,6 +84,8 @@
     <Compile Include="Margins\InlineCommentMargin.cs" />
     <Compile Include="Margins\InlineCommentMarginVisible.cs" />
     <Compile Include="Margins\InlineCommentMarginEnabled.cs" />
+    <Compile Include="Services\CommentService.cs" />
+    <Compile Include="Services\ICommentService.cs" />
     <Compile Include="PullRequestStatusBarPackage.cs" />
     <Compile Include="InlineReviewsPackage.cs" />
     <Compile Include="Models\InlineCommentThreadModel.cs" />

--- a/src/GitHub.InlineReviews/Peek/InlineCommentPeekableItemSource.cs
+++ b/src/GitHub.InlineReviews/Peek/InlineCommentPeekableItemSource.cs
@@ -16,17 +16,19 @@ namespace GitHub.InlineReviews.Peek
         readonly IPullRequestSessionManager sessionManager;
         readonly INextInlineCommentCommand nextCommentCommand;
         readonly IPreviousInlineCommentCommand previousCommentCommand;
+        readonly ICommentService commentService;
 
-        public InlineCommentPeekableItemSource(
-            IInlineCommentPeekService peekService,
+        public InlineCommentPeekableItemSource(IInlineCommentPeekService peekService,
             IPullRequestSessionManager sessionManager,
             INextInlineCommentCommand nextCommentCommand,
-            IPreviousInlineCommentCommand previousCommentCommand)
+            IPreviousInlineCommentCommand previousCommentCommand,
+            ICommentService commentService)
         {
             this.peekService = peekService;
             this.sessionManager = sessionManager;
             this.nextCommentCommand = nextCommentCommand;
             this.previousCommentCommand = previousCommentCommand;
+            this.commentService = commentService;
         }
 
         public void AugmentPeekSession(IPeekSession session, IList<IPeekableItem> peekableItems)
@@ -38,7 +40,8 @@ namespace GitHub.InlineReviews.Peek
                     session,
                     sessionManager,
                     nextCommentCommand,
-                    previousCommentCommand);
+                    previousCommentCommand,
+                    commentService);
                 viewModel.Initialize().Forget();
                 peekableItems.Add(new InlineCommentPeekableItem(viewModel));
             }

--- a/src/GitHub.InlineReviews/Peek/InlineCommentPeekableItemSourceProvider.cs
+++ b/src/GitHub.InlineReviews/Peek/InlineCommentPeekableItemSourceProvider.cs
@@ -20,18 +20,21 @@ namespace GitHub.InlineReviews.Peek
         readonly IPullRequestSessionManager sessionManager;
         readonly INextInlineCommentCommand nextCommentCommand;
         readonly IPreviousInlineCommentCommand previousCommentCommand;
+        readonly ICommentService commentService;
 
         [ImportingConstructor]
         public InlineCommentPeekableItemSourceProvider(
             IInlineCommentPeekService peekService,
             IPullRequestSessionManager sessionManager,
             INextInlineCommentCommand nextCommentCommand,
-            IPreviousInlineCommentCommand previousCommentCommand)
+            IPreviousInlineCommentCommand previousCommentCommand,
+            ICommentService commentService)
         {
             this.peekService = peekService;
             this.sessionManager = sessionManager;
             this.nextCommentCommand = nextCommentCommand;
             this.previousCommentCommand = previousCommentCommand;
+            this.commentService = commentService;
         }
 
         public IPeekableItemSource TryCreatePeekableItemSource(ITextBuffer textBuffer)
@@ -40,7 +43,8 @@ namespace GitHub.InlineReviews.Peek
                 peekService,
                 sessionManager,
                 nextCommentCommand,
-                previousCommentCommand);
+                previousCommentCommand,
+                commentService);
         }
     }
 }

--- a/src/GitHub.InlineReviews/Services/CommentService.cs
+++ b/src/GitHub.InlineReviews/Services/CommentService.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.Composition;
+using System.Windows.Forms;
+
+namespace GitHub.InlineReviews.Services
+{
+    [Export(typeof(ICommentService))]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
+    public class CommentService:ICommentService
+    {
+        public bool ConfirmCommentDelete()
+        {
+            return MessageBox.Show(
+                VisualStudio.UI.Resources.DeleteCommentConfirmation,
+                VisualStudio.UI.Resources.DeleteCommentConfirmationCaption,
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Question) == DialogResult.Yes;
+        }
+    }
+}

--- a/src/GitHub.InlineReviews/Services/ICommentService.cs
+++ b/src/GitHub.InlineReviews/Services/ICommentService.cs
@@ -1,7 +1,14 @@
 ﻿namespace GitHub.InlineReviews.Services
 {
+    /// <summary>
+    /// This service allows for functionality to be injected into the chain of different peek Comment ViewModel types.
+    /// </summary>
     public interface ICommentService
     {
+        /// <summary>
+        /// This function uses MessageBox.Show to display a confirmation if a comment should be deleted.
+        /// </summary>
+        /// <returns></returns>
         bool ConfirmCommentDelete();
     }
 }

--- a/src/GitHub.InlineReviews/Services/ICommentService.cs
+++ b/src/GitHub.InlineReviews/Services/ICommentService.cs
@@ -1,0 +1,7 @@
+﻿namespace GitHub.InlineReviews.Services
+{
+    public interface ICommentService
+    {
+        bool ConfirmCommentDelete();
+    }
+}

--- a/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
@@ -131,13 +131,11 @@ namespace GitHub.InlineReviews.ViewModels
 
         async Task DoDelete(object unused)
         {
-            string deleteCommentMessageBoxText = VisualStudio.UI.Resources.DeleteCommentConfirmation;
-            string deleteCommentCaption = VisualStudio.UI.Resources.DeleteCommentConfirmationCaption;
-            
-            MessageBoxButton deleteCommentButton = MessageBoxButton.YesNo;
-            MessageBoxImage deleteCommentImage = MessageBoxImage.Question;
-
-            MessageBoxResult result = MessageBox.Show(deleteCommentMessageBoxText, deleteCommentCaption, deleteCommentButton, deleteCommentImage);
+            var result = MessageBox.Show(
+                VisualStudio.UI.Resources.DeleteCommentConfirmation, 
+                VisualStudio.UI.Resources.DeleteCommentConfirmationCaption, 
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question);
 
             switch(result)
             {

--- a/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
@@ -5,6 +5,7 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using GitHub.Extensions;
+using GitHub.InlineReviews.Services;
 using GitHub.Logging;
 using GitHub.Models;
 using GitHub.ViewModels;
@@ -19,6 +20,7 @@ namespace GitHub.InlineReviews.ViewModels
     public class CommentViewModel : ReactiveObject, ICommentViewModel
     {
         static readonly ILogger log = LogManager.ForContext<CommentViewModel>();
+        ICommentService commentService;
         string body;
         string errorMessage;
         bool isReadOnly;
@@ -31,6 +33,7 @@ namespace GitHub.InlineReviews.ViewModels
         /// <summary>
         /// Initializes a new instance of the <see cref="CommentViewModel"/> class.
         /// </summary>
+        /// <param name="commentService">The comment service</param>
         /// <param name="thread">The thread that the comment is a part of.</param>
         /// <param name="currentUser">The current user.</param>
         /// <param name="pullRequestId">The pull request id of the comment.</param>
@@ -42,6 +45,7 @@ namespace GitHub.InlineReviews.ViewModels
         /// <param name="updatedAt">The modified date of the comment.</param>
         /// <param name="webUrl"></param>
         protected CommentViewModel(
+            ICommentService commentService,
             ICommentThreadViewModel thread,
             IActorViewModel currentUser,
             int pullRequestId,
@@ -53,6 +57,7 @@ namespace GitHub.InlineReviews.ViewModels
             DateTimeOffset updatedAt,
             Uri webUrl)
         {
+            this.commentService = commentService;
             Guard.ArgumentNotNull(thread, nameof(thread));
             Guard.ArgumentNotNull(currentUser, nameof(currentUser));
             Guard.ArgumentNotNull(author, nameof(author));
@@ -103,14 +108,17 @@ namespace GitHub.InlineReviews.ViewModels
         /// <summary>
         /// Initializes a new instance of the <see cref="CommentViewModel"/> class.
         /// </summary>
+        /// <param name="commentService">Comment Service</param>
         /// <param name="thread">The thread that the comment is a part of.</param>
         /// <param name="currentUser">The current user.</param>
         /// <param name="model">The comment model.</param>
         protected CommentViewModel(
+            ICommentService commentService,
             ICommentThreadViewModel thread,
             ActorModel currentUser,
             CommentModel model)
             : this(
+                  commentService,
                   thread, 
                   new ActorViewModel(currentUser),
                   model.PullRequestId, 
@@ -131,13 +139,7 @@ namespace GitHub.InlineReviews.ViewModels
 
         async Task DoDelete(object unused)
         {
-            var result = MessageBox.Show(
-                VisualStudio.UI.Resources.DeleteCommentConfirmation, 
-                VisualStudio.UI.Resources.DeleteCommentConfirmationCaption, 
-                MessageBoxButton.YesNo,
-                MessageBoxImage.Question);
-
-            if (result == MessageBoxResult.Yes)
+            if (commentService.ConfirmCommentDelete())
             {
                 try
                 {

--- a/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using System.Windows;
 using GitHub.Extensions;
 using GitHub.Logging;
 using GitHub.Models;
@@ -130,22 +131,41 @@ namespace GitHub.InlineReviews.ViewModels
 
         async Task DoDelete(object unused)
         {
-            try
-            {
-                ErrorMessage = null;
-                IsSubmitting = true;
+            string deleteCommentMessageBoxText = "Are you sure you want to delete this comment?";
+            string deleteCommentCaption = "Delete Comment";
+            MessageBoxButton deleteCommentButton = MessageBoxButton.YesNo;
+            MessageBoxImage deleteCommentImage = MessageBoxImage.Question;
 
-                await Thread.DeleteComment.ExecuteAsyncTask(new Tuple<int, int>(PullRequestId, DatabaseId));
-            }
-            catch (Exception e)
+            MessageBoxResult result = MessageBox.Show(deleteCommentMessageBoxText, deleteCommentCaption, deleteCommentButton, deleteCommentImage);
+
+            switch(result)
             {
-                var message = e.Message;
-                ErrorMessage = message;
-                log.Error(e, "Error Deleting comment");
-            }
-            finally
-            {
-                IsSubmitting = false;
+                case (MessageBoxResult.Yes):
+                {
+                    try
+                    {
+                        ErrorMessage = null;
+                        IsSubmitting = true;
+
+                        await Thread.DeleteComment.ExecuteAsyncTask(new Tuple<int, int>(PullRequestId, DatabaseId));
+                    }
+                    catch (Exception e)
+                    {
+                        var message = e.Message;
+                        ErrorMessage = message;
+                        log.Error(e, "Error Deleting comment");
+                    }
+                    finally
+                    {
+                        IsSubmitting = false;
+                    }
+                        break;
+                }
+
+                case (MessageBoxResult.No):
+                {
+                    break;
+                }
             }
         }
 

--- a/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
@@ -137,33 +137,24 @@ namespace GitHub.InlineReviews.ViewModels
                 MessageBoxButton.YesNo,
                 MessageBoxImage.Question);
 
-            switch(result)
+            if (result == MessageBoxResult.Yes)
             {
-                case (MessageBoxResult.Yes):
+                try
                 {
-                    try
-                    {
-                        ErrorMessage = null;
-                        IsSubmitting = true;
+                    ErrorMessage = null;
+                    IsSubmitting = true;
 
-                        await Thread.DeleteComment.ExecuteAsyncTask(new Tuple<int, int>(PullRequestId, DatabaseId));
-                    }
-                    catch (Exception e)
-                    {
-                        var message = e.Message;
-                        ErrorMessage = message;
-                        log.Error(e, "Error Deleting comment");
-                    }
-                    finally
-                    {
-                        IsSubmitting = false;
-                    }
-                        break;
+                    await Thread.DeleteComment.ExecuteAsyncTask(new Tuple<int, int>(PullRequestId, DatabaseId));
                 }
-
-                case (MessageBoxResult.No):
+                catch (Exception e)
                 {
-                    break;
+                    var message = e.Message;
+                    ErrorMessage = message;
+                    log.Error(e, "Error Deleting comment");
+                }
+                finally
+                {
+                    IsSubmitting = false;
                 }
             }
         }

--- a/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/CommentViewModel.cs
@@ -131,8 +131,9 @@ namespace GitHub.InlineReviews.ViewModels
 
         async Task DoDelete(object unused)
         {
-            string deleteCommentMessageBoxText = "Are you sure you want to delete this comment?";
-            string deleteCommentCaption = "Delete Comment";
+            string deleteCommentMessageBoxText = VisualStudio.UI.Resources.DeleteCommentConfirmation;
+            string deleteCommentCaption = VisualStudio.UI.Resources.DeleteCommentConfirmationCaption;
+            
             MessageBoxButton deleteCommentButton = MessageBoxButton.YesNo;
             MessageBoxImage deleteCommentImage = MessageBoxImage.Question;
 

--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
@@ -10,6 +10,7 @@ using GitHub.Extensions;
 using GitHub.Extensions.Reactive;
 using GitHub.Factories;
 using GitHub.InlineReviews.Commands;
+using GitHub.InlineReviews.Peek;
 using GitHub.InlineReviews.Services;
 using GitHub.Logging;
 using GitHub.Models;
@@ -31,6 +32,7 @@ namespace GitHub.InlineReviews.ViewModels
         readonly IInlineCommentPeekService peekService;
         readonly IPeekSession peekSession;
         readonly IPullRequestSessionManager sessionManager;
+        readonly ICommentService commentService;
         IPullRequestSession session;
         IPullRequestSessionFile file;
         ICommentThreadViewModel thread;
@@ -44,12 +46,12 @@ namespace GitHub.InlineReviews.ViewModels
         /// <summary>
         /// Initializes a new instance of the <see cref="InlineCommentPeekViewModel"/> class.
         /// </summary>
-        public InlineCommentPeekViewModel(
-            IInlineCommentPeekService peekService,
+        public InlineCommentPeekViewModel(IInlineCommentPeekService peekService,
             IPeekSession peekSession,
             IPullRequestSessionManager sessionManager,
             INextInlineCommentCommand nextCommentCommand,
-            IPreviousInlineCommentCommand previousCommentCommand)
+            IPreviousInlineCommentCommand previousCommentCommand,
+            ICommentService commentService)
         {
             Guard.ArgumentNotNull(peekService, nameof(peekService));
             Guard.ArgumentNotNull(peekSession, nameof(peekSession));
@@ -60,6 +62,7 @@ namespace GitHub.InlineReviews.ViewModels
             this.peekService = peekService;
             this.peekSession = peekSession;
             this.sessionManager = sessionManager;
+            this.commentService = commentService;
             triggerPoint = peekSession.GetTriggerPoint(peekSession.TextView.TextBuffer);
 
             peekSession.Dismissed += (s, e) => Dispose();
@@ -180,11 +183,11 @@ namespace GitHub.InlineReviews.ViewModels
 
             if (thread != null)
             {
-                Thread = new InlineCommentThreadViewModel(session, thread.Comments);
+                Thread = new InlineCommentThreadViewModel(commentService, session, thread.Comments);
             }
             else
             {
-                Thread = new NewInlineCommentThreadViewModel(session, file, lineNumber, leftBuffer);
+                Thread = new NewInlineCommentThreadViewModel(commentService, session, file, lineNumber, leftBuffer);
             }
 
             if (!string.IsNullOrWhiteSpace(placeholderBody))

--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentThreadViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentThreadViewModel.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using GitHub.Extensions;
+using GitHub.InlineReviews.Services;
 using GitHub.Models;
 using GitHub.Services;
 using ReactiveUI;
@@ -18,10 +19,10 @@ namespace GitHub.InlineReviews.ViewModels
         /// <summary>
         /// Initializes a new instance of the <see cref="InlineCommentThreadViewModel"/> class.
         /// </summary>
+        /// <param name="commentService">The comment service</param>
         /// <param name="session">The current PR review session.</param>
         /// <param name="comments">The comments to display in this inline review.</param>
-        public InlineCommentThreadViewModel(
-            IPullRequestSession session,
+        public InlineCommentThreadViewModel(ICommentService commentService, IPullRequestSession session,
             IEnumerable<InlineCommentModel> comments)
             : base(session.User)
         {
@@ -45,13 +46,14 @@ namespace GitHub.InlineReviews.ViewModels
             {
                 Comments.Add(new PullRequestReviewCommentViewModel(
                     session,
+                    commentService,
                     this,
                     CurrentUser,
                     comment.Review,
                     comment.Comment));
             }
 
-            Comments.Add(PullRequestReviewCommentViewModel.CreatePlaceholder(session, this, CurrentUser));
+            Comments.Add(PullRequestReviewCommentViewModel.CreatePlaceholder(session, commentService, this, CurrentUser));
         }
 
         /// <summary>

--- a/src/GitHub.InlineReviews/ViewModels/NewInlineCommentThreadViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/NewInlineCommentThreadViewModel.cs
@@ -4,6 +4,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using GitHub.Extensions;
+using GitHub.InlineReviews.Services;
 using GitHub.Models;
 using GitHub.Services;
 using ReactiveUI;
@@ -20,13 +21,14 @@ namespace GitHub.InlineReviews.ViewModels
         /// <summary>
         /// Initializes a new instance of the <see cref="InlineCommentThreadViewModel"/> class.
         /// </summary>
+        /// <param name="commentService">The comment service</param>
         /// <param name="session">The current PR review session.</param>
         /// <param name="file">The file being commented on.</param>
         /// <param name="lineNumber">The 0-based line number in the file.</param>
         /// <param name="leftComparisonBuffer">
-        /// True if the comment is being left on the left-hand-side of a diff; otherwise false.
+        ///     True if the comment is being left on the left-hand-side of a diff; otherwise false.
         /// </param>
-        public NewInlineCommentThreadViewModel(
+        public NewInlineCommentThreadViewModel(ICommentService commentService,
             IPullRequestSession session,
             IPullRequestSessionFile file,
             int lineNumber,
@@ -53,7 +55,7 @@ namespace GitHub.InlineReviews.ViewModels
                 Observable.Return(false),
                 o => null);
 
-            var placeholder = PullRequestReviewCommentViewModel.CreatePlaceholder(session, this, CurrentUser);
+            var placeholder = PullRequestReviewCommentViewModel.CreatePlaceholder(session, commentService, this, CurrentUser);
             placeholder.BeginEdit.Execute(null);
             this.WhenAnyValue(x => x.NeedsPush).Subscribe(x => placeholder.IsReadOnly = x);
             Comments.Add(placeholder);

--- a/src/GitHub.InlineReviews/ViewModels/PullRequestReviewCommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/PullRequestReviewCommentViewModel.cs
@@ -5,6 +5,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using GitHub.Extensions;
+using GitHub.InlineReviews.Services;
 using GitHub.Logging;
 using GitHub.Models;
 using GitHub.Services;
@@ -28,6 +29,7 @@ namespace GitHub.InlineReviews.ViewModels
         /// Initializes a new instance of the <see cref="PullRequestReviewCommentViewModel"/> class.
         /// </summary>
         /// <param name="session">The pull request session.</param>
+        /// <param name="commentService">The comment service</param>
         /// <param name="thread">The thread that the comment is a part of.</param>
         /// <param name="currentUser">The current user.</param>
         /// <param name="pullRequestId">The pull request id of the comment.</param>
@@ -39,7 +41,9 @@ namespace GitHub.InlineReviews.ViewModels
         /// <param name="updatedAt">The modified date of the comment.</param>
         /// <param name="isPending">Whether this is a pending comment.</param>
         /// <param name="webUrl"></param>
-        public PullRequestReviewCommentViewModel(IPullRequestSession session,
+        public PullRequestReviewCommentViewModel(
+            IPullRequestSession session,
+            ICommentService commentService,
             ICommentThreadViewModel thread,
             IActorViewModel currentUser,
             int pullRequestId,
@@ -51,7 +55,7 @@ namespace GitHub.InlineReviews.ViewModels
             DateTimeOffset updatedAt,
             bool isPending,
             Uri webUrl)
-            : base(thread, currentUser, pullRequestId, commentId, databaseId, body, state, author, updatedAt, webUrl)
+            : base(commentService, thread, currentUser, pullRequestId, commentId, databaseId, body, state, author, updatedAt, webUrl)
         {
             Guard.ArgumentNotNull(session, nameof(session));
 
@@ -81,17 +85,20 @@ namespace GitHub.InlineReviews.ViewModels
         /// Initializes a new instance of the <see cref="PullRequestReviewCommentViewModel"/> class.
         /// </summary>
         /// <param name="session">The pull request session.</param>
+        /// <param name="commentService">Comment Service</param>
         /// <param name="thread">The thread that the comment is a part of.</param>
         /// <param name="currentUser">The current user.</param>
         /// <param name="model">The comment model.</param>
         public PullRequestReviewCommentViewModel(
             IPullRequestSession session,
+            ICommentService commentService,
             ICommentThreadViewModel thread,
             IActorViewModel currentUser,
             PullRequestReviewModel review,
             PullRequestReviewCommentModel model)
             : this(
                   session,
+                  commentService,
                   thread,
                   currentUser,
                   model.PullRequestId,
@@ -110,16 +117,19 @@ namespace GitHub.InlineReviews.ViewModels
         /// Creates a placeholder comment which can be used to add a new comment to a thread.
         /// </summary>
         /// <param name="session">The pull request session.</param>
+        /// <param name="commentService">Comment Service</param>
         /// <param name="thread">The comment thread.</param>
         /// <param name="currentUser">The current user.</param>
         /// <returns>THe placeholder comment.</returns>
         public static CommentViewModel CreatePlaceholder(
             IPullRequestSession session,
+            ICommentService commentService,
             ICommentThreadViewModel thread,
             IActorViewModel currentUser)
         {
             return new PullRequestReviewCommentViewModel(
                 session,
+                commentService,
                 thread,
                 currentUser,
                 0,

--- a/src/GitHub.InlineReviews/Views/CommentView.xaml
+++ b/src/GitHub.InlineReviews/Views/CommentView.xaml
@@ -74,9 +74,9 @@
               <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" DockPanel.Dock="Right"
                           Visibility="{Binding CanDelete, Converter={ui:BooleanToVisibilityConverter}}">
                 <ui:OcticonButton Command="{Binding BeginEdit}"
-                                  Width="16"
                                   Height="16"
-                                  Margin="0"
+                                  Width="20"
+                                  Margin="0 0 4 0"
                                   Background="Transparent"
                                   Foreground="{DynamicResource GitHubVsToolWindowText}"
                                   Icon="pencil"/>

--- a/src/GitHub.UI/Controls/Buttons/OcticonButton.xaml
+++ b/src/GitHub.UI/Controls/Buttons/OcticonButton.xaml
@@ -61,13 +61,13 @@
                                    Opacity="0"
                                    SnapsToDevicePixels="True"/>
                         <Border x:Name="MouseOverBorder"
-                                Background="#FFDDDDE6"
+                                Background="{DynamicResource VsBrush.CommandBarHover}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="1"
                                 Opacity="0"
                                 SnapsToDevicePixels="True"/>
                         <Border x:Name="PressedBorder"
-                                Background="#FFCFCFDB"
+                                Background="{DynamicResource VsBrush.CommandBarMouseDownBackgroundBegin}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="1"
                                 Opacity="0"

--- a/src/GitHub.VisualStudio.UI/Resources.Designer.cs
+++ b/src/GitHub.VisualStudio.UI/Resources.Designer.cs
@@ -232,6 +232,24 @@ namespace GitHub.VisualStudio.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to delete this comment?.
+        /// </summary>
+        public static string DeleteCommentConfirmation {
+            get {
+                return ResourceManager.GetString("DeleteCommentConfirmation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete Comment.
+        /// </summary>
+        public static string DeleteCommentConfirmationCaption {
+            get {
+                return ResourceManager.GetString("DeleteCommentConfirmationCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Description.
         /// </summary>
         public static string Description {

--- a/src/GitHub.VisualStudio.UI/Resources.resx
+++ b/src/GitHub.VisualStudio.UI/Resources.resx
@@ -437,4 +437,10 @@
   <data name="Open" xml:space="preserve">
     <value>Open</value>
   </data>
+  <data name="DeleteCommentConfirmation" xml:space="preserve">
+    <value>Are you sure you want to delete this comment?</value>
+  </data>
+  <data name="DeleteCommentConfirmationCaption" xml:space="preserve">
+    <value>Delete Comment</value>
+  </data>
 </root>

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentPeekViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentPeekViewModelTests.cs
@@ -42,7 +42,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 CreatePeekSession(),
                 CreateSessionManager(),
                 Substitute.For<INextInlineCommentCommand>(),
-                Substitute.For<IPreviousInlineCommentCommand>());
+                Substitute.For<IPreviousInlineCommentCommand>(),
+                Substitute.For<ICommentService>());
 
             await target.Initialize();
 
@@ -63,7 +64,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 CreatePeekSession(),
                 CreateSessionManager(),
                 Substitute.For<INextInlineCommentCommand>(),
-                Substitute.For<IPreviousInlineCommentCommand>());
+                Substitute.For<IPreviousInlineCommentCommand>(),
+                Substitute.For<ICommentService>());
 
             await target.Initialize();
 
@@ -88,7 +90,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 CreatePeekSession(),
                 sessionManager,
                 Substitute.For<INextInlineCommentCommand>(),
-                Substitute.For<IPreviousInlineCommentCommand>());
+                Substitute.For<IPreviousInlineCommentCommand>(),
+                Substitute.For<ICommentService>());
 
             await target.Initialize();
 
@@ -110,7 +113,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 peekSession,
                 sessionManager,
                 Substitute.For<INextInlineCommentCommand>(),
-                Substitute.For<IPreviousInlineCommentCommand>());
+                Substitute.For<IPreviousInlineCommentCommand>(),
+                Substitute.For<ICommentService>());
 
             await target.Initialize();
             Assert.That(target.Thread, Is.InstanceOf(typeof(NewInlineCommentThreadViewModel)));
@@ -151,7 +155,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 peekSession,
                 sessionManager,
                 Substitute.For<INextInlineCommentCommand>(),
-                Substitute.For<IPreviousInlineCommentCommand>());
+                Substitute.For<IPreviousInlineCommentCommand>(),
+                Substitute.For<ICommentService>());
 
             await target.Initialize();
 
@@ -177,7 +182,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 CreatePeekSession(),
                 sessionManager,
                 Substitute.For<INextInlineCommentCommand>(),
-                Substitute.For<IPreviousInlineCommentCommand>());
+                Substitute.For<IPreviousInlineCommentCommand>(),
+                Substitute.For<ICommentService>());
 
             await target.Initialize();
 
@@ -209,7 +215,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 peekSession,
                 sessionManager,
                 Substitute.For<INextInlineCommentCommand>(),
-                Substitute.For<IPreviousInlineCommentCommand>());
+                Substitute.For<IPreviousInlineCommentCommand>(),
+                Substitute.For<ICommentService>());
 
             await target.Initialize();
 
@@ -245,7 +252,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 peekSession,
                 sessionManager,
                 Substitute.For<INextInlineCommentCommand>(),
-                Substitute.For<IPreviousInlineCommentCommand>());
+                Substitute.For<IPreviousInlineCommentCommand>(),
+                Substitute.For<ICommentService>());
 
             await target.Initialize();
 

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentThreadViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentThreadViewModelTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using GitHub.InlineReviews.Services;
 using GitHub.InlineReviews.ViewModels;
 using GitHub.Models;
 using GitHub.Services;
@@ -15,7 +16,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
         public void CreatesComments()
         {
             var target = new InlineCommentThreadViewModel(
-                CreateSession(),
+                Substitute.For<ICommentService>()
+                , CreateSession(),
                 CreateComments("Comment 1", "Comment 2"));
 
             Assert.That(3, Is.EqualTo(target.Comments.Count));
@@ -42,6 +44,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
         public void PlaceholderCommitEnabledWhenCommentHasBody()
         {
             var target = new InlineCommentThreadViewModel(
+                Substitute.For<ICommentService>(),
                 CreateSession(),
                 CreateComments("Comment 1"));
 
@@ -56,6 +59,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
         {
             var session = CreateSession();
             var target = new InlineCommentThreadViewModel(
+                Substitute.For<ICommentService>(),
                 session,
                 CreateComments("Comment 1", "Comment 2"));
 

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentThreadViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/InlineCommentThreadViewModelTests.cs
@@ -16,8 +16,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
         public void CreatesComments()
         {
             var target = new InlineCommentThreadViewModel(
-                Substitute.For<ICommentService>()
-                , CreateSession(),
+                Substitute.For<ICommentService>(),
+                CreateSession(),
                 CreateComments("Comment 1", "Comment 2"));
 
             Assert.That(3, Is.EqualTo(target.Comments.Count));

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/NewInlineCommentThreadViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/NewInlineCommentThreadViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
+using GitHub.InlineReviews.Services;
 using GitHub.InlineReviews.ViewModels;
 using GitHub.Models;
 using GitHub.Services;
@@ -19,6 +20,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
         public void CreatesReplyPlaceholder()
         {
             var target = new NewInlineCommentThreadViewModel(
+                Substitute.For<ICommentService>(),
                 CreateSession(),
                 Substitute.For<IPullRequestSessionFile>(),
                 10,
@@ -34,6 +36,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
         {
             var file = CreateFile();
             var target = new NewInlineCommentThreadViewModel(
+                Substitute.For<ICommentService>(),
                 CreateSession(),
                 file,
                 10,
@@ -58,6 +61,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
         {
             var file = CreateFile();
             var target = new NewInlineCommentThreadViewModel(
+                Substitute.For<ICommentService>(),
                 CreateSession(),
                 file,
                 10,
@@ -80,7 +84,9 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
         {
             var session = CreateSession();
             var file = CreateFile();
-            var target = new NewInlineCommentThreadViewModel(session, file, 10, false);
+            var target = new NewInlineCommentThreadViewModel(
+                Substitute.For<ICommentService>(),
+                session, file, 10, false);
 
             target.Comments[0].Body = "New Comment";
             target.Comments[0].CommitEdit.Execute(null);
@@ -110,7 +116,9 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 }
             });
 
-            var target = new NewInlineCommentThreadViewModel(session, file, 16, true);
+            var target = new NewInlineCommentThreadViewModel(
+                Substitute.For<ICommentService>(),
+                session, file, 16, true);
 
             target.Comments[0].Body = "New Comment";
             target.Comments[0].CommitEdit.Execute(null);

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/PullRequestReviewCommentViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/PullRequestReviewCommentViewModelTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using GitHub.InlineReviews.Services;
 using GitHub.InlineReviews.ViewModels;
 using GitHub.Models;
 using GitHub.Services;
@@ -52,7 +53,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 var session = CreateSession();
                 var thread = CreateThread();
                 var currentUser = Substitute.For<IActorViewModel>();
-                var target = PullRequestReviewCommentViewModel.CreatePlaceholder(session, thread, currentUser);
+                var commentService = Substitute.For<ICommentService>();
+                var target = PullRequestReviewCommentViewModel.CreatePlaceholder(session, commentService, thread, currentUser);
                 Assert.That(target.BeginEdit.CanExecute(new object()), Is.True);
             }
 
@@ -65,7 +67,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 var currentUser = new ActorModel { Login = "CurrentUser" };
                 var comment = new PullRequestReviewCommentModel { Author = currentUser };
 
-                var target = CreateTarget(session, thread, currentUser, null, comment);
+                var target = CreateTarget(session, null, thread, currentUser, null, comment);
                 Assert.That(target.BeginEdit.CanExecute(new object()), Is.True);
             }
 
@@ -79,7 +81,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 var otherUser = new ActorModel { Login = "OtherUser" };
                 var comment = new PullRequestReviewCommentModel { Author = otherUser };
 
-                var target = CreateTarget(session, thread, currentUser, null, comment);
+                var target = CreateTarget(session, null, thread, currentUser, null, comment);
                 Assert.That(target.BeginEdit.CanExecute(new object()), Is.False);
             }
         }
@@ -92,7 +94,8 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 var session = CreateSession();
                 var thread = CreateThread();
                 var currentUser = Substitute.For<IActorViewModel>();
-                var target = PullRequestReviewCommentViewModel.CreatePlaceholder(session, thread, currentUser);
+                var commentService = Substitute.For<ICommentService>();
+                var target = PullRequestReviewCommentViewModel.CreatePlaceholder(session, commentService, thread, currentUser);
                 Assert.That(target.Delete.CanExecute(new object()), Is.False);
             }
 
@@ -105,7 +108,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 var currentUser = new ActorModel { Login = "CurrentUser" };
                 var comment = new PullRequestReviewCommentModel { Author = currentUser };
 
-                var target = CreateTarget(session, thread, currentUser, null, comment);
+                var target = CreateTarget(session, null, thread, currentUser, null, comment);
                 Assert.That(target.Delete.CanExecute(new object()), Is.True);
             }
 
@@ -119,7 +122,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 var otherUser = new ActorModel { Login = "OtherUser" };
                 var comment = new PullRequestReviewCommentModel { Author = otherUser };
 
-                var target = CreateTarget(session, thread, currentUser, null, comment);
+                var target = CreateTarget(session, null, thread, currentUser, null, comment);
                 Assert.That(target.Delete.CanExecute(new object()), Is.False);
             }
         }
@@ -206,12 +209,14 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
         static PullRequestReviewCommentViewModel CreateTarget(
             IPullRequestSession session = null,
+            ICommentService commentService = null,
             ICommentThreadViewModel thread = null,
             ActorModel currentUser = null,
             PullRequestReviewModel review = null,
             PullRequestReviewCommentModel comment = null)
         {
             session = session ?? CreateSession();
+            commentService = commentService ?? Substitute.For<ICommentService>();
             thread = thread ?? CreateThread();
             currentUser = currentUser ?? new ActorModel { Login = "CurrentUser" };
             comment = comment ?? new PullRequestReviewCommentModel();
@@ -219,6 +224,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
 
             return new PullRequestReviewCommentViewModel(
                 session,
+                commentService,
                 thread,
                 new ActorViewModel(currentUser),
                 review,


### PR DESCRIPTION
Fixes https://github.com/github/VisualStudio/issues/1713 and https://github.com/github/VisualStudio/issues/1797

This pull request introduces a confirmation modal when a user tries to delete a comment. It also increases the spacing between the ✏️ and ❌ octicon to decrease the chance of clicking on the wrong icon:

![delete-comment](https://user-images.githubusercontent.com/1174461/43545286-56ad9e62-958a-11e8-8b8f-d46118714c6f.gif)

A couple of things that I noticed while working on this:

- I did not provide any designs for an activity indicator. When I was testing the delete action, there wasn't anything to signal that deleting was in progress. I'll open up an issue to track this.
- If deleting a comment was successful, then it would be great if there was a way to update the UI to reflect this. Currently, the deleted comment persists, which makes it difficult to understand if deleting was successful or not. (in the gif above, I toggle the comment thread to check) This feels related to the first observation above and I will track in the same issue.
- ~The hover styles for the octicons need to be tweaked. I'll work on that in a separate branch.~ Done in 53cee1b