### PR TITLE
Restore the link with the comment time.

### DIFF
--- a/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
@@ -56,7 +56,7 @@
                                         Account="{Binding Author}"/>
 
                 <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" FontWeight="Bold" Text="{Binding Author.Login}" Margin="4 0"/>
-                <ui:GitHubActionLink Content="{Binding UpdatedAt, Converter={ui:DurationToStringConverter}}"
+                <ui:GitHubActionLink Content="{Binding CreatedAt, Converter={ui:DurationToStringConverter}}"
                                      Command="{Binding OpenOnGitHub}"
                                      Foreground="{DynamicResource GitHubVsToolWindowText}"
                                      Opacity="0.75" />


### PR DESCRIPTION
The `UpdatedAt` property was renamed to `CreatedAt` (as that's what .com displays here) but the binding wasn't updated.