### PR TITLE
Fix start page clone.

### DIFF
--- a/src/GitHub.App/Services/DialogService.cs
+++ b/src/GitHub.App/Services/DialogService.cs
@@ -31,15 +31,21 @@ namespace GitHub.Services
 
         public async Task<CloneDialogResult> ShowCloneDialog(IConnection connection)
         {
-            Guard.ArgumentNotNull(connection, nameof(connection));
-
             var viewModel = factory.CreateViewModel<IRepositoryCloneViewModel>();
 
-            return (CloneDialogResult)await showDialog.Show(
-                viewModel,
-                connection,
-                ApiClientConfiguration.RequestedScopes)
-                .ConfigureAwait(false);
+            if (connection != null)
+            {
+                return (CloneDialogResult)await showDialog.Show(
+                    viewModel,
+                    connection,
+                    ApiClientConfiguration.RequestedScopes)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                return (CloneDialogResult)await showDialog.ShowWithFirstConnection(viewModel)
+                    .ConfigureAwait(false);
+            }
         }
 
         public async Task<string> ShowReCloneDialog(IRepositoryModel repository)

--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerSectionBase.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerSectionBase.cs
@@ -118,7 +118,8 @@ namespace GitHub.VisualStudio.Base
 
         protected ITeamExplorerSection GetSection(Guid section)
         {
-            var tep = (ITeamExplorerPage)TEServiceProvider.GetServiceSafe(typeof(ITeamExplorerPage));
+            // Return null if section hasn't been initialized yet
+            var tep = (ITeamExplorerPage)TEServiceProvider?.GetServiceSafe(typeof(ITeamExplorerPage));
             return tep?.GetSection(section);
         }
     }

--- a/src/GitHub.VisualStudio/Services/ShowDialogService.cs
+++ b/src/GitHub.VisualStudio/Services/ShowDialogService.cs
@@ -75,10 +75,10 @@ namespace GitHub.VisualStudio.UI.Services
             using (var dialogViewModel = CreateViewModel())
             using (dialogViewModel.Done.Take(1).Subscribe(x => result = x))
             {
-                await dialogViewModel.StartWithConnection(viewModel);
-
+                var task = dialogViewModel.StartWithConnection(viewModel);
                 var window = new GitHubDialogWindow(dialogViewModel);
                 window.ShowModal();
+                await task;
             }
 
             return result;


### PR DESCRIPTION
- When no connection is passed into `DialogService.ShowCloneDialog`, call `ShowWithFirstConnection` to ensure a connection exists.
- Fix bug in `ShowWithFirstConnection` where the task it returns can't be completed until the UI is shown!
- Fixed exception that was appearing in log: `GetServiceSafe: Could not obtain instance of 'Microsoft.TeamFoundation.Controls.ITeamExplorerPage'`

Fixes #1927