### PR TITLE
Fixing inline comment bugs

### DIFF
--- a/src/GitHub.App/ViewModels/PullRequestReviewCommentThreadViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestReviewCommentThreadViewModel.cs
@@ -78,7 +78,6 @@ namespace GitHub.ViewModels
         public async Task InitializeAsync(
             IPullRequestSession session,
             IPullRequestSessionFile file,
-            PullRequestReviewModel review,
             IInlineCommentThreadModel thread,
             bool addPlaceholder)
         {
@@ -97,7 +96,7 @@ namespace GitHub.ViewModels
                 await vm.InitializeAsync(
                     session,
                     this,
-                    review,
+                    comment.Review,
                     comment.Comment,
                     CommentEditState.None).ConfigureAwait(false);
                 Comments.Add(vm);
@@ -110,7 +109,7 @@ namespace GitHub.ViewModels
                 await vm.InitializeAsPlaceholderAsync(
                     session,
                     this,
-                    review.State == PullRequestReviewState.Pending,
+                    session.HasPendingReview,
                     false).ConfigureAwait(true);
 
                 var (key, secondaryKey) = GetDraftKeys(vm);

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestReviewCommentThreadViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestReviewCommentThreadViewModel.cs
@@ -46,7 +46,6 @@ namespace GitHub.ViewModels
         /// </summary>
         /// <param name="session">The pull request session.</param>
         /// <param name="file">The file that the comment is on.</param>
-        /// <param name="review">The associated review.</param>
         /// <param name="thread">The thread.</param>
         /// <param name="addPlaceholder">
         /// Whether to add a placeholder comment at the end of the thread.
@@ -54,7 +53,6 @@ namespace GitHub.ViewModels
         Task InitializeAsync(
             IPullRequestSession session,
             IPullRequestSessionFile file,
-            PullRequestReviewModel review,
             IInlineCommentThreadModel thread,
             bool addPlaceholder);
 

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -845,7 +845,7 @@ namespace GitHub.InlineReviews.Services
             }
 
             // Get the comments that are replies and place them into the relevant list.
-            foreach (CommentAdapter comment in model.Reviews.SelectMany(x => x.Comments))
+            foreach (CommentAdapter comment in model.Reviews.SelectMany(x => x.Comments).OrderBy(x => x.CreatedAt))
             {
                 if (comment.ReplyTo != null)
                 {

--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
@@ -181,7 +181,7 @@ namespace GitHub.InlineReviews.ViewModels
 
             if (thread?.Comments.Count > 0)
             {
-                await vm.InitializeAsync(session, file, thread.Comments[0].Review, thread, true);
+                await vm.InitializeAsync(session, file, thread, true);
             }
             else
             {

--- a/test/GitHub.App.UnitTests/ViewModels/PullRequestReviewCommentThreadViewModelTests.cs
+++ b/test/GitHub.App.UnitTests/ViewModels/PullRequestReviewCommentThreadViewModelTests.cs
@@ -111,7 +111,6 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             IViewViewModelFactory factory = null,
             IPullRequestSession session = null,
             IPullRequestSessionFile file = null,
-            PullRequestReviewModel review = null,
             IEnumerable<InlineCommentModel> comments = null,
             bool newThread = false)
         {
@@ -119,7 +118,6 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
             factory = factory ?? CreateFactory();
             session = session ?? CreateSession();
             file = file ?? CreateFile();
-            review = review ?? new PullRequestReviewModel();
             comments = comments ?? CreateComments();
 
             var result = new PullRequestReviewCommentThreadViewModel(draftStore, factory);
@@ -134,7 +132,7 @@ namespace GitHub.InlineReviews.UnitTests.ViewModels
                 thread.Comments.Returns(comments.ToList());
                 thread.LineNumber.Returns(10);
 
-                await result.InitializeAsync(session, file, review, thread, true);
+                await result.InitializeAsync(session, file, thread, true);
             }
 
             return result;


### PR DESCRIPTION
- Order comments when building comment threads: looks like the API has started returning pending comments out of order, so order by `CreatedAt` client-side.
- Use correct review for comments: comments in a thread can be from different reviews, use `comment.Review` rather than the review for the first comment in the thread. Also use `session.HasPendingReview` to determine whether a review is ongoing.

Fixes #2022 