### PR TITLE
Including the xlf files in ncrunch's build

### DIFF
--- a/.ncrunch/GitHub.VisualStudio.v3.ncrunchproject
+++ b/.ncrunch/GitHub.VisualStudio.v3.ncrunchproject
@@ -1,8 +1,7 @@
 ﻿<ProjectConfiguration>
   <Settings>
     <AdditionalFilesToIncludeForProject>
-      <Value>xlf\GitHub.VisualStudio.vsct.zh-CN.xlf</Value>
-      <Value>xlf\VSPackage.zh-CN.xlf</Value>
+      <Value>xlf\**.*</Value>
     </AdditionalFilesToIncludeForProject>
     <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
   </Settings>

--- a/.ncrunch/GitHub.VisualStudio.v3.ncrunchproject
+++ b/.ncrunch/GitHub.VisualStudio.v3.ncrunchproject
@@ -1,5 +1,9 @@
 ﻿<ProjectConfiguration>
   <Settings>
+    <AdditionalFilesToIncludeForProject>
+      <Value>xlf\GitHub.VisualStudio.vsct.zh-CN.xlf</Value>
+      <Value>xlf\VSPackage.zh-CN.xlf</Value>
+    </AdditionalFilesToIncludeForProject>
     <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
   </Settings>
 </ProjectConfiguration>


### PR DESCRIPTION
NCrunch build was failing with:

```
NCrunch: This project was built on server '(local)'
..\..\packages\XliffTasks.0.2.0-beta-63125-01\build\XliffTasks.targets (92, 5): 'xlf\VSPackage.zh-CN.xlf' for 'VSPackage.resx' does not exist. Run `msbuild /t:UpdateXlf` to update .xlf files or set UpdateXlfOnBuild=true to update them on every build, but note that it is strongly discouraged to set UpdateXlfOnBuild=true in official/CI build environments as they should not modify source code during the build.
```