### PR TITLE
Count the number of clones to the default clone path

### DIFF
--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -135,6 +135,12 @@ namespace GitHub.Services
                     // If it isn't a GitHub URL, assume it's an Enterprise URL
                     await usageTracker.IncrementCounter(x => x.NumberOfEnterpriseClones);
                 }
+
+                if (repositoryPath.StartsWith(DefaultClonePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Count the number of times users clone into the Default Repository Location
+                    await usageTracker.IncrementCounter(x => x.NumberOfClonesToDefaultClonePath);
+                }
             }
             catch (Exception ex)
             {

--- a/src/GitHub.Exports/Models/UsageModel.cs
+++ b/src/GitHub.Exports/Models/UsageModel.cs
@@ -91,6 +91,7 @@ namespace GitHub.Models
             public int NumberOfCloneViewUrlTab { get; set; }
             public int NumberOfGitHubClones { get; set; }
             public int NumberOfEnterpriseClones { get; set; }
+            public int NumberOfClonesToDefaultClonePath { get; set; }
         }
     }
 }


### PR DESCRIPTION
### What this PR does

We're interested to know whether users are bothering to set their `Default Repository Location`. This PR will count the number of times a repository is cloned into a the active default location.

- Increment the `NumberOfClonesToDefaultClonePath` counter when a repository is cloned into the default clone path

### How to test

1. Clone a repository without changing the default location
2. Check that `NumberOfClonesToDefaultClonePath` has been incremented
3. Clone a repository outside of the default location
4. Check that `NumberOfClonesToDefaultClonePath` hasn't been incremented

### Questions

The `Default Repository Location` is somewhat hidden away under `Team Explorer > Settings > Global Settings`.

![image](https://user-images.githubusercontent.com/11719160/46154133-69146180-c26c-11e8-9d3f-440d2e8800e0.png)

- Are users bothering to set this default or manually changing the target path every time they clone?
- How does whether the default has been correctly set impact usage?
- Should we guide users towards changing this setting if they're setting in manually on very clone?
