### PR TITLE
Remove repository responsibilities from TeamExplorerServiceHolder (repository refactor part 2)

### DIFF
--- a/src/GitHub.App/SampleData/GitServiceDesigner.cs
+++ b/src/GitHub.App/SampleData/GitServiceDesigner.cs
@@ -10,7 +10,6 @@ namespace GitHub.SampleData
     {
         public ILocalRepositoryModel CreateLocalRepositoryModel(string localPath) => null;
         public IBranch CreateCurrentBranchModel(ILocalRepositoryModel model) => null;
-        public void RefreshCloneUrl(ILocalRepositoryModel localRepositoryModel) { }
         public Task<string> GetLatestPushedSha(string path, string remote = "origin") => Task.FromResult<string>(null);
         public UriString GetRemoteUri(IRepository repo, string remote = "origin") => null;
         public IRepository GetRepository(string path) => null;

--- a/src/GitHub.Exports/Services/GitService.cs
+++ b/src/GitHub.Exports/Services/GitService.cs
@@ -69,18 +69,6 @@ namespace GitHub.Services
         }
 
         /// <summary>
-        /// Updates the CloneUrl from the "origin" remote.
-        /// </summary>
-        public void RefreshCloneUrl(ILocalRepositoryModel localRepositoryModel)
-        {
-            var localPath = localRepositoryModel.LocalPath;
-            if (localPath == null)
-                return;
-
-            localRepositoryModel.CloneUrl = GetUri(localPath);
-        }
-
-        /// <summary>
         /// Returns the URL of the remote for the specified <see cref="repository"/>. If the repository
         /// is null or no remote named origin exists, this method returns null
         /// </summary>

--- a/src/GitHub.Exports/Services/IGitService.cs
+++ b/src/GitHub.Exports/Services/IGitService.cs
@@ -22,12 +22,6 @@ namespace GitHub.Services
         IBranch CreateCurrentBranchModel(ILocalRepositoryModel model);
 
         /// <summary>
-        /// Updates the CloneUrl information based on the "origin" remote.
-        /// </summary>
-        /// <param name="localRepositoryModel">The repository model to refresh.</param>
-        void RefreshCloneUrl(ILocalRepositoryModel localRepositoryModel);
-
-        /// <summary>
         /// Returns the URL of the remote for the specified <see cref="repository"/>. If the repository
         /// is null or no remote exists, this method returns null
         /// </summary>

--- a/src/GitHub.Exports/Services/ITeamExplorerServiceHolder.cs
+++ b/src/GitHub.Exports/Services/ITeamExplorerServiceHolder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using GitHub.Primitives;
 using GitHub.Models;
+using Microsoft.VisualStudio.Threading;
 
 namespace GitHub.Services
 {
@@ -17,6 +18,7 @@ namespace GitHub.Services
         /// changes in the source control context.
         /// </summary>
         IServiceProvider ServiceProvider { get; set; }
+
         /// <summary>
         /// Clears the current ServiceProvider if it matches the one that is passed in.
         /// This is usually called on Dispose, which might happen after another section
@@ -25,21 +27,10 @@ namespace GitHub.Services
         /// </summary>
         /// <param name="provider">If the current ServiceProvider matches this, clear it</param>
         void ClearServiceProvider(IServiceProvider provider);
-        /// <summary>
-        /// A IGitRepositoryInfo representing the currently active repository
-        /// </summary>
-        ILocalRepositoryModel ActiveRepo { get; }
-        /// <summary>
-        /// Subscribe to be notified when the active repository is set and Notify is called.
-        /// </summary>
-        /// <param name="who">The instance that is interested in being called (or a unique key/object for that instance)</param>
-        /// <param name="handler">The handler to call when ActiveRepo is set</param>
-        void Subscribe(object who, Action<ILocalRepositoryModel> handler);
-        /// <summary>
-        /// Unsubscribe from notifications
-        /// </summary>
-        /// <param name="who">The instance/key that previously subscribed to notifications</param>
-        void Unsubscribe(object who);
+
+        ITeamExplorerContext TeamExplorerContext { get; }
+
+        JoinableTaskFactory JoinableTaskFactory { get; }
 
         IGitAwareItem HomeSection { get; }
     }

--- a/src/GitHub.Exports/Services/ITeamExplorerServiceHolder.cs
+++ b/src/GitHub.Exports/Services/ITeamExplorerServiceHolder.cs
@@ -28,8 +28,14 @@ namespace GitHub.Services
         /// <param name="provider">If the current ServiceProvider matches this, clear it</param>
         void ClearServiceProvider(IServiceProvider provider);
 
+        /// <summary>
+        /// A service that can be used for repository changed events.
+        /// </summary>
         ITeamExplorerContext TeamExplorerContext { get; }
 
+        /// <summary>
+        /// A service for avoiding deadlocks and marshaling tasks onto the UI thread.
+        /// </summary>
         JoinableTaskFactory JoinableTaskFactory { get; }
 
         IGitAwareItem HomeSection { get; }

--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerNavigationItemBase.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerNavigationItemBase.cs
@@ -39,9 +39,9 @@ namespace GitHub.VisualStudio.Base
                 Invalidate();
             };
 
-            UpdateRepo(holder.TeamExplorerContext.ActiveRepository);
+            ActiveRepo = holder.TeamExplorerContext.ActiveRepository;
             holder.TeamExplorerContext.PropertyChanged += TeamExplorerContext_PropertyChanged;
-            holder.TeamExplorerContext.StatusChanged += TeamExplorerContext_StatusChanged; ;
+            holder.TeamExplorerContext.StatusChanged += TeamExplorerContext_StatusChanged;
         }
 
         void TeamExplorerContext_StatusChanged(object sender, EventArgs e)

--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerServiceHolder.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerServiceHolder.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using GitHub.Extensions;
-using GitHub.Logging;
 using GitHub.Services;
-using Serilog;
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
@@ -14,8 +12,6 @@ namespace GitHub.VisualStudio.Base
     [PartCreationPolicy(CreationPolicy.Shared)]
     public class TeamExplorerServiceHolder : ITeamExplorerServiceHolder
     {
-        static readonly ILogger log = LogManager.ForContext<TeamExplorerServiceHolder>();
-
         IServiceProvider serviceProvider;
 
         /// <summary>

--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerServiceHolder.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerServiceHolder.cs
@@ -1,16 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
 using GitHub.Extensions;
 using GitHub.Logging;
-using GitHub.Models;
 using GitHub.Services;
 using Serilog;
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
-using System.Windows;
 
 namespace GitHub.VisualStudio.Base
 {
@@ -20,20 +16,15 @@ namespace GitHub.VisualStudio.Base
     {
         static readonly ILogger log = LogManager.ForContext<TeamExplorerServiceHolder>();
 
-        readonly Dictionary<object, Action<ILocalRepositoryModel>> activeRepoHandlers = new Dictionary<object, Action<ILocalRepositoryModel>>();
-        ILocalRepositoryModel activeRepo;
-        bool activeRepoNotified = false;
-
         IServiceProvider serviceProvider;
-        readonly IVSGitExt gitExt;
-        readonly IGitService gitService;
 
         /// <summary>
         /// This class relies on IVSGitExt that provides information when VS switches repositories.
         /// </summary>
         /// <param name="gitExt">Used for monitoring the active repository.</param>
         [ImportingConstructor]
-        TeamExplorerServiceHolder(IVSGitExt gitExt, IGitService gitService) : this(gitExt, gitService, ThreadHelper.JoinableTaskContext)
+        TeamExplorerServiceHolder(ITeamExplorerContext teamExplorerContext) :
+            this(teamExplorerContext, ThreadHelper.JoinableTaskContext)
         {
         }
 
@@ -42,23 +33,13 @@ namespace GitHub.VisualStudio.Base
         /// </summary>
         /// <param name="gitService">Used for monitoring the active repository.</param>
         /// <param name="joinableTaskContext">Used for switching to the Main thread.</param>
-        public TeamExplorerServiceHolder(IVSGitExt gitExt, IGitService gitService, JoinableTaskContext joinableTaskContext)
+        public TeamExplorerServiceHolder(ITeamExplorerContext teamExplorerContext, JoinableTaskContext joinableTaskContext)
         {
             JoinableTaskCollection = joinableTaskContext.CreateCollection();
             JoinableTaskCollection.DisplayName = nameof(TeamExplorerServiceHolder);
             JoinableTaskFactory = joinableTaskContext.CreateFactory(JoinableTaskCollection);
 
-            // HACK: This might be null in SafeMode.
-            // We should be throwing rather than returning a null MEF service.
-            if (gitExt == null)
-            {
-                return;
-            }
-
-            this.gitExt = gitExt;
-            this.gitService = gitService;
-            UpdateActiveRepo();
-            gitExt.ActiveRepositoriesChanged += UpdateActiveRepo;
+            TeamExplorerContext = teamExplorerContext;
         }
 
         // set by the sections when they get initialized
@@ -76,61 +57,6 @@ namespace GitHub.VisualStudio.Base
             }
         }
 
-        public ILocalRepositoryModel ActiveRepo
-        {
-            get { return activeRepo; }
-            private set
-            {
-                if (activeRepo == value)
-                    return;
-                if (activeRepo != null)
-                    activeRepo.PropertyChanged -= ActiveRepoPropertyChanged;
-                activeRepo = value;
-                if (activeRepo != null)
-                    activeRepo.PropertyChanged += ActiveRepoPropertyChanged;
-                NotifyActiveRepo();
-            }
-        }
-
-        public void Subscribe(object who, Action<ILocalRepositoryModel> handler)
-        {
-            Guard.ArgumentNotNull(who, nameof(who));
-            Guard.ArgumentNotNull(handler, nameof(handler));
-
-            bool notificationsExist;
-            ILocalRepositoryModel repo;
-            lock (activeRepoHandlers)
-            {
-                repo = ActiveRepo;
-                notificationsExist = activeRepoNotified;
-                if (!activeRepoHandlers.ContainsKey(who))
-                    activeRepoHandlers.Add(who, handler);
-                else
-                    activeRepoHandlers[who] = handler;
-            }
-
-            // the repo url might have changed and we don't get notifications
-            // for that, so this is a good place to refresh it in case that happened
-            if (repo != null)
-            {
-                gitService.RefreshCloneUrl(repo);
-            }
-
-            // if the active repo hasn't changed and there's notifications queued up,
-            // notify the subscriber. If the repo has changed, the set above will trigger
-            // notifications so we don't have to do it here.
-            if (repo == ActiveRepo && notificationsExist)
-                handler(repo);
-        }
-
-        public void Unsubscribe(object who)
-        {
-            Guard.ArgumentNotNull(who, nameof(who));
-
-            if (activeRepoHandlers.ContainsKey(who))
-                activeRepoHandlers.Remove(who);
-        }
-
         /// <summary>
         /// Clears the current ServiceProvider if it matches the one that is passed in.
         /// This is usually called on Dispose, which might happen after another section
@@ -146,39 +72,6 @@ namespace GitHub.VisualStudio.Base
                 return;
 
             ServiceProvider = null;
-        }
-
-        void NotifyActiveRepo()
-        {
-            lock (activeRepoHandlers)
-            {
-                activeRepoNotified = true;
-                foreach (var handler in activeRepoHandlers.Values)
-                    handler(activeRepo);
-            }
-        }
-
-        void UpdateActiveRepo()
-        {
-            var repo = gitExt.ActiveRepositories.FirstOrDefault();
-
-            if (!Equals(repo, ActiveRepo))
-            {
-                // Fire property change events on Main thread
-                JoinableTaskFactory.RunAsync(async () =>
-                {
-                    await JoinableTaskFactory.SwitchToMainThreadAsync();
-                    ActiveRepo = repo;
-                }).Task.Forget(log);
-            }
-        }
-
-        void ActiveRepoPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            Guard.ArgumentNotNull(e, nameof(e));
-
-            if (e.PropertyName == "CloneUrl")
-                ActiveRepo = sender as ILocalRepositoryModel;
         }
 
         public IGitAwareItem HomeSection
@@ -200,6 +93,7 @@ namespace GitHub.VisualStudio.Base
         }
 
         public JoinableTaskCollection JoinableTaskCollection { get; }
-        JoinableTaskFactory JoinableTaskFactory { get; }
+        public JoinableTaskFactory JoinableTaskFactory { get; }
+        public ITeamExplorerContext TeamExplorerContext { get; }
     }
 }

--- a/src/GitHub.VisualStudio/Commands/LinkCommandBase.cs
+++ b/src/GitHub.VisualStudio/Commands/LinkCommandBase.cs
@@ -63,7 +63,7 @@ namespace GitHub.VisualStudio.Commands
 
         protected ILocalRepositoryModel GetActiveRepo()
         {
-            var activeRepo = ServiceProvider.TryGetService<ITeamExplorerServiceHolder>()?.ActiveRepo;
+            var activeRepo = ServiceProvider.TryGetService<ITeamExplorerServiceHolder>()?.TeamExplorerContext.ActiveRepository;
             // activeRepo can be null at this point because it is set elsewhere as the result of async operation that may not have completed yet.
             if (activeRepo == null)
             {
@@ -82,7 +82,7 @@ namespace GitHub.VisualStudio.Commands
 
         void RefreshRepo()
         {
-            ActiveRepo = ServiceProvider.TryGetService<ITeamExplorerServiceHolder>().ActiveRepo;
+            ActiveRepo = ServiceProvider.TryGetService<ITeamExplorerServiceHolder>()?.TeamExplorerContext.ActiveRepository;
 
             if (ActiveRepo == null)
             {

--- a/test/GitHub.TeamFoundation.UnitTests/VSGitExtTests.cs
+++ b/test/GitHub.TeamFoundation.UnitTests/VSGitExtTests.cs
@@ -317,6 +317,5 @@ public class VSGitExtTests
         public IRepository GetRepository(string path) => throw new NotImplementedException();
         public UriString GetUri(IRepository repository, string remote = "origin") => throw new NotImplementedException();
         public UriString GetUri(string path, string remote = "origin") => throw new NotImplementedException();
-        public void RefreshCloneUrl(ILocalRepositoryModel localRepositoryModel) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
- Depends on #2008

### What this PR does

`TeamExplorerServiceHolder` has picked up responsibilities beyond holding services for the Team Explorer views. This PR removes its repository watching and event marshaling responsibilities and delegates them to `ITeamExplorerContext`. It also removes the need for refreshing a live `LocalRepositoryModel`, meaning the model can now be immutable after creation.

- Remove `ActiveRepo`, `Subscribe` and `Unsubscribe` from `ITeamExplorerServiceHolder`
- Remove `RefreshCloneUrl` from `IGitService`
- Expose `TeamExplorerContext` and `JoinableTaskFactory` from `ITeamExplorerServiceHolder` (for repo change events and marshaling)

### How to test

I've changed code that listens for repository change and refreshes the Team Explorer UI. We need to test moving between repositories and changing the clone URL.

1. Open a repository that it on GitHub
2. Open the `Team Explorer - Home` view
3. The repository URL should be visible
4. From the command line: `git remote rename _origin origin`
5. The repository URL and banner should no longer appear
6. From the command line: `git remote rename origin _origin`
7. The repository URL and banner should re-appear
