### PR TITLE
Fix log source on IServiceProviderExtensions 

### DIFF
--- a/src/GitHub.Exports/Extensions/ServiceProviderExtensions.cs
+++ b/src/GitHub.Exports/Extensions/ServiceProviderExtensions.cs
@@ -8,7 +8,7 @@ namespace GitHub.Extensions
 {
     public static class IServiceProviderExtensions
     {
-        static readonly ILogger log = LogManager.ForContext<VSServices>();
+        static readonly ILogger log = LogManager.ForContext(typeof(IServiceProviderExtensions));
 
         /// <summary>
         /// Safe variant of GetService that doesn't throw exceptions if the service is


### PR DESCRIPTION
The incorrect type was being specified as the source.

- Log for `IServiceProviderExtensions` not `VSServices`

![image](https://user-images.githubusercontent.com/11719160/45545415-17062180-b812-11e8-80da-1f9e6bdb59e4.png)

