### PR TITLE
Allow user to choose between creating GitHub or GitHub Enterprise Gist

### DIFF
--- a/src/GitHub.App/Services/DialogService.cs
+++ b/src/GitHub.App/Services/DialogService.cs
@@ -54,8 +54,16 @@ namespace GitHub.Services
         public async Task ShowCreateGist(IConnection connection)
         {
             var viewModel = factory.CreateViewModel<IGistCreationViewModel>();
-            await viewModel.InitializeAsync(connection);
-            await showDialog.Show(viewModel);
+
+            if (connection != null)
+            {
+                await viewModel.InitializeAsync(connection);
+                await showDialog.Show(viewModel);
+            }
+            else
+            {
+                await showDialog.ShowWithFirstConnection(viewModel);
+            }
         }
 
         public async Task ShowCreateRepositoryDialog(IConnection connection)

--- a/src/GitHub.App/Services/DialogService.cs
+++ b/src/GitHub.App/Services/DialogService.cs
@@ -51,10 +51,11 @@ namespace GitHub.Services
             return (string)await showDialog.ShowWithFirstConnection(viewModel);
         }
 
-        public async Task ShowCreateGist()
+        public async Task ShowCreateGist(IConnection connection)
         {
             var viewModel = factory.CreateViewModel<IGistCreationViewModel>();
-            await showDialog.ShowWithFirstConnection(viewModel);
+            await viewModel.InitializeAsync(connection);
+            await showDialog.Show(viewModel);
         }
 
         public async Task ShowCreateRepositoryDialog(IConnection connection)

--- a/src/GitHub.Exports/Commands/ICreateGistEnterpriseCommand.cs
+++ b/src/GitHub.Exports/Commands/ICreateGistEnterpriseCommand.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace GitHub.Commands
+{
+    /// <summary>
+    /// Creates a GitHub Enterprise gist from the currently selected text.
+    /// </summary>
+    public interface ICreateGistEnterpriseCommand : IVsCommand
+    {
+    }
+}

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -149,6 +149,7 @@
   <ItemGroup>
     <Compile Include="Commands\ICopyLinkCommand.cs" />
     <Compile Include="Commands\IBlameLinkCommand.cs" />
+    <Compile Include="Commands\ICreateGistEnterpriseCommand.cs" />
     <Compile Include="Commands\IOpenFromClipboardCommand.cs" />
     <Compile Include="Commands\IOpenFromUrlCommand.cs" />
     <Compile Include="Commands\IToggleInlineCommentMarginCommand.cs" />

--- a/src/GitHub.Exports/Services/IDialogService.cs
+++ b/src/GitHub.Exports/Services/IDialogService.cs
@@ -39,7 +39,10 @@ namespace GitHub.Services
         /// <summary>
         /// Shows the Create Gist dialog.
         /// </summary>
-        Task ShowCreateGist();
+        /// <param name="connection">
+        /// The connection to use. May not be null.
+        /// </param>
+        Task ShowCreateGist(IConnection connection);
 
         /// <summary>
         /// Shows the Create Repository dialog.

--- a/src/GitHub.Exports/Services/IDialogService.cs
+++ b/src/GitHub.Exports/Services/IDialogService.cs
@@ -40,7 +40,8 @@ namespace GitHub.Services
         /// Shows the Create Gist dialog.
         /// </summary>
         /// <param name="connection">
-        /// The connection to use. May not be null.
+        /// The connection to use. If null, the first connection will be used, or the user promted
+        /// to log in if there are no connections.
         /// </param>
         Task ShowCreateGist(IConnection connection);
 

--- a/src/GitHub.Exports/Settings/PkgCmdID.cs
+++ b/src/GitHub.Exports/Settings/PkgCmdID.cs
@@ -19,6 +19,7 @@ namespace GitHub.VisualStudio
         public const int refreshCommand = 0x302;
         public const int pullRequestCommand = 0x310;
         public const int createGistCommand = 0x400;
+        public const int createGistEnterpriseCommand = 0x401;
         public const int openLinkCommand = 0x100;
         public const int copyLinkCommand = 0x101;
         public const int goToSolutionOrPullRequestFileCommand = 0x102;

--- a/src/GitHub.VisualStudio/Commands/CreateGistCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/CreateGistCommand.cs
@@ -14,12 +14,8 @@ namespace GitHub.VisualStudio.Commands
     /// Creates a GitHub Gist from the currently selected text.
     /// </summary>
     [Export(typeof(ICreateGistCommand))]
-    public class CreateGistCommand : CreateGistCommandBase
+    public class CreateGistCommand : CreateGistCommandBase, ICreateGistCommand
     {
-        readonly Lazy<IDialogService> dialogService;
-        readonly Lazy<ISelectedTextProvider> selectedTextProvider;
-        readonly Lazy<IConnectionManager> connectionManager;
-
         [ImportingConstructor]
         protected CreateGistCommand(
             Lazy<IDialogService> dialogService,
@@ -41,10 +37,35 @@ namespace GitHub.VisualStudio.Commands
     }
 
     /// <summary>
+    /// Creates a GitHub Enterprise Gist from the currently selected text.
+    /// </summary>
+    [Export(typeof(ICreateGistEnterpriseCommand))]
+    public class CreateGistEnterpriseCommand : CreateGistCommandBase, ICreateGistEnterpriseCommand
+    {
+        [ImportingConstructor]
+        protected CreateGistEnterpriseCommand(
+            Lazy<IDialogService> dialogService,
+            Lazy<ISelectedTextProvider> selectedTextProvider,
+            Lazy<IConnectionManager> connectionManager)
+            : base(CommandSet, CommandId, dialogService, selectedTextProvider, connectionManager, false)
+        {
+        }
+
+        /// <summary>
+        /// Gets the GUID of the group the command belongs to.
+        /// </summary>
+        public static readonly Guid CommandSet = Guids.guidContextMenuSet;
+
+        /// <summary>
+        /// Gets the numeric identifier of the command.
+        /// </summary>
+        public const int CommandId = PkgCmdIDList.createGistEnterpriseCommand;
+    }
+
+    /// <summary>
     /// Creates a GitHub or GitHub Enterprise Gist from the currently selected text.
     /// </summary>
-    [Export(typeof(ICreateGistCommand))]
-    public abstract class CreateGistCommandBase : VsCommand, ICreateGistCommand
+    public abstract class CreateGistCommandBase : VsCommand
     {
         readonly bool isGitHubDotCom;
         readonly Lazy<IDialogService> dialogService;

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.vsct
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.vsct
@@ -214,6 +214,18 @@
         </Strings>
       </Button>
 
+      <Button guid="guidContextMenuSet" id="idCreateGistEnterpriseCommand" priority="0x0101" type="Button">
+        <Icon guid="guidImages" id="logo" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Create an Enterprise Gist</ButtonText>
+          <CanonicalName>.GitHub.CreateGistEnterprise</CanonicalName>
+          <LocCanonicalName>.GitHub.CreateGistEnterprise</LocCanonicalName>
+        </Strings>
+      </Button>
+
       <Button guid="guidContextMenuSet" id="openLinkCommand" type="Button">
         <Icon guid="guidImages" id="link_external" />
         <CommandFlag>IconIsMoniker</CommandFlag>
@@ -303,7 +315,11 @@
       <Parent guid="guidContextMenuSet" id="idGitHubContextSubMenuGroup"/>
     </CommandPlacement>
 
-    <CommandPlacement guid="guidContextMenuSet" id="idBlameCommand" priority="0x104">
+    <CommandPlacement guid="guidContextMenuSet" id="idCreateGistEnterpriseCommand" priority="0x104">
+      <Parent guid="guidContextMenuSet" id="idGitHubContextSubMenuGroup"/>
+    </CommandPlacement>
+
+    <CommandPlacement guid="guidContextMenuSet" id="idBlameCommand" priority="0x105">
       <Parent guid="guidContextMenuSet" id="idGitHubContextSubMenuGroup"/>
     </CommandPlacement>
 
@@ -410,6 +426,7 @@
       <IDSymbol name="copyLinkCommand" value="0x101"/>
       <IDSymbol name="goToSolutionOrPullRequestFileCommand" value="0x0102" />
       <IDSymbol name="idCreateGistCommand" value="0x0400" />
+      <IDSymbol name="idCreateGistEnterpriseCommand" value="0x0401" />
       <IDSymbol name="idBlameCommand" value="0x0500" />
     </GuidSymbol>
 

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -85,6 +85,7 @@ namespace GitHub.VisualStudio
                     exports.GetExportedValue<IBlameLinkCommand>(),
                     exports.GetExportedValue<ICopyLinkCommand>(),
                     exports.GetExportedValue<ICreateGistCommand>(),
+                    exports.GetExportedValue<ICreateGistEnterpriseCommand>(),
                     exports.GetExportedValue<IOpenLinkCommand>(),
                     exports.GetExportedValue<IOpenPullRequestsCommand>(),
                     exports.GetExportedValue<IShowCurrentPullRequestCommand>(),


### PR DESCRIPTION
Previously Gists were being created on the first available connection. There was no obvious indication when a Gist was being created on GitHub Enterprise rather than github.com.

### What this PR does

- Allow user to choose between `Create a GitHub Gist` and `Create an Enterprise Gist` when logged into both
- Make it obvious when an Enterprise Gist will be created by showing `Create an Enterprise Gist`
- Preserve original functionality and behavior (users won't find functionality missing or be surprised)

### How to test

#### When not logged in
1. Log out of GitHub and GitHub Enterprise
2. Select some text and right-click, `GitHub > Create a GitHub Gist`
3. Login to either GitHub or GitHub Enterprise
4. Create a Gist on the logged in server

![image](https://user-images.githubusercontent.com/11719160/43910536-fd5a2026-9bf4-11e8-9244-6bd9837499ab.png)

#### When logged into GitHub
1. Log in to GitHub and log out of GitHub Enterprise
2. Select some text and right-click, `GitHub > Create a GitHub Gist`
3. Only `Create a GitHub Gist` should be visible
4. Create a Gist on github.com

![image](https://user-images.githubusercontent.com/11719160/43910406-a7fc3ee8-9bf4-11e8-91c6-b18dafb622c8.png)

#### When logged into GitHub Enterprise
1. Log in to GitHub Enterprise and out of GitHub
2. Select some text and right-click, `GitHub > Create a GitHub Gist`
3. Only `Create an Enterprise Gist` should be visible
4. Create a Gist on your GitHub Enterprise server

![image](https://user-images.githubusercontent.com/11719160/43910629-3ffc377a-9bf5-11e8-94c3-41ed0c59729e.png)

#### When logged into GitHub and GitHub Enterprise
1. Log in to both GitHub and GitHub Enterprise
2. Select some text and right-click, `GitHub > Create a GitHub Gist`
3. `Create a GitHub Gist` and `Create an Enterprise Gist` should be visible
4. Create a Gist on GitHub or GitHub Enterprise

![image](https://user-images.githubusercontent.com/11719160/43911668-f8b23dd0-9bf7-11e8-9c21-bbd32d73504a.png)

### Related

This is an alternative to the following PR which only supported creating Gists on github.com.
- #1840 Always create GitHub Gists on GitHub 

Fixes #1832