### PR TITLE
Fix GitHub button on Start Page

### DIFF
--- a/src/GitHub.App/Services/DialogService.cs
+++ b/src/GitHub.App/Services/DialogService.cs
@@ -31,8 +31,6 @@ namespace GitHub.Services
 
         public async Task<CloneDialogResult> ShowCloneDialog(IConnection connection)
         {
-            Guard.ArgumentNotNull(connection, nameof(connection));
-
             var viewModel = factory.CreateViewModel<IRepositoryCloneViewModel>();
 
             return (CloneDialogResult)await showDialog.Show(

--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositoryCloneViewModel.cs
@@ -118,6 +118,11 @@ namespace GitHub.ViewModels.Dialog.Clone
                 SelectedTabIndex = 1;
             }
 
+            if (connection == null)
+            {
+                SelectedTabIndex = 2;
+            }
+
             this.WhenAnyValue(x => x.SelectedTabIndex).Subscribe(x => tabs[x].Activate().Forget());
         }
 

--- a/src/GitHub.Exports/Services/IDialogService.cs
+++ b/src/GitHub.Exports/Services/IDialogService.cs
@@ -13,8 +13,7 @@ namespace GitHub.Services
         /// Shows the Clone dialog.
         /// </summary>
         /// <param name="connection">
-        /// The connection to use. If null, the first connection will be used, or the user promted
-        /// to log in if there are no connections.
+        /// The connection to use. If null, the URL tab will be used.
         /// </param>
         /// <returns>
         /// A task that returns an instance of <see cref="CloneDialogResult"/> on success,

--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerSectionBase.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerSectionBase.cs
@@ -118,7 +118,8 @@ namespace GitHub.VisualStudio.Base
 
         protected ITeamExplorerSection GetSection(Guid section)
         {
-            var tep = (ITeamExplorerPage)TEServiceProvider.GetServiceSafe(typeof(ITeamExplorerPage));
+            // Return null if section hasn't been initialized yet
+            var tep = (ITeamExplorerPage)TEServiceProvider?.GetServiceSafe(typeof(ITeamExplorerPage));
             return tep?.GetSection(section);
         }
     }

--- a/src/GitHub.VisualStudio/Services/ShowDialogService.cs
+++ b/src/GitHub.VisualStudio/Services/ShowDialogService.cs
@@ -50,7 +50,7 @@ namespace GitHub.VisualStudio.UI.Services
             using (var dialogViewModel = CreateViewModel())
             using (dialogViewModel.Done.Take(1).Subscribe(x => result = x))
             {
-                if (!connection.Scopes.Matches(scopes))
+                if (connection != null && !connection.Scopes.Matches(scopes))
                 {
                     await dialogViewModel.StartWithLogout(viewModel, connection);
                 }

--- a/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
+++ b/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
@@ -56,7 +56,7 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
             var cm = CreateConnectionManager("https://github.com", "https://enterprise.com");
             var target = CreateTarget(connectionManager: cm);
 
-            await target.InitializeAsync(null);
+            await target.InitializeAsync(cm.Connections[0]);
 
             await target.GitHubTab.Received(1).Activate();
             await target.EnterpriseTab.DidNotReceive().Activate();
@@ -131,7 +131,7 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
         }
 
         [Test]
-        public async Task PathError_Is_Set_For_Existing_Destination()
+        public async Task PathError_Is_Set_For_Existing_File_At_Destination()
         {
             var target = CreateTarget();
             SetRepository(target.GitHubTab, CreateRepositoryModel("owner", "repo"));
@@ -284,7 +284,7 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
             service = service ?? CreateRepositoryCloneService(defaultClonePath);
             gitHubTab = gitHubTab ?? CreateSelectViewModel();
             enterpriseTab = enterpriseTab ?? CreateSelectViewModel();
-            urlTab = urlTab ?? Substitute.For<IRepositoryUrlViewModel>();
+            urlTab = urlTab ?? CreateRepositoryUrlViewModel();
 
             return new RepositoryCloneViewModel(
                 os,
@@ -308,6 +308,14 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
             repository.Owner.Returns(owner);
             repository.Name.Returns(name);
             return repository;
+        }
+
+        static IRepositoryUrlViewModel CreateRepositoryUrlViewModel()
+        {
+            var repositoryUrlViewModel = Substitute.For<IRepositoryUrlViewModel>();
+            repositoryUrlViewModel.Repository.Returns(null as IRepositoryModel);
+            repositoryUrlViewModel.Url.Returns(string.Empty);
+            return repositoryUrlViewModel;
         }
     }
 }


### PR DESCRIPTION
### What this PR does

Default to using the URL tab when no explicit connection is specified by the StartPage button. This is the neutral tab that works with both GitHub and GitHub Enterprise.

- Let StartPage pass `null` to `ShowCloneDialog`
- Updated unit tests
- Fixed exception that was appearing in log
`GetServiceSafe: Could not obtain instance of 'Microsoft.TeamFoundation.Controls.ITeamExplorerPage'`

### How to test

1. Open Visual Studio 2017
2. Click the GitHub button on the Start Page

Expect the `Clone` dialog to appear with the URL tab selected. Check that a GitHub or GitHub Enterprise repository can be cloned.

Fixes #1927