### PR TITLE
Install GitHub.TeamFoundation.15 MEF component in all Visual Studio versions

### DIFF
--- a/src/GitHub.TeamFoundation.15/GitHub.TeamFoundation.15.csproj
+++ b/src/GitHub.TeamFoundation.15/GitHub.TeamFoundation.15.csproj
@@ -89,8 +89,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.15.0.15.4.27004\lib\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.15.0.15.0.26228\lib\Microsoft.VisualStudio.Shell.15.0.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Framework.15.4.27004\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
@@ -130,9 +129,8 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.15.4.4\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.15.0.240\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Utilities.15.4.27004\lib\net46\Microsoft.VisualStudio.Utilities.dll</HintPath>

--- a/src/GitHub.TeamFoundation.15/packages.config
+++ b/src/GitHub.TeamFoundation.15/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.VisualStudio.Imaging" version="15.4.27004" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.SDK.EmbedInteropTypes" version="15.0.12" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Shell.15.0" version="15.4.27004" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26228" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Framework" version="15.4.27004" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.11.0" version="11.0.50727" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Shell.Immutable.14.0" version="14.3.25407" targetFramework="net461" />
@@ -16,7 +16,7 @@
   <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Threading" version="15.4.4" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.0.240" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Utilities" version="15.4.27004" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
   <package id="Rx-Core" version="2.2.5-custom" targetFramework="net45" />

--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -1,42 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="c3d3dc68-c977-411f-b3e8-03b0dccf7dfc" Version="2.5.5.0" Language="en-US" Publisher="GitHub, Inc" />
-    <DisplayName>GitHub Extension for Visual Studio</DisplayName>
-    <Description xml:space="preserve">A Visual Studio Extension that brings the GitHub Flow into Visual Studio.</Description>
-    <PackageId>GitHub.VisualStudio</PackageId>
-    <MoreInfo>https://visualstudio.github.com</MoreInfo>
-    <License>LICENSE.txt</License>
-    <ReleaseNotes>https://visualstudio.github.com/release-notes.html</ReleaseNotes>
-    <Icon>Resources\logo_32x32@2x.png</Icon>
-    <PreviewImage>Resources\preview_200x200.png</PreviewImage>
-    <Tags>GitHub;git;open source;source control;branch;pull request;team explorer;commit;publish</Tags>
-  </Metadata>
-  <Installation AllUsers="true" Experimental="false">
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0,]" />
-    <Dependency Id="Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions" DisplayName="Team Explorer" d:Source="Installed" Version="[14.0,16.0)" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Exports" Path="|GitHub.Exports|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Api" Path="|GitHub.Api|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Exports.Reactive" Path="|GitHub.Exports.Reactive|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.App" Path="|GitHub.App|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Services.Vssdk" Path="|GitHub.Services.Vssdk|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.TeamFoundation.14" TargetVersion="[14.0,15.0)" Path="|GitHub.TeamFoundation.14|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.TeamFoundation.15" TargetVersion="[15.0,16.0)" Path="|GitHub.TeamFoundation.15|" />
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitHub.InlineReviewsPackage" Path="|GitHub.InlineReviews;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitHub.StartPage" Path="|GitHub.StartPage;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.InlineReviews" Path="|GitHub.InlineReviews|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Rothko.dll" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25824.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+	<Metadata>
+		<Identity Id="c3d3dc68-c977-411f-b3e8-03b0dccf7dfc" Version="2.5.5.0" Language="en-US" Publisher="GitHub, Inc" />
+		<DisplayName>GitHub Extension for Visual Studio</DisplayName>
+		<Description xml:space="preserve">A Visual Studio Extension that brings the GitHub Flow into Visual Studio.</Description>
+		<PackageId>GitHub.VisualStudio</PackageId>
+		<MoreInfo>https://visualstudio.github.com</MoreInfo>
+		<License>LICENSE.txt</License>
+		<ReleaseNotes>https://visualstudio.github.com/release-notes.html</ReleaseNotes>
+		<Icon>Resources\logo_32x32@2x.png</Icon>
+		<PreviewImage>Resources\preview_200x200.png</PreviewImage>
+		<Tags>GitHub;git;open source;source control;branch;pull request;team explorer;commit;publish</Tags>
+	</Metadata>
+	<Installation AllUsers="true" Experimental="false">
+		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
+		<InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
+	</Installation>
+	<Dependencies>
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+		<Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0,]" />
+		<Dependency Id="Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions" DisplayName="Team Explorer" d:Source="Installed" Version="[14.0,16.0)" />
+	</Dependencies>
+	<Assets>
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Exports" Path="|GitHub.Exports|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Api" Path="|GitHub.Api|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Exports.Reactive" Path="|GitHub.Exports.Reactive|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.App" Path="|GitHub.App|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Services.Vssdk" Path="|GitHub.Services.Vssdk|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.TeamFoundation.14" TargetVersion="[14.0,15.0)" Path="|GitHub.TeamFoundation.14|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.TeamFoundation.15" TargetVersion="" Path="|GitHub.TeamFoundation.15|" />
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitHub.InlineReviewsPackage" Path="|GitHub.InlineReviews;PkgdefProjectOutputGroup|" />
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitHub.StartPage" Path="|GitHub.StartPage;PkgdefProjectOutputGroup|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.InlineReviews" Path="|GitHub.InlineReviews|" />
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Rothko.dll" />
+	</Assets>
+	<Prerequisites>
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25824.0,16.0)" DisplayName="Visual Studio core editor" />
+	</Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
It looks like https://github.com/github/VisualStudio/commit/c9703cd2a284840474b191449c52bb67b181a5e4 might have stopped the extension from working on some Visual Studio installations.

From the MEF log https://github.com/github/VisualStudio/issues/1810#issuecomment-410738319, it appears the VSIX installer is attempting to install the `GitHub.TeamFoundation.14` assembly on Visual Studio 2017 (and failing), but ignoring the `GitHub.TeamFoundation.15` assembly.

## What this PR does

- Allow the `GitHub.TeamFoundation.15` assembly to install on all Visual Studio versions

There should no change on Visual Studio 2015 which doesn't support version ranges and will attempt to install all MEF assemblies anyway.

Visual Studio 2017 should always install `GitHub.TeamFoundation.15`, even if an erroneous attempt has been made to install `GitHub.TeamFoundation.14`.

We don't know if Visual Studio 2019+ will release new `TeamFoundation` assemblies. If they don't, this change will allow the extension to carry on working. If they do, we will need to create a new `GitHub.TeamFoundation.16` project to target them.

*Update: I think this was actually an issue with a reference to Microsoft.VisualStudio.Threading v15.0*
- #1839 Reference Microsoft.VisualStudio.Threading v15.0

Fixes #1810 
