### PR TITLE
Always create GitHub Gists on GitHub

### DIFF
--- a/src/GitHub.App/Services/DialogService.cs
+++ b/src/GitHub.App/Services/DialogService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using GitHub.Extensions;
 using GitHub.Factories;
 using GitHub.Models;
+using GitHub.Primitives;
 using GitHub.ViewModels.Dialog;
 
 namespace GitHub.Services
@@ -54,7 +55,7 @@ namespace GitHub.Services
         public async Task ShowCreateGist()
         {
             var viewModel = factory.CreateViewModel<IGistCreationViewModel>();
-            await showDialog.ShowWithFirstConnection(viewModel);
+            await showDialog.ShowWithFirstConnection(viewModel, HostAddress.GitHubDotComHostAddress);
         }
 
         public async Task ShowCreateRepositoryDialog(IConnection connection)

--- a/src/GitHub.App/ViewModels/Dialog/GitHubDialogWindowViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/GitHubDialogWindowViewModel.cs
@@ -6,6 +6,7 @@ using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using GitHub.Factories;
 using GitHub.Models;
+using GitHub.Primitives;
 using GitHub.Services;
 using ReactiveUI;
 
@@ -59,11 +60,11 @@ namespace GitHub.ViewModels.Dialog
         }
 
         /// <inheritdoc/>
-        public async Task StartWithConnection<T>(T viewModel)
+        public async Task StartWithConnection<T>(T viewModel, HostAddress hostAddress = null)
             where T : IDialogContentViewModel, IConnectionInitializedViewModel
         {
             var connections = await connectionManager.Value.GetLoadedConnections();
-            var connection = connections.FirstOrDefault(x => x.IsLoggedIn);
+            var connection = connections.FirstOrDefault(x => x.IsLoggedIn && (hostAddress == null || x.HostAddress == hostAddress));
 
             if (connection == null)
             {
@@ -80,7 +81,7 @@ namespace GitHub.ViewModels.Dialog
                     }
                     else
                     {
-                       done.OnNext(null);
+                        done.OnNext(null);
                     }
                 });
 

--- a/src/GitHub.Exports.Reactive/Services/IShowDialogService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IShowDialogService.cs
@@ -31,15 +31,16 @@ namespace GitHub.Services
         /// Shows a view model that requires a connection in the dialog.
         /// </summary>
         /// <param name="viewModel">The view model to show.</param>
+        /// <param name="hostAddress">An optional specific <see cref="HostAddress"/> to show.</param>
         /// <returns>
         /// The value returned by the <paramref name="viewModel"/>'s 
         /// <see cref="IDialogContentViewModel.Done"/> observable, or null if the dialog was
         /// canceled.
         /// <remarks>
-        /// The first existing connection will be used. If there is no existing connection, the
-        /// login dialog will be shown first.
+        /// The first existing connection will be used unless a specific <see cref="HostAddress"/> is specified.
+        /// If there is no existing connection, the login dialog will be shown first.
         /// </remarks>
-        Task<object> ShowWithFirstConnection<TViewModel>(TViewModel viewModel)
+        Task<object> ShowWithFirstConnection<TViewModel>(TViewModel viewModel, HostAddress hostAddress = null)
             where TViewModel : IDialogContentViewModel, IConnectionInitializedViewModel;
     }
 }

--- a/src/GitHub.Exports.Reactive/ViewModels/Dialog/IGitHubDialogWindowViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/Dialog/IGitHubDialogWindowViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using GitHub.Primitives;
 
 namespace GitHub.ViewModels.Dialog
 {
@@ -31,7 +32,8 @@ namespace GitHub.ViewModels.Dialog
         /// Starts displaying a view model that requires a connection.
         /// </summary>
         /// <param name="viewModel">The view model to display.</param>
-        Task StartWithConnection<T>(T viewModel)
+        /// <param name="hostAddress">An optional specific <see cref="HostAddress"/> to show.</param>
+        Task StartWithConnection<T>(T viewModel, HostAddress hostAddress = null)
             where T : IDialogContentViewModel, IConnectionInitializedViewModel;
     }
 }

--- a/src/GitHub.VisualStudio/Services/ShowDialogService.cs
+++ b/src/GitHub.VisualStudio/Services/ShowDialogService.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.Composition;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using GitHub.Primitives;
 using GitHub.Services;
 using GitHub.ViewModels;
 using GitHub.ViewModels.Dialog;
@@ -21,6 +22,7 @@ namespace GitHub.VisualStudio.UI.Services
             this.serviceProvider = serviceProvider;
         }
 
+        /// <inheritdoc/>
         public Task<object> Show(IDialogContentViewModel viewModel)
         {
             var result = default(object);
@@ -37,7 +39,8 @@ namespace GitHub.VisualStudio.UI.Services
             return Task.FromResult(result);
         }
 
-        public async Task<object> ShowWithFirstConnection<TViewModel>(TViewModel viewModel)
+        /// <inheritdoc/>
+        public async Task<object> ShowWithFirstConnection<TViewModel>(TViewModel viewModel, HostAddress hostAddress = null)
             where TViewModel : IDialogContentViewModel, IConnectionInitializedViewModel
         {
             var result = default(object);
@@ -45,7 +48,7 @@ namespace GitHub.VisualStudio.UI.Services
             using (var dialogViewModel = CreateViewModel())
             using (dialogViewModel.Done.Take(1).Subscribe(x => result = x))
             {
-                await dialogViewModel.StartWithConnection(viewModel);
+                await dialogViewModel.StartWithConnection(viewModel, hostAddress);
 
                 var window = new GitHubDialogWindow(dialogViewModel);
                 window.ShowModal();


### PR DESCRIPTION
Previously Gists were being created on the first available connection. There was no indication when it was being created on GitHub Enterprise rather than github.com. This didn't make much sense when creating and sharing a GitHub Gist.

## What this PR does

Ensure that Gists are created on github.com.

- Allow `ShowWithFirstConnection` to specify a `HostAddress`
- Make `ShowCreateGist` use `HostAddress.GitHubDotComHostAddress`

## How to test

1. Log in to GitHub Enterprise
2. Log out of GitHub
3. Select some text and right-click `GitHub > Create GitHub Gist`
4. Login dialog should appear
5. Log in to GitHub
6. Create a Gist
7. Browser should appear with Gist on GitHub not GitHub Enterprise

Fixes #1832