### PR TITLE
Include collaborator repositories in clone dialog list

### DIFF
--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -84,6 +84,7 @@ namespace GitHub.Services
                     .Viewer
                     .Select(viewer => new ViewerRepositoriesModel
                     {
+                        Owner = viewer.Login,
                         Repositories = viewer.Repositories(null, null, null, null, null, order, affiliation, null, null)
                             .AllPages()
                             .Select(repositorySelection).ToList(),

--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -66,7 +66,7 @@ namespace GitHub.Services
 
                 var affiliation = new RepositoryAffiliation?[]
                 {
-                    RepositoryAffiliation.Owner
+                    RepositoryAffiliation.Owner, RepositoryAffiliation.Collaborator
                 };
 
                 var repositorySelection = new Fragment<Repository, RepositoryListItemModel>(

--- a/src/GitHub.Exports/Models/ViewerRepositoriesModel.cs
+++ b/src/GitHub.Exports/Models/ViewerRepositoriesModel.cs
@@ -5,6 +5,7 @@ namespace GitHub.Models
 {
     public class ViewerRepositoriesModel
     {
+        public string Owner { get; set; }
         public IReadOnlyList<RepositoryListItemModel> Repositories { get; set; }
         public IDictionary<string, IReadOnlyList<RepositoryListItemModel>> OrganizationRepositories { get; set; }
     }


### PR DESCRIPTION
### What this PR does

The previous clone dialog implementation included collaborator repositories in its list of possible repositories  to clone. This PR adds these repositories back under the heading `Collaborator repositories`.

![image](https://user-images.githubusercontent.com/11719160/45563660-f3f56500-b845-11e8-9c60-3296b1011d61.png)

### How to test

The previous clone dialog implementation surfaced `Collaborator repositories` under separate owner sections like this:

![image](https://user-images.githubusercontent.com/11719160/45563726-24d59a00-b846-11e8-9efc-ff19b3478783.png)

The recent update shows the users repositories but not repositories they are a collaborator on like this:

![image](https://user-images.githubusercontent.com/11719160/45563785-50f11b00-b846-11e8-86d7-33a18ae9cc36.png)

- Check that repositories that the current user is a collaborator on appear under the heading `Collaborator repositories`.

Fixes #1921