### PR TITLE
Show clone URL tab by default (A/B testing)

### DIFF
--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -121,7 +121,20 @@ namespace GitHub.Services
             try
             {
                 await vsGitServices.Clone(cloneUrl, repositoryPath, true, progress);
+
                 await usageTracker.IncrementCounter(x => x.NumberOfClones);
+
+                var repositoryUrl = new UriString(cloneUrl).ToRepositoryUrl();
+                var isDotCom = HostAddress.IsGitHubDotComUri(repositoryUrl);
+                if (isDotCom)
+                {
+                    await usageTracker.IncrementCounter(x => x.NumberOfGitHubClones);
+                }
+                else
+                {
+                    // If it isn't a GitHub URL, assume it's an Enterprise URL
+                    await usageTracker.IncrementCounter(x => x.NumberOfEnterpriseClones);
+                }
             }
             catch (Exception ex)
             {

--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositoryCloneViewModel.cs
@@ -24,6 +24,7 @@ namespace GitHub.ViewModels.Dialog.Clone
         readonly IConnectionManager connectionManager;
         readonly IRepositoryCloneService service;
         readonly IUsageService usageService;
+        readonly IUsageTracker usageTracker;
         readonly IReadOnlyList<IRepositoryCloneTabViewModel> tabs;
         string path;
         IRepositoryModel previousRepository;
@@ -36,6 +37,7 @@ namespace GitHub.ViewModels.Dialog.Clone
             IConnectionManager connectionManager,
             IRepositoryCloneService service,
             IUsageService usageService,
+            IUsageTracker usageTracker,
             IRepositorySelectViewModel gitHubTab,
             IRepositorySelectViewModel enterpriseTab,
             IRepositoryUrlViewModel urlTab)
@@ -44,6 +46,7 @@ namespace GitHub.ViewModels.Dialog.Clone
             this.connectionManager = connectionManager;
             this.service = service;
             this.usageService = usageService;
+            this.usageTracker = usageTracker;
 
             GitHubTab = gitHubTab;
             EnterpriseTab = enterpriseTab;
@@ -127,6 +130,19 @@ namespace GitHub.ViewModels.Dialog.Clone
             if (await IsGroupA().ConfigureAwait(false))
             {
                 SelectedTabIndex = 2;
+            }
+
+            switch (SelectedTabIndex)
+            {
+                case 0:
+                    usageTracker.IncrementCounter(model => model.NumberOfCloneViewGitHubTab).Forget();
+                    break;
+                case 1:
+                    usageTracker.IncrementCounter(model => model.NumberOfCloneViewEnterpriseTab).Forget();
+                    break;
+                case 2:
+                    usageTracker.IncrementCounter(model => model.NumberOfCloneViewUrlTab).Forget();
+                    break;
             }
         }
 

--- a/src/GitHub.Exports/Models/UsageModel.cs
+++ b/src/GitHub.Exports/Models/UsageModel.cs
@@ -89,6 +89,8 @@ namespace GitHub.Models
             public int NumberOfCloneViewGitHubTab { get; set; }
             public int NumberOfCloneViewEnterpriseTab { get; set; }
             public int NumberOfCloneViewUrlTab { get; set; }
+            public int NumberOfGitHubClones { get; set; }
+            public int NumberOfEnterpriseClones { get; set; }
         }
     }
 }

--- a/src/GitHub.Exports/Models/UsageModel.cs
+++ b/src/GitHub.Exports/Models/UsageModel.cs
@@ -86,6 +86,9 @@ namespace GitHub.Models
             public int ExecuteToggleInlineCommentMarginCommand { get; set; }
             public int NumberOfPullRequestFileMarginToggleInlineCommentMargin { get; set; }
             public int NumberOfPullRequestFileMarginViewChanges { get; set; }
+            public int NumberOfCloneViewGitHubTab { get; set; }
+            public int NumberOfCloneViewEnterpriseTab { get; set; }
+            public int NumberOfCloneViewUrlTab { get; set; }
         }
     }
 }

--- a/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
+++ b/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Numerics;
 using System.Threading.Tasks;
@@ -59,8 +60,9 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
 
             await target.InitializeAsync(connection).ConfigureAwait(false);
 
-            await usageTracker.Received(1).IncrementCounter(Arg.Is<Expression<Func<UsageModel.MeasuresModel, int>>>(
-                x => x.ToString() == expressionString)).ConfigureAwait(false);
+            await usageTracker.Received(1).IncrementCounter(Arg.Any<Expression<Func<UsageModel.MeasuresModel, int>>>()).ConfigureAwait(false);
+            var expression = (Expression<Func<UsageModel.MeasuresModel, int>>) usageTracker.ReceivedCalls().First().GetArguments()[0];
+            Assert.AreEqual(expressionString, expression.ToString());
         }
 
         [Test]

--- a/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
+++ b/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
@@ -45,11 +45,11 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
             Assert.That(target.SelectedTabIndex, Is.EqualTo(expectTabIndex));
         }
 
-        [TestCase("https://github.com", false, nameof(UsageModel.MeasuresModel.NumberOfCloneViewGitHubTab))]
-        [TestCase("https://enterprise.com", false, nameof(UsageModel.MeasuresModel.NumberOfCloneViewEnterpriseTab))]
-        [TestCase("https://github.com", true, nameof(UsageModel.MeasuresModel.NumberOfCloneViewUrlTab))]
-        [TestCase("https://enterprise.com", true, nameof(UsageModel.MeasuresModel.NumberOfCloneViewUrlTab))]
-        public async Task IncrementCounter_Showing_Default_Tab(string address, bool isGroupA, string expectCounter)
+        [TestCase("https://github.com", false, 1, nameof(UsageModel.MeasuresModel.NumberOfCloneViewGitHubTab))]
+        [TestCase("https://enterprise.com", false, 1, nameof(UsageModel.MeasuresModel.NumberOfCloneViewEnterpriseTab))]
+        [TestCase("https://github.com", true, 1, nameof(UsageModel.MeasuresModel.NumberOfCloneViewUrlTab))]
+        [TestCase("https://enterprise.com", true, 1, nameof(UsageModel.MeasuresModel.NumberOfCloneViewUrlTab))]
+        public async Task IncrementCounter_Showing_Default_Tab(string address, bool isGroupA, int numberOfCalls, string counterName)
         {
             var cm = CreateConnectionManager(address);
             var connection = cm.Connections[0];
@@ -60,8 +60,9 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
 
             await target.InitializeAsync(connection).ConfigureAwait(false);
 
-            var counter = await GetIncrementedCounter(usageTracker);
-            Assert.That(counter, Is.EqualTo(expectCounter));
+            await usageTracker.Received(numberOfCalls).IncrementCounter(
+                Arg.Is<Expression<Func<UsageModel.MeasuresModel, int>>>(x =>
+                    ((MemberExpression)x.Body).Member.Name == counterName));
         }
 
         [Test]
@@ -362,14 +363,6 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
             repository.Owner.Returns(owner);
             repository.Name.Returns(name);
             return repository;
-        }
-
-        static async Task<string> GetIncrementedCounter(IUsageTracker usageTracker)
-        {
-            await usageTracker.Received(1).IncrementCounter(Arg.Any<Expression<Func<UsageModel.MeasuresModel, int>>>()).ConfigureAwait(false);
-            var expression = (Expression<Func<UsageModel.MeasuresModel, int>>)usageTracker.ReceivedCalls().First().GetArguments()[0];
-            var counter = ((MemberExpression)expression.Body).Member.Name;
-            return counter;
         }
     }
 }

--- a/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
+++ b/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Numerics;
 using System.Threading.Tasks;
 using GitHub.Extensions;
 using GitHub.Models;
@@ -274,6 +275,8 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
             IOperatingSystem os = null,
             IConnectionManager connectionManager = null,
             IRepositoryCloneService service = null,
+            IUsageService usageService = null,
+            IUsageTracker usageTracker = null,
             IRepositorySelectViewModel gitHubTab = null,
             IRepositorySelectViewModel enterpriseTab = null,
             IRepositoryUrlViewModel urlTab = null,
@@ -282,6 +285,8 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
             os = os ?? Substitute.For<IOperatingSystem>();
             connectionManager = connectionManager ?? CreateConnectionManager("https://github.com");
             service = service ?? CreateRepositoryCloneService(defaultClonePath);
+            usageService = CreateUsageService();
+            usageTracker = Substitute.For<IUsageTracker>();
             gitHubTab = gitHubTab ?? CreateSelectViewModel();
             enterpriseTab = enterpriseTab ?? CreateSelectViewModel();
             urlTab = urlTab ?? Substitute.For<IRepositoryUrlViewModel>();
@@ -290,9 +295,21 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
                 os,
                 connectionManager,
                 service,
+                usageService,
+                usageTracker,
                 gitHubTab,
                 enterpriseTab,
                 urlTab);
+        }
+
+        static IUsageService CreateUsageService(bool isGroupA = false)
+        {
+            var usageService = Substitute.For<IUsageService>();
+            var guidBytes = new byte[16];
+            guidBytes[guidBytes.Length - 1] = (byte)(isGroupA ? 0 : 1);
+            var userGuid = new Guid(guidBytes);
+            usageService.GetUserGuid().Returns(userGuid);
+            return usageService;
         }
 
         static IRepositoryModel CreateRepositoryModel(string repo = "owner/repo")


### PR DESCRIPTION
### What this PR does

- Show clone URL tab by default 50% of the time
- Increment `NumberOfCloneView*Tab` counter when Clone dialog is displayed
- Record GitHub and GitHub Enterprise clones separately
- Add the following counters
```
NumberOfCloneViewGitHubTab
NumberOfCloneViewEnterpriseTab
NumberOfCloneViewUrlTab
NumberOfGitHubClones
NumberOfEnterpriseClones
```

### TODO

- [x] Add separate counters for `NumberOfGitHubClones` and `NumberOfEnterpriseClones`

### A/B Testing

The counters are intended to answer the following questions about showing the clone URL tab by default:

1. Does it make users more less likely to clone a repository
2. Does it make users more less likely to use the clone dialog
3. Is there any difference in behavior between GitHub and GitHub Enterprise

### How to test

#### The Start Page button
1. Open the file at `%USERPROFILE%\AppData\Local\GìtHūbVisualStudio\user.json`
2. Users with a `UserGuid` that ends with an even number will be group A (and odd ones group B)
3. Click on the `Start Page > Open > GitHub` button
4. If you're in group A the `URL` tab should be selected
5. If you're in group B the `GitHub` or `Enterprise` tab should be selected
![image](https://user-images.githubusercontent.com/11719160/45890333-a84d3900-bdba-11e8-9b54-2585e15909b0.png)
6. Change the last number of your `UserGuid`, restart Visual Studio and repeat the steps above


#### The Team Explorer - Connect buttons

1. Click the `Manage Connections` button on the `Team Explorer` tool bar
2. Click `Clone` on either the GitHub or GitHub Enterprise section
3. When the Clone dialog appears, the `NumberOfCloneViewGitHubTab`, `NumberOfCloneViewEnterpriseTab` or `NumberOfCloneViewUrlTab` counter should increment (depending on which tab is selected by default)
4. Select and clone a repository
5. The `NumberOfClones` *and* `NumberOfGitHubClones` / `NumberOfEnterpriseClones` counters should increment (depending on what type of repository as cloned)

![image](https://user-images.githubusercontent.com/11719160/45949465-d6698d80-bff3-11e8-8046-239d4af2707b.png)

Note: the counters will appear in the log when `Enable Trace Logging` is checked
![image](https://user-images.githubusercontent.com/11719160/45949690-a078d900-bff4-11e8-8f44-39adc86df6fd.png)

### Assumptions

- The last number of the `UserGuid` is random

### Related

- github/editor-tools#327: Discoverability of Clone from URL functionality
- #1937: Fix GitHub button on Start Page (Closed with discussion)