### PR TITLE
Use alias classes instead of alias references

### DIFF
--- a/src/GitHub.TeamFoundation.14/GitHub.TeamFoundation.14.csproj
+++ b/src/GitHub.TeamFoundation.14/GitHub.TeamFoundation.14.csproj
@@ -104,7 +104,6 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Immutable.14.0.14.3.25407\lib\net45\Microsoft.VisualStudio.Shell.Immutable.14.0.dll</HintPath>
       <Private>True</Private>
-      <Aliases>global</Aliases>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6071\lib\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -15,6 +15,24 @@ using Task = System.Threading.Tasks.Task;
 
 namespace GitHub.VisualStudio.Base
 {
+    // This is a workaround to avoid using reference aliases, which don't currently work with <PackageReference>.
+#if TEAMEXPLORER14
+    public class VSGitExt14 : VSGitExt
+    {
+        public VSGitExt14(IServiceProvider serviceProvider, IGitService gitService) : base(serviceProvider, gitService) { }
+    }
+#elif TEAMEXPLORER15
+    public class VSGitExt15 : VSGitExt
+    {
+        public VSGitExt15(IServiceProvider serviceProvider, IGitService gitService) : base(serviceProvider, gitService) { }
+    }
+#elif TEAMEXPLORER16
+    public class VSGitExt16 : VSGitExt
+    {
+        public VSGitExt16(IServiceProvider serviceProvider, IGitService gitService) : base(serviceProvider, gitService) { }
+    }
+#endif
+
     /// <summary>
     /// This service acts as an always available version of <see cref="IGitExt"/>.
     /// </summary>

--- a/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
@@ -1,11 +1,4 @@
-﻿#if TEAMEXPLORER15
-// Microsoft.VisualStudio.Shell.Framework has an alias to avoid conflict with IAsyncServiceProvider
-extern alias SF15;
-using ServiceProgressData = SF15::Microsoft.VisualStudio.Shell.ServiceProgressData;
-#endif
-
-using System;
-using System.Threading;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.ComponentModel.Composition;
@@ -90,22 +83,14 @@ namespace GitHub.Services
             await StartClonenOnConnectPageAsync(teamExplorer, cloneUrl, clonePath, recurseSubmodules);
             NavigateToHomePage(teamExplorer); // Show progress on Team Explorer - Home
             await WaitForCloneOnHomePageAsync(teamExplorer);
-#elif TEAMEXPLORER15
-            var gitExt = serviceProvider.GetService<IGitActionsExt>();
-            var typedProgress = ((Progress<ServiceProgressData>)progress) ?? new Progress<ServiceProgressData>();
-            typedProgress.ProgressChanged += (s, e) => statusBar.Value.ShowMessage(e.ProgressText);
-            var cloneTask = gitExt.CloneAsync(cloneUrl, clonePath, recurseSubmodules, default(CancellationToken), typedProgress);
-
-            NavigateToHomePage(teamExplorer); // Show progress on Team Explorer - Home
-            await cloneTask;
-#elif TEAMEXPLORER16
+#elif TEAMEXPLORER15 || TEAMEXPLORER16
             // The ServiceProgressData type is in a Visual Studio 2019 assembly that we don't currently have access to.
             // Using reflection to call the CloneAsync in order to avoid conflicts with the Visual Studio 2017 version.
             // Progress won't be displayed on the status bar, but it appears prominently on the Team Explorer Home view.
             var gitExt = serviceProvider.GetService<IGitActionsExt>();
             var cloneAsyncMethod = typeof(IGitActionsExt).GetMethod(nameof(IGitActionsExt.CloneAsync));
             Assumes.NotNull(cloneAsyncMethod);
-            var cloneParameters = new object[] { cloneUrl, clonePath, recurseSubmodules, default(CancellationToken), null };
+            var cloneParameters = new object[] { cloneUrl, clonePath, recurseSubmodules, default, null };
             var cloneTask = (Task)cloneAsyncMethod.Invoke(gitExt, cloneParameters);
 
             NavigateToHomePage(teamExplorer); // Show progress on Team Explorer - Home

--- a/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
@@ -90,7 +90,7 @@ namespace GitHub.Services
             var gitExt = serviceProvider.GetService<IGitActionsExt>();
             var cloneAsyncMethod = typeof(IGitActionsExt).GetMethod(nameof(IGitActionsExt.CloneAsync));
             Assumes.NotNull(cloneAsyncMethod);
-            var cloneParameters = new object[] { cloneUrl, clonePath, recurseSubmodules, default, null };
+            var cloneParameters = new object[] { cloneUrl, clonePath, recurseSubmodules, null, null };
             var cloneTask = (Task)cloneAsyncMethod.Invoke(gitExt, cloneParameters);
 
             NavigateToHomePage(teamExplorer); // Show progress on Team Explorer - Home

--- a/src/GitHub.TeamFoundation.15/GitHub.TeamFoundation.15.csproj
+++ b/src/GitHub.TeamFoundation.15/GitHub.TeamFoundation.15.csproj
@@ -95,7 +95,6 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Framework.15.4.27004\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
       <Private>True</Private>
-      <Aliases>SF15</Aliases>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Immutable.11.0.11.0.50727\lib\net45\Microsoft.VisualStudio.Shell.Immutable.11.0.dll</HintPath>
@@ -104,7 +103,6 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Immutable.14.0.14.3.25407\lib\net45\Microsoft.VisualStudio.Shell.Immutable.14.0.dll</HintPath>
       <Private>True</Private>
-      <Aliases>global</Aliases>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6071\lib\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>

--- a/src/GitHub.TeamFoundation.16/GitHub.TeamFoundation.16.csproj
+++ b/src/GitHub.TeamFoundation.16/GitHub.TeamFoundation.16.csproj
@@ -95,7 +95,6 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Framework.15.4.27004\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll</HintPath>
       <Private>True</Private>
-      <Aliases>SF15</Aliases>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Immutable.11.0.11.0.50727\lib\net45\Microsoft.VisualStudio.Shell.Immutable.11.0.dll</HintPath>
@@ -104,7 +103,6 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Immutable.14.0.14.3.25407\lib\net45\Microsoft.VisualStudio.Shell.Immutable.14.0.dll</HintPath>
       <Private>True</Private>
-      <Aliases>global</Aliases>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6071\lib\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -605,7 +605,7 @@
       <Private>True</Private>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIXLocalOnly>
-      <Aliases>TF14</Aliases>
+      <Aliases>global</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\GitHub.TeamFoundation.15\GitHub.TeamFoundation.15.csproj">
       <Project>{161dbf01-1dbf-4b00-8551-c5c00f26720e}</Project>
@@ -613,14 +613,14 @@
       <Private>True</Private>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIXLocalOnly>
-      <Aliases>TF15</Aliases>
+      <Aliases>global</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\GitHub.TeamFoundation.16\GitHub.TeamFoundation.16.csproj">
       <Project>{F08BD4BC-B5DF-4193-9B01-6D0BBE101BD7}</Project>
       <Name>GitHub.TeamFoundation.16</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIXLocalOnly>
-      <Aliases>TF16</Aliases>
+      <Aliases>global</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\GitHub.UI.Reactive\GitHub.UI.Reactive.csproj">
       <Project>{158b05e8-fdbc-4d71-b871-c96e28d5adf5}</Project>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -605,7 +605,6 @@
       <Private>True</Private>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIXLocalOnly>
-      <Aliases>global</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\GitHub.TeamFoundation.15\GitHub.TeamFoundation.15.csproj">
       <Project>{161dbf01-1dbf-4b00-8551-c5c00f26720e}</Project>
@@ -613,14 +612,12 @@
       <Private>True</Private>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIXLocalOnly>
-      <Aliases>global</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\GitHub.TeamFoundation.16\GitHub.TeamFoundation.16.csproj">
       <Project>{F08BD4BC-B5DF-4193-9B01-6D0BBE101BD7}</Project>
       <Name>GitHub.TeamFoundation.16</Name>
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup;</IncludeOutputGroupsInVSIXLocalOnly>
-      <Aliases>global</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\GitHub.UI.Reactive\GitHub.UI.Reactive.csproj">
       <Project>{158b05e8-fdbc-4d71-b871-c96e28d5adf5}</Project>

--- a/src/GitHub.VisualStudio/Services/VSGitExtFactory.cs
+++ b/src/GitHub.VisualStudio/Services/VSGitExtFactory.cs
@@ -1,13 +1,7 @@
-﻿extern alias TF14;
-extern alias TF15;
-extern alias TF16;
-
-using System;
+﻿using System;
 using GitHub.Logging;
+using GitHub.VisualStudio.Base;
 using Serilog;
-using VSGitExt14 = TF14.GitHub.VisualStudio.Base.VSGitExt;
-using VSGitExt15 = TF15.GitHub.VisualStudio.Base.VSGitExt;
-using VSGitExt16 = TF16.GitHub.VisualStudio.Base.VSGitExt;
 
 namespace GitHub.Services
 {

--- a/test/GitHub.VisualStudio.UnitTests/GitHub.VisualStudio.UnitTests.csproj
+++ b/test/GitHub.VisualStudio.UnitTests/GitHub.VisualStudio.UnitTests.csproj
@@ -12,11 +12,9 @@
     <Compile Include="..\Helpers\SplatModeDetectorSetUp.cs" />
     <Compile Include="..\Helpers\TestBaseClass.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
-    <ProjectReference Include="..\..\src\GitHub.TeamFoundation.15\GitHub.TeamFoundation.15.csproj">
-      <Aliases>TF15</Aliases>
-    </ProjectReference>
+    <ProjectReference Include="..\..\src\GitHub.TeamFoundation.15\GitHub.TeamFoundation.15.csproj" />
     <ProjectReference Include="..\..\src\GitHub.VisualStudio\GitHub.VisualStudio.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Conditionally define VSGitExt14, VSGitExt15 and VSGitExt16 to avoid having to use reference aliases.