### PR TITLE
Don't crash when cancelling a PR review.

### DIFF
--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -230,13 +230,8 @@ namespace GitHub.InlineReviews.Services
                 throw new InvalidOperationException("There is no pending review to cancel.");
             }
 
-            await service.CancelPendingReview(LocalRepository, PendingReviewId);
-
-            PullRequest.Reviews = PullRequest.Reviews
-                .Where(x => x.Id != PendingReviewId)
-                .ToList();
-
-            await Update(PullRequest);
+            var pullRequest = await service.CancelPendingReview(LocalRepository, PendingReviewId);
+            await Update(pullRequest);
         }
 
         /// <inheritdoc/>

--- a/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
+++ b/test/GitHub.InlineReviews.UnitTests/Services/PullRequestSessionTests.cs
@@ -143,10 +143,11 @@ namespace GitHub.InlineReviews.UnitTests.Services
             {
                 var currentUser = CreateActor();
                 var review = CreateReview(author: currentUser, state: PullRequestReviewState.Pending);
+                var service = Substitute.For<IPullRequestSessionService>();
                 var pr = CreatePullRequest(review);
 
                 var target = new PullRequestSession(
-                    Substitute.For<IPullRequestSessionService>(),
+                    service,
                     currentUser,
                     pr,
                     Substitute.For<ILocalRepositoryModel>(),
@@ -155,6 +156,7 @@ namespace GitHub.InlineReviews.UnitTests.Services
 
                 Assert.That(target.HasPendingReview, Is.True);
 
+                service.CancelPendingReview(null, null).ReturnsForAnyArgs(CreatePullRequest());
                 await target.CancelReview();
 
                 Assert.That(target.HasPendingReview, Is.False);
@@ -329,6 +331,8 @@ Line 4";
                 var service = Substitute.For<IPullRequestSessionService>();
                 var target = CreateTargetWithPendingReview(service);
 
+                service.CancelPendingReview(null, null).ReturnsForAnyArgs(CreatePullRequest());
+
                 await target.CancelReview();
 
                 await service.Received(1).CancelPendingReview(
@@ -341,6 +345,8 @@ Line 4";
             {
                 var service = Substitute.For<IPullRequestSessionService>();
                 var target = CreateTargetWithPendingReview(service);
+
+                service.CancelPendingReview(null, null).ReturnsForAnyArgs(CreatePullRequest());
 
                 await target.CancelReview();
 


### PR DESCRIPTION
Previously we were ignoring the new PR model returned by `CancelPendingReview`, and instead mutating the current PR model (wrongly) causing the crash in #1847.

Fixes #1847