### PR TITLE
Style TreeViewItem

### DIFF
--- a/src/GitHub.VisualStudio.UI/Styles/ItemsControls.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ItemsControls.xaml
@@ -74,4 +74,151 @@
             </Setter.Value>
         </Setter>
     </Style>
+
+    <PathGeometry x:Key="TreeArrow" Figures="M0.5,0.5 L0.5,8.5 L4.5,4.5 z"/>
+
+    <Style x:Key="ExpandCollapseToggleStyle" TargetType="{x:Type ToggleButton}">
+        <Style.Resources>
+            <PathGeometry x:Key="ArrowCollapsed">
+                <PathGeometry.Figures>
+                    <PathFigureCollection>
+                        <PathFigure IsClosed="True" IsFilled="True" StartPoint="0.5 0.5">
+                            <PathFigure.Segments>
+                                <PathSegmentCollection>
+                                    <LineSegment Point="4.5 4.5" />
+                                    <LineSegment Point="0.5 8.5" />
+                                </PathSegmentCollection>
+                            </PathFigure.Segments>
+                        </PathFigure>
+                    </PathFigureCollection>
+                </PathGeometry.Figures>
+            </PathGeometry>
+            <PathGeometry x:Key="ArrowExpanded">
+                <PathGeometry.Figures>
+                    <PathFigureCollection>
+                        <PathFigure IsClosed="True" IsFilled="True" StartPoint="5.5 0.5">
+                            <PathFigure.Segments>
+                                <PathSegmentCollection>
+                                    <LineSegment Point="0.5 5.5" />
+                                    <LineSegment Point="5.5 5.5" />
+                                </PathSegmentCollection>
+                            </PathFigure.Segments>
+                        </PathFigure>
+                    </PathFigureCollection>
+                </PathGeometry.Figures>
+            </PathGeometry>
+        </Style.Resources>
+        <Setter Property="Focusable" Value="False"/>
+        <Setter Property="Width" Value="16"/>
+        <Setter Property="Height" Value="16"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Border Width="16" Height="16" Background="Transparent">
+                        <Path Name="ExpandPath"
+                              SnapsToDevicePixels="True"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              Data="{StaticResource ArrowCollapsed}"
+                              Stroke="{DynamicResource {x:Static vsp:TreeViewColors.GlyphBrushKey}}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Data" TargetName="ExpandPath" Value="{StaticResource ArrowExpanded}"/>
+                            <Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource {x:Static vsp:TreeViewColors.GlyphBrushKey}}"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource {x:Static vsp:TreeViewColors.GlyphMouseOverBrushKey}}"/>
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsChecked" Value="True"/>
+                                <Condition Property="IsMouseOver" Value="True"/>
+                            </MultiTrigger.Conditions>
+                            <Setter Property="Fill" TargetName="ExpandPath" Value="{DynamicResource {x:Static vsp:TreeViewColors.GlyphMouseOverBrushKey}}"/>
+                            <Setter Property="Stroke" TargetName="ExpandPath" Value="{DynamicResource {x:Static vsp:TreeViewColors.GlyphMouseOverBrushKey}}"/>
+                        </MultiTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="TreeViewItemFocusVisual">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="TreeViewItem">
+        <Setter Property="Background" Value="{DynamicResource {x:Static vsp:TreeViewColors.BackgroundBrushKey}}"/>
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+        <Setter Property="Padding" Value="1,0,0,0"/>
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static vsp:TreeViewColors.BackgroundTextBrushKey}}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource TreeViewItemFocusVisual}"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TreeViewItem}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition MinWidth="19" Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <ToggleButton x:Name="Expander"
+                                      ClickMode="Press"
+                                      IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}"
+                                      Style="{StaticResource ExpandCollapseToggleStyle}"/>
+                        <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Grid.Column="1" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
+                            <ContentPresenter x:Name="PART_Header" ContentSource="Header" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                        </Border>
+                        <ItemsPresenter x:Name="ItemsHost" Grid.ColumnSpan="2" Grid.Column="1" Grid.Row="1"/>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsExpanded" Value="false">
+                            <Setter Property="Visibility" TargetName="ItemsHost" Value="Collapsed"/>
+                        </Trigger>
+                        <Trigger Property="HasItems" Value="false">
+                            <Setter Property="Visibility" TargetName="Expander" Value="Hidden"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="true">
+                            <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static vsp:TreeViewColors.SelectedItemActiveBrushKey}}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsp:TreeViewColors.SelectedItemActiveTextBrushKey}}"/>
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsSelected" Value="true"/>
+                                <Condition Property="IsSelectionActive" Value="false"/>
+                            </MultiTrigger.Conditions>
+                            <Setter Property="Background" TargetName="Bd" Value="{DynamicResource {x:Static vsp:TreeViewColors.SelectedItemInactiveBrushKey}}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static vsp:TreeViewColors.SelectedItemInactiveTextBrushKey}}"/>
+                        </MultiTrigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="VirtualizingPanel.IsVirtualizing" Value="true">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel/>
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
 </ResourceDictionary>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestDetailView.xaml
@@ -256,6 +256,7 @@
                 <!-- Put the changes tree outside its expander, so it can scroll horizontally 
                      while the header remains fixed -->
                 <local:PullRequestFilesView DataContext="{Binding Files}"
+                                            Margin="8,0,0,0"
                                             Visibility="{Binding ElementName=changesSection, Path=IsExpanded, Converter={ghfvs:BooleanToVisibilityConverter}}"/>
             </ghfvs:ScrollingVerticalStackPanel>
         </ScrollViewer>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml
@@ -66,7 +66,7 @@
                             KeyboardNavigation.DirectionalNavigation="None">
 
                     <imaging:CrispImage Moniker="{Binding Converter={StaticResource FileNameToImageMonikerConverter}, Path=FileName}"
-                                        Width="16" Height="16" Margin="0,0,0,2"/>
+                                        Width="16" Height="16" Margin="0,2"/>
 
                     <TextBlock Text="{Binding FileName}" Margin="4 2" VerticalAlignment="Center">
                         <TextBlock.Style>

--- a/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml
+++ b/src/GitHub.VisualStudio/Views/GitHubPane/PullRequestFilesView.xaml
@@ -43,9 +43,8 @@
               MouseDoubleClick="changesTree_MouseDoubleClick"
               MouseRightButtonDown="changesTree_MouseRightButtonDown">
         <TreeView.ItemContainerStyle>
-            <Style TargetType="TreeViewItem">
+            <Style TargetType="TreeViewItem" BasedOn="{StaticResource {x:Type TreeViewItem}}">
                 <Setter Property="IsExpanded" Value="True"/>
-                <Setter Property="Foreground" Value="{DynamicResource GitHubVsWindowText}"/>
             </Style>
         </TreeView.ItemContainerStyle>
         <TreeView.Resources>


### PR DESCRIPTION
This PR adds a new style for `TreeViewItem` to match VS' theme.

- Correctly uses gray as the non-active selection background (see #1294)
- Uses the same expander size as elsewhere
- Styles the expanders to be hollow when not expanded and use correct mouseover colors

Before:

![image](https://user-images.githubusercontent.com/1775141/43832150-be2fdf92-9b06-11e8-8997-24aa9dc06fb8.png)

After:

![image](https://user-images.githubusercontent.com/1775141/43836027-49721716-9b14-11e8-8c2a-48095b5c03da.png)

Fixes #1294