### PR TITLE
Add option to install and start Visual Studio 2015

### DIFF
--- a/GitHubVS.sln
+++ b/GitHubVS.sln
@@ -131,6 +131,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.Testing", "submo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.Wpf", "submodules\reactiveui\src\ReactiveUI.Wpf\ReactiveUI.Wpf.csproj", "{E899B03C-6E8E-4375-AB65-FC925D721D8B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InstallAndStart", "test\Launcher\InstallAndStart.csproj", "{79F32BE1-2764-4DBA-97F6-21053DE44270}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -530,6 +532,16 @@ Global
 		{E899B03C-6E8E-4375-AB65-FC925D721D8B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E899B03C-6E8E-4375-AB65-FC925D721D8B}.ReleaseWithoutVsix|Any CPU.ActiveCfg = Release|Any CPU
 		{E899B03C-6E8E-4375-AB65-FC925D721D8B}.ReleaseWithoutVsix|Any CPU.Build.0 = Release|Any CPU
+		{79F32BE1-2764-4DBA-97F6-21053DE44270}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79F32BE1-2764-4DBA-97F6-21053DE44270}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79F32BE1-2764-4DBA-97F6-21053DE44270}.DebugCodeAnalysis|Any CPU.ActiveCfg = Debug|Any CPU
+		{79F32BE1-2764-4DBA-97F6-21053DE44270}.DebugCodeAnalysis|Any CPU.Build.0 = Debug|Any CPU
+		{79F32BE1-2764-4DBA-97F6-21053DE44270}.DebugWithoutVsix|Any CPU.ActiveCfg = Debug|Any CPU
+		{79F32BE1-2764-4DBA-97F6-21053DE44270}.DebugWithoutVsix|Any CPU.Build.0 = Debug|Any CPU
+		{79F32BE1-2764-4DBA-97F6-21053DE44270}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79F32BE1-2764-4DBA-97F6-21053DE44270}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79F32BE1-2764-4DBA-97F6-21053DE44270}.ReleaseWithoutVsix|Any CPU.ActiveCfg = Release|Any CPU
+		{79F32BE1-2764-4DBA-97F6-21053DE44270}.ReleaseWithoutVsix|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,8 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-	<add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="vsixtesting" value="https://www.myget.org/F/vsixtesting/api/v3/index.json" />
     <add key="Custom Packages for GHfVS" value="lib" />
   </packageSources>
   <activePackageSource>

--- a/test/Launcher/InstallAndStart.csproj
+++ b/test/Launcher/InstallAndStart.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="VsixTesting.Installer" Version="0.1.36-beta-g2c36f902a0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GitHub.VisualStudio\GitHub.VisualStudio.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Launcher/Properties/launchSettings.json
+++ b/test/Launcher/Properties/launchSettings.json
@@ -7,6 +7,10 @@
     "Visual Studio 2017": {
       "executablePath": "$(DevEnvDir)devenv.exe",
       "commandLineArgs": "/rootsuffix Exp /log"
+    },
+    "Visual Studio 2017 - Team Explorer": {
+      "executablePath": "$(VsixTestingInstallerPath)",
+      "commandLineArgs": "/ApplicationPath \"C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\TeamExplorer\\Common7\\IDE\\devenv.exe\" /RootSuffix Exp /InstallAndStart \"$(SolutionDir)\\build\\$(Configuration)\\GitHub.VisualStudio.vsix\""
     }
   }
 }

--- a/test/Launcher/Properties/launchSettings.json
+++ b/test/Launcher/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "profiles": {
+    "Visual Studio 2015": {
+      "executablePath": "$(VsixTestingInstallerPath)",
+      "commandLineArgs": "/ApplicationPath \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\IDE\\devenv.exe\" /RootSuffix Exp /InstallAndStart \"$(SolutionDir)\\build\\$(Configuration)\\GitHub.VisualStudio.vsix\""
+    },
+    "Visual Studio 2017": {
+      "executablePath": "$(DevEnvDir)devenv.exe",
+      "commandLineArgs": "/rootsuffix Exp /log"
+    }
+  }
+}


### PR DESCRIPTION
Use `VsixTesting.Installer` and `launchSettings.json` to create an option to install and start Visual Studio 2015 / alternative versions.

### What this PR does

- Add `VsixTesting.Installer` package for installing extension and launching Visual Studio
- Add `launchSettings.json` with launch profiles for `Visual Studio 2015` and `Visual Studio 2017`
- Add `InstallAndStart.csproj` project which contains `launchSettings.json` and depends on `GitHub.VisualStudio`
- Add option to launch `Visual Studio 2017 - Team Explorer`

![image](https://user-images.githubusercontent.com/11719160/47043214-f4568800-d184-11e8-8271-30043e2c9e3c.png)

### Notes

The `launchSettings.json` file is an Sdk style project feature. If `GitHub.VisualStudio` was an Sdk style project, we wouldn't need the separate `InstallAndStart.csproj` project.

`VsixTesting.Installer` is a spin off from the https://github.com/josetr/VsixTesting project. Here is an issue with more about this option: https://github.com/josetr/VsixTesting/issues/14. It's still experimental, so the package is loaded from https://www.myget.org/F/vsixtesting/api/v3/index.json.

`Visual Studio 2017 - Team Explorer` is a version of Visual Studio 2017 with just enough for the `Team Explorer` functionality. It doesn't contain language support and few extension will install there. This minimal version should be easier to debug because there will be fewer exceptions thrown and assemblies loaded.