### PR TITLE
Navigate to the correct fork in PR authoring.

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModel.cs
@@ -68,7 +68,7 @@ namespace GitHub.ViewModels.GitHubPane
                 _ => DoSubmit(Octokit.PullRequestReviewEvent.RequestChanges));
             Cancel = ReactiveCommand.CreateAsyncTask(DoCancel);
             NavigateToPullRequest = ReactiveCommand.Create().OnExecuteCompleted(_ =>
-                NavigateTo(Invariant($"{LocalRepository.Owner}/{LocalRepository.Name}/pull/{PullRequestModel.Number}")));
+                NavigateTo(Invariant($"{RemoteRepositoryOwner}/{LocalRepository.Name}/pull/{PullRequestModel.Number}")));
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
`PullRequestReviewAuthoringViewModel.NavigateToPullRequest` wasn't using `RemoteRepositoryOwner` to build the URL for the PR to navigate to.

Fixes #1683