### PR TITLE
Fix when "Start a Review" button is enabled

### DIFF
--- a/src/GitHub.InlineReviews/ViewModels/PullRequestReviewCommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/PullRequestReviewCommentViewModel.cs
@@ -58,7 +58,7 @@ namespace GitHub.InlineReviews.ViewModels
             this.session = session;
             IsPending = isPending;
 
-            var pendingReviewAndIdObservable = Observable.CombineLatest(
+            var pendingReviewAndIdAndCommentCountObservable = Observable.CombineLatest(
                 session.WhenAnyValue(x => x.HasPendingReview, x => !x),
                 this.WhenAnyValue(model => model.Id).Select(i => i == null),
                 thread.Comments.ToObservable().ToList(),
@@ -70,13 +70,13 @@ namespace GitHub.InlineReviews.ViewModels
                         = threadComments.Count(model => model.EditState == CommentEditState.None)
                 });
 
-            var canStartReviewObservable = pendingReviewAndIdObservable
+            var canStartReviewObservable = pendingReviewAndIdAndCommentCountObservable
                 .Select(arg => arg.hasPendingReview && arg.isNewComment && arg.threadCommentCount == 0);
 
             canStartReview = canStartReviewObservable
                     .ToProperty(this, x => x.CanStartReview);
 
-            commitCaption = pendingReviewAndIdObservable
+            commitCaption = pendingReviewAndIdAndCommentCountObservable
                 .Select(arg => !arg.isNewComment ? Resources.UpdateComment : arg.hasPendingReview ? Resources.AddSingleComment : Resources.AddReviewComment)
                 .ToProperty(this, x => x.CommitCaption);
 

--- a/src/GitHub.InlineReviews/ViewModels/PullRequestReviewCommentViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/PullRequestReviewCommentViewModel.cs
@@ -61,14 +61,8 @@ namespace GitHub.InlineReviews.ViewModels
             var pendingReviewAndCommentDataObservable = Observable.CombineLatest(
                 session.WhenAnyValue(x => x.HasPendingReview, x => !x),
                 this.WhenAnyValue(model => model.Id).Select(i => i == null),
-                thread.Comments.ToObservable().ToList(),
-                (hasPendingReview, isNewComment, threadComments) => new
-                {
-                    hasPendingReview,
-                    isNewComment,
-                    hasCommentsInThread
-                        = threadComments.Any(model => model.EditState == CommentEditState.None)
-                });
+                thread.Comments.ToObservable().ToList().Select(list => list.Any(model => model.EditState == CommentEditState.None)),
+                (hasPendingReview, isNewComment, hasCommentsInThread) => new { hasPendingReview, isNewComment, hasCommentsInThread });
 
             var canStartReviewObservable = pendingReviewAndCommentDataObservable
                 .Select(arg => arg.hasPendingReview && arg.isNewComment && !arg.hasCommentsInThread);

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/PullRequestReviewCommentViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/PullRequestReviewCommentViewModelTests.cs
@@ -191,12 +191,12 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             }
 
             [Test]
-            public void IsDisabledWhenSessionHasNoPendingReview()
+            public void IsEnabledWhenSessionHasNoPendingReview()
             {
                 var session = CreateSession(false);
                 var target = CreateTarget(session);
 
-                Assert.That(target.StartReview.CanExecute(null), Is.False);
+                Assert.That(target.StartReview.CanExecute(null), Is.True);
             }
 
             [Test]

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/PullRequestReviewCommentViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/PullRequestReviewCommentViewModelTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.ObjectModel;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using GitHub.InlineReviews.ViewModels;
@@ -31,6 +32,24 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 var target = CreateTarget(session);
 
                 Assert.That(target.CanStartReview, Is.True);
+            }
+
+            [Test]
+            public void IsFalseWhenThreadHasPreexistingComments()
+            {
+                var session = CreateSession();
+
+                var commentViewModel = Substitute.For<ICommentViewModel>();
+                commentViewModel.EditState.Returns(CommentEditState.None);
+
+                var commentThreadViewModel = CreateThread();
+                commentThreadViewModel.Comments.Returns(new ObservableCollection<ICommentViewModel>(
+                    new[] {commentViewModel}
+                ));
+
+                var target = CreateTarget(session, commentThreadViewModel);
+
+                Assert.That(target.CanStartReview, Is.False);
             }
 
             [Test]
@@ -247,6 +266,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
         {
             var result = Substitute.For<ICommentThreadViewModel>();
             result.PostComment.Returns(ReactiveCommand.CreateAsyncTask(_ => Task.CompletedTask));
+            result.Comments.Returns(new ObservableCollection<ICommentViewModel>());
             return result;
         }
     }

--- a/test/GitHub.InlineReviews.UnitTests/ViewModels/PullRequestReviewCommentViewModelTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/ViewModels/PullRequestReviewCommentViewModelTests.cs
@@ -191,12 +191,12 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             }
 
             [Test]
-            public void IsEnabledWhenSessionHasNoPendingReview()
+            public void IsDisabledWhenSessionHasNoPendingReview()
             {
                 var session = CreateSession(false);
                 var target = CreateTarget(session);
 
-                Assert.That(target.StartReview.CanExecute(null), Is.True);
+                Assert.That(target.StartReview.CanExecute(null), Is.False);
             }
 
             [Test]


### PR DESCRIPTION
Fixes: #1806 

Users cannot start a review from a comment if there are already comments in the thread.

- Correct the observable that is referenced to enable the `StartReview` command.
   https://github.com/github/VisualStudio/blob/8c9f77afaafd26d4bd2a641b46fff3b2c4b9958f/src/GitHub.InlineReviews/ViewModels/PullRequestReviewCommentViewModel.cs#L83-L85

` Added a count of comments in thread of `None` state into the criteria for `CanStartReview`
  - And used that information in determining if a review can be started.
   https://github.com/github/VisualStudio/blob/956d9d6f900e7f4831f88218887c0df3be79a816/src/GitHub.InlineReviews/ViewModels/PullRequestReviewCommentViewModel.cs#L61-L68

- Changed or removed tests that depending on being able to start a review after comments were made