### PR TITLE
Fix usernames not displayed in file comments

### DIFF
--- a/src/GitHub.InlineReviews/Views/CommentView.xaml
+++ b/src/GitHub.InlineReviews/Views/CommentView.xaml
@@ -56,7 +56,7 @@
                                         Height="16" 
                                         Account="{Binding Author}"/>
 
-                <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" FontWeight="Bold" Text="{Binding User.Login}" Margin="4 0"/>
+                <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" FontWeight="Bold" Text="{Binding Author.Login}" Margin="4 0"/>
                 <ui:GitHubActionLink Content="{Binding UpdatedAt, Converter={ui:DurationToStringConverter}}"
                                      Command="{Binding OpenOnGitHub}"
                                      Foreground="{DynamicResource GitHubVsToolWindowText}"


### PR DESCRIPTION
Fixes https://github.com/github/VisualStudio/issues/1819

Usernames previously were not showing up in file comment threads. This pull requests fixes that issue.

<img width="540" alt="screen shot 2018-08-02 at 3 22 59 pm" src="https://user-images.githubusercontent.com/1174461/43614444-562fea56-9668-11e8-8190-9967ef8350df.png">
