### PR TITLE
Don't allow "Open File in Solution" for deleted files.

### DIFF
--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml.cs
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml.cs
@@ -61,13 +61,15 @@ namespace GitHub.VisualStudio.Views.GitHubPane
 
                 if (fileNode != null)
                 {
-                    container.ContextMenu.DataContext = this.DataContext;
-
                     foreach (var menuItem in container.ContextMenu.Items.OfType<MenuItem>())
                     {
                         menuItem.CommandParameter = fileNode;
                     }
 
+                    // HACK: MenuItem doesn't re-query ICommand.CanExecute when CommandParameter changes. Force
+                    // this to happen by resetting its DataContext to null and then to the correct value.
+                    container.ContextMenu.DataContext = null;
+                    container.ContextMenu.DataContext = this.DataContext;
                     e.Handled = false;
                 }
             }


### PR DESCRIPTION
When a PR is checked out and a deleted file is right-clicked on the changed files list, disable the "Open File in Solution" menu item as the file won't exist.

Fixes #1348