### PR TITLE
Prefer VS Images over Octicons in file tree

### DIFF
--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestFilesView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestFilesView.xaml
@@ -6,6 +6,7 @@
              xmlns:ghfvs="https://github.com/github/VisualStudio"
              xmlns:local="clr-namespace:GitHub.VisualStudio.Views.GitHubPane"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              mc:Ignorable="d" d:DesignHeight="300" d:DesignWidth="300"
              Name="root">
 
@@ -108,7 +109,8 @@
                                 </Style.Triggers>
                             </Style>
                         </TextBlock.Style>
-                        <ghfvs:OcticonImage Icon="alert" Height="10" Margin="-2 0"/>
+                        <imaging:CrispImage Width="10" Height="10" 
+                                            Moniker="{x:Static catalog:KnownMonikers.StatusWarning}" Margin="-2 0" />
                         <Hyperlink Command="{Binding DataContext.OpenFirstAnnotationNotice, ElementName=root}"
                                    CommandParameter="{Binding}">
                             <Run Text="{Binding AnnotationNoticeCount, Mode=OneWay}"/>
@@ -125,7 +127,8 @@
                                 </Style.Triggers>
                             </Style>
                         </TextBlock.Style>
-                        <ghfvs:OcticonImage Icon="alert" Height="10" Margin="-2 0"/>
+                        <imaging:CrispImage Width="10" Height="10" 
+                                            Moniker="{x:Static catalog:KnownMonikers.StatusWarning}" Margin="-2 0"/>
                         <Hyperlink Command="{Binding DataContext.OpenFirstAnnotationWarning, ElementName=root}"
                                    CommandParameter="{Binding}">
                             <Run Text="{Binding AnnotationWarningCount, Mode=OneWay}"/>
@@ -142,7 +145,8 @@
                                 </Style.Triggers>
                             </Style>
                         </TextBlock.Style>
-                        <ghfvs:OcticonImage Icon="x" Height="10" Margin="-2 0"/>
+                        <imaging:CrispImage Width="10" Height="10" 
+                                            Moniker="{x:Static catalog:KnownMonikers.StatusError}" Margin="-2 0" />
                         <Hyperlink Command="{Binding DataContext.OpenFirstAnnotationFailure, ElementName=root}"
                                    CommandParameter="{Binding}">
                             <Run Text="{Binding AnnotationFailureCount, Mode=OneWay}"/>


### PR DESCRIPTION
This pull request updates the icons in the file tree to use Visual Studio's icons:

**Before**
<img width="337" alt="screen shot 2018-11-07 at 3 53 17 pm" src="https://user-images.githubusercontent.com/1174461/48168780-97428380-e2a5-11e8-90ee-cfa499dcbd1b.png">
<img width="319" alt="screen shot 2018-11-07 at 3 53 09 pm" src="https://user-images.githubusercontent.com/1174461/48168781-97428380-e2a5-11e8-94b3-407b560d78bf.png">

**After**

<img width="312" alt="screen shot 2018-11-07 at 3 55 25 pm" src="https://user-images.githubusercontent.com/1174461/48168785-9d386480-e2a5-11e8-8e0b-f41fb0329cb2.png">
<img width="317" alt="screen shot 2018-11-07 at 3 45 58 pm" src="https://user-images.githubusercontent.com/1174461/48168629-e89e4300-e2a4-11e8-9197-fc950c6e4056.png">
<img width="331" alt="screen shot 2018-11-07 at 3 55 34 pm" src="https://user-images.githubusercontent.com/1174461/48168795-ac1f1700-e2a5-11e8-9c70-f57343e80972.png">

