### PR TITLE
Ignore zero width lines in document snapshot

### DIFF
--- a/src/GitHub.VisualStudio/Helpers/ActiveDocumentSnapshot.cs
+++ b/src/GitHub.VisualStudio/Helpers/ActiveDocumentSnapshot.cs
@@ -3,7 +3,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using GitHub.Logging;
 
 namespace GitHub.VisualStudio
@@ -32,6 +31,17 @@ namespace GitHub.VisualStudio
             if (ErrorHandler.Succeeded(textManager.GetActiveView(0, null, out view)) &&
                 ErrorHandler.Succeeded(view.GetSelection(out anchorLine, out anchorCol, out endLine, out endCol)))
             {
+                // Ignore the bottom anchor or end line if it has zero width (starts on column 0)
+                // This prevents non-visible parts of the selection from being inclused in the range
+                if (anchorLine < endLine && endCol == 0)
+                {
+                    endLine--;
+                }
+                else if (anchorLine > endLine && anchorCol == 0)
+                {
+                    anchorLine--;
+                }
+
                 StartLine = anchorLine + 1;
                 EndLine = endLine + 1;
             }


### PR DESCRIPTION
When a selection ends with a zero width line, this extra line was being included in the selected range.

### What this PR does

- Trim any extra new line from the active document snapshot

### How to test

1. Select some text
![image](https://user-images.githubusercontent.com/11719160/43835021-3ce27c18-9b08-11e8-84e2-7b068311c30c.png)
2. Right-click, `GitHub > Open on GitHub`

- Only the selected text should be highlighted on github.com

Fixes #1843