### PR TITLE
Tidy up Rx in PullRequestStatusBarManager

### DIFF
--- a/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
@@ -70,6 +70,7 @@ namespace GitHub.InlineReviews.Services
                 var sessions = pullRequestSessionManager.Value.WhenAnyValue(x => x.CurrentSession);
                 activeReposities
                     .CombineLatest(sessions, (r, s) => (r, s))
+                    .Throttle(TimeSpan.FromSeconds(1))
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(x => RefreshCurrentSession(x.r, x.s).Forget());
             }


### PR DESCRIPTION
- Use `CombineLatest` to combine the latest repository and PR session
- Use `Throttle(TimeSpan.FromSeconds(1))` to get rid of jitter when repo / branch change
- Use `Forget(log)` to log exception (rather than a try catch on async method)
