### PR TITLE
Fix to allow debugging Visual Studio 2019 Preview

### DIFF
--- a/test/Launcher/InstallAndStart.csproj
+++ b/test/Launcher/InstallAndStart.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VsixTesting.Installer" Version="0.1.38-beta-g6b91b368d9" />
+    <PackageReference Include="VsixTesting.Installer" Version="0.1.46-beta-g3578f97a2e" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\GitHub.VisualStudio\GitHub.VisualStudio.csproj" />


### PR DESCRIPTION
### What this PR does

- Use `VsixTesting.Installer` 0.1.47-beta which includes debugging fix

### How to test

1. Select the `InstallAndStart` project with the `Visual Studio 2019 - Preview` target.
![image](https://user-images.githubusercontent.com/11719160/47667419-cc601f00-db9d-11e8-82e4-e56722447635.png)
2. Click `Debug > Start Debugging (F5)`

Visual Studio 2019 Preview should start with the debugger attached. Previously Visual Studio 2019 would start but the debugger wouldn't remain attached.