### PR TITLE
Unify Newtonsoft.Json versions to 9.0.1.

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <Product>GitHub Extension for Visual Studio</Product>
-    <Version>2.5.6.0</Version>
+    <Version>2.5.7.0</Version>
     <Copyright>Copyright © GitHub, Inc. 2014-2018</Copyright>
-	  <LangVersion>7.3</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2017
-version: '2.5.6.{build}'
+version: '2.5.7.{build}'
 skip_tags: true
 install:
 - ps: |

--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Octokit.GraphQL" Version="0.1.1-beta" />
   </ItemGroup>
 </Project>

--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Editor" Version="14.3.25407" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.17" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.3.25407" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Octokit.GraphQL" Version="0.1.1-beta" />
     <PackageReference Include="Rothko" Version="0.0.3-ghfvs" />
     <PackageReference Include="Rx-Main" Version="2.2.5-custom" targetFramework="net45" />

--- a/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
+++ b/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
@@ -370,9 +370,8 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Octokit.GraphQL, Version=0.1.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Octokit.GraphQL.0.1.1-beta\lib\netstandard1.1\Octokit.GraphQL.dll</HintPath>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -475,6 +475,11 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll">
+      <Link>Newtonsoft.Json.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="Resources\preview_200x200.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -12,7 +12,7 @@
     <VsixType>v3</VsixType>
     <IsProductComponent>false</IsProductComponent>
     <ExtensionInstallationFolder>GitHub\GitHub</ExtensionInstallationFolder>
-	<XlfLanguages>zh-CN</XlfLanguages>
+    <XlfLanguages>zh-CN</XlfLanguages>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -243,9 +243,8 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Octokit.GraphQL, Version=0.1.1.0, Culture=neutral, PublicKeyToken=0be8860aee462442, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Octokit.GraphQL.0.1.1-beta\lib\netstandard1.1\Octokit.GraphQL.dll</HintPath>

--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="c3d3dc68-c977-411f-b3e8-03b0dccf7dfc" Version="2.5.6.0" Language="en-US" Publisher="GitHub, Inc" />
+    <Identity Id="c3d3dc68-c977-411f-b3e8-03b0dccf7dfc" Version="2.5.7.0" Language="en-US" Publisher="GitHub, Inc" />
     <DisplayName>GitHub Extension for Visual Studio</DisplayName>
     <Description xml:space="preserve">A Visual Studio Extension that brings the GitHub Flow into Visual Studio.</Description>
     <PackageId>GitHub.VisualStudio</PackageId>

--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -37,6 +37,7 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitHub.StartPage" Path="|GitHub.StartPage;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.InlineReviews" Path="|GitHub.InlineReviews|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Rothko.dll" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" TargetVersion="[14.0,15.0)" AssemblyName="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25824.0,)" DisplayName="Visual Studio core editor" />

--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -37,7 +37,7 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitHub.StartPage" Path="|GitHub.StartPage;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.InlineReviews" Path="|GitHub.InlineReviews|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Rothko.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" TargetVersion="[14.0,15.0)" AssemblyName="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" AssemblyName="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25824.0,)" DisplayName="Visual Studio core editor" />

--- a/src/common/SolutionInfo.cs
+++ b/src/common/SolutionInfo.cs
@@ -18,6 +18,6 @@ using System.Runtime.InteropServices;
 namespace System
 {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "2.5.6.0";
+        internal const string Version = "2.5.7.0";
     }
 }

--- a/test/GitHub.App.UnitTests/app.config
+++ b/test/GitHub.App.UnitTests/app.config
@@ -3,7 +3,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="10.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="9.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
**Note: Targets `release/2.5.7 branch`** for hotfix patch release

Previously we were using a mix of Newtonsoft.Json versions 9 and 10. As mentioned in #1774, VS extensions should not ship with a version later than 9.

- #1767 correctly downgraded the packages to 9.0.1 but then #1761 seems to have had a bad merge somewhere and undid some those changes, reverting some projects back to version 10. This PR fixes that.
- Add `Newtonsoft.Json, Version 9.0.0.0` to our package so it can be resolved inside Visual Studio 2015 using our `ProvideBindingPath` (see #1236)
- We tried including `TargetVersion="[14.0,15.0)"` on the `Newtonsoft.Json.dll` asset to prevent it from being included with the Visual Studio 2017 extension, but this appears not to work. It doesn't do any harm having it included (many extensions do).

<Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" TargetVersion="[14.0,15.0)" AssemblyName="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />

### Notes

TLDR; there are many extensions that include `Newtonsoft.Json, Version 9.0.0.0` in their package, so it should be safe for us to do the same.

The Visual Studio 2017 app config contains the following elements:
```xml
<probing privatePath="PublicAssemblies;PrivateAssemblies;... />

<dependentAssembly>
  <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
  <bindingRedirect oldVersion="1.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
</dependentAssembly>
```

With `Newtonsoft.Json, Version 9.0.0.0` (file version `9.0.1`) at:
```
C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\PrivateAssemblies\
```

The Visual Studio 2015 app config contains the following:
```xml
<dependentAssembly>
  <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
  <bindingRedirect oldVersion="4.5.0.0-6.0.0.0" newVersion="6.0.0.0"/>
</dependentAssembly>
```

With `Newtonsoft.Json, Version 6.0.0.0` (file version `6.0.4`) at:
```
C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\PrivateAssemblies
```

Because `Newtonsoft.Json.dll` exists on Visual Studio 2017's `privatePath`, all `Newtonsoft.Json` references between `1.0.0.0-9.0.0.0` will resolve to this location.

There are also multiple extensions packaged with Visual Studio 2017 that include the `Newtonsoft.Json, Version 9.0.0.0` (sometimes using `ProvideBindingPath` attribute, see #1236). Because these are loaded using the `Assembly.LoadFrom` context, the assembly in `Common7\IDE\PrivateAssemblies\` will always take priority (because it's loaded using the `Assembly.Load` context).

### How to test

- When loaded inside Visual Studio 2017, `Newtonsoft.Json, Version 9.0.0.0` should resolve to:
`C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\PrivateAssemblies\Newtonsoft.Json.dll` (or `Community` / `Professional`).

- When loaded inside Visual Studio 2015, `Newtonsoft.Json, Version 9.0.0.0` should resolve to the GitHub extensions folder (or possible the folder of some other extension that packages the same version).

Fixes #1969 