### PR TITLE
Fix draft appearing after sucessful submit.

### DIFF
--- a/src/GitHub.App/ViewModels/PullRequestReviewCommentThreadViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestReviewCommentThreadViewModel.cs
@@ -227,12 +227,13 @@ namespace GitHub.ViewModels
 
         protected override CommentDraft BuildDraft(ICommentViewModel comment)
         {
-            return new PullRequestReviewCommentDraft
-            {
-                Body = comment.Body,
-                Side = Side,
-                UpdatedAt = DateTimeOffset.UtcNow,
-            };
+            return !string.IsNullOrEmpty(comment.Body) ?
+                new PullRequestReviewCommentDraft
+                {
+                    Body = comment.Body,
+                    Side = Side,
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                } : null;
         }
 
         protected override (string key, string secondaryKey) GetDraftKeys(ICommentViewModel comment)


### PR DESCRIPTION
In certain situations, the inline comment thread was refreshed before the `DeleteDraft(comment)` line in `PullRequestReviewCommentThreadViewModel.PostComment` was run, meaning that the draft would be displayed _after_ the comment was succesfully submitted, causing a situation like this:

![image](https://user-images.githubusercontent.com/1775141/47909010-f318a100-de8e-11e8-8c46-6bf7884995a9.png)

Work around this by deleting the draft before submitting the comment, and if we get an error re-insert the draft.

Bonus fix: Don't save drafts of empty comments.