### PR TITLE
Package Newtonsoft.Json.9.0.1 from OutputPath

### DIFF
--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -386,7 +386,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll">
+    <Content Include="$(OutputPath)\Newtonsoft.Json.dll">
       <Link>Newtonsoft.Json.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>


### PR DESCRIPTION
Copy Newtonsoft.Json.9.0.1 to the OutputPath and package from there,
rather than referencing the one in `..\..\packages`.