### PR TITLE
Make publish repository description only accept a single line

### DIFF
--- a/src/GitHub.VisualStudio/Views/TeamExplorer/RepositoryPublishView.xaml
+++ b/src/GitHub.VisualStudio/Views/TeamExplorer/RepositoryPublishView.xaml
@@ -123,7 +123,8 @@
                TextWrapping="WrapWithOverflow"
                PromptText="{x:Static prop:Resources.DescriptionOptional}"
                SpellCheck.IsEnabled="True"
-               AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.TeamExplorerPublishRepositoryDescriptionTextBox}" />
+               AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.TeamExplorerPublishRepositoryDescriptionTextBox}"
+               VerticalContentAlignment="Center" />
     </Grid>
 
         <CheckBox x:Name="makePrivate"

--- a/src/GitHub.VisualStudio/Views/TeamExplorer/RepositoryPublishView.xaml
+++ b/src/GitHub.VisualStudio/Views/TeamExplorer/RepositoryPublishView.xaml
@@ -115,9 +115,8 @@
     
     <Grid>
       <ghfvs:PromptTextBox x:Name="description"
-               Height="52"
+               Height="23"
                Margin="0,8,0,0"
-               AcceptsReturn="True"
                Background="{DynamicResource GitHubVsSearchBoxBackground}"
                Foreground="{DynamicResource GitHubVsWindowText}"
                Text="{Binding Description}"


### PR DESCRIPTION
The description of a repository should be a single and will fail with, "description control characters are not allowed" if the description includes a line break.

### What this PR does

- Change the publish to GitHub description to not accept return

### How to test

1. Create a new project with a Git repository
2. Open the GitHub pane
3. Click the `Get Started` button
4. Check that the `Description` text box won't accept multiple lines

It should look like this:

![image](https://user-images.githubusercontent.com/11719160/43915070-81968418-9c01-11e8-885b-16a45628e587.png)

Fixes #1777