### PR TITLE
Polish the list of checks

### DIFF
--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
@@ -6,6 +6,8 @@
              xmlns:ghfvs="https://github.com/github/VisualStudio"
              xmlns:local="clr-namespace:GitHub.VisualStudio.Views.GitHubPane"
              xmlns:prop="clr-namespace:GitHub.VisualStudio.UI;assembly=GitHub.VisualStudio.UI"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"  
              xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
              mc:Ignorable="d" d:DesignHeight="500" d:DesignWidth="300">
 
@@ -25,7 +27,7 @@
     </Control.Resources>
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel>
+        <DockPanel>
             <StackPanel DockPanel.Dock="Top" Margin="8 0" Orientation="Vertical">
                 <TextBlock FontSize="16" VerticalAlignment="Center">
                         <Run FontWeight="SemiBold" Text="{Binding CheckSuiteName, Mode=OneWay}"/>
@@ -44,79 +46,54 @@
                            TextWrapping="Wrap"/>
                 <Rectangle Fill="{DynamicResource GitHubHeaderSeparatorBrush}" Height="1" Margin="0 4"/>
 
-                <ItemsControl ItemsSource="{Binding AnnotationsDictionary}">
+                <ItemsControl Margin="-4 0"  ItemsSource="{Binding AnnotationsDictionary}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <StackPanel>
                                 <Expander>
                                     <Expander.Header>
-                                        <Label Content="{Binding Key}"></Label>
+                                        <Label Content="{Binding Key}" FontWeight="SemiBold" ToolTip="{Binding Key}" />
                                     </Expander.Header>
 
                                     <ItemsControl ItemsSource="{Binding Value}">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
-                                                <StackPanel Margin="22 0 0 0">
-                                                    <StackPanel Orientation="Horizontal">
-                                                        <ghfvs:OcticonImage Margin="0 0 0 0" MinWidth="20" Icon="search" Foreground="CornflowerBlue" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Notice}}"/>
-                                                        <ghfvs:OcticonImage Margin="0 0 0 0" MinWidth="20" Icon="alert" Foreground="#f1c647" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Warning}}"/>
-                                                        <ghfvs:OcticonImage Margin="0 0 0 0" MinWidth="20" Icon="x" Foreground="#cb2431" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
-                                                        <TextBlock FontWeight="SemiBold" Margin="2 0">
-                                                        <Run Text="{Binding Annotation.Title, Mode=OneWay}"/>
-                                                        </TextBlock>
+                                                <Grid Margin="22 0 0 8" >
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="16" />
+                                                        <ColumnDefinition Width="*" />
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                                        <imaging:CrispImage  Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.StatusInformation}" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Notice}}"/>
+                                                        <imaging:CrispImage  Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.StatusWarning}" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Warning}}"/>
+                                                        <imaging:CrispImage  Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.StatusError}" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
                                                     </StackPanel>
 
-                                                    <StackPanel Margin="21 4 0 4">
-                                                        <TextBlock Margin="5 4 0 0">
-                                                        <Run Text="{Binding Annotation.Path, Mode=OneWay}"/>
-                                                        <Run FontWeight="SemiBold" Text="{Binding LineDescription, Mode=OneWay}"/>
+                                                    <StackPanel Margin="8,0,0,0" Grid.Column="1">
+                                                        <TextBlock FontFamily="Consolas" Foreground="{DynamicResource VsBrush.GrayText}" Grid.Row="0">
+                                                            <Run Text="Line" />
+                                                            <Run Text="{Binding LineDescription, Mode=OneWay}"/>
                                                         </TextBlock>
-                                                        <markdig:MarkdownViewer Margin="5 0 0 0" Markdown="{Binding Annotation.Message}"/>
+
+                                                        <TextBlock FontWeight="SemiBold" Grid.Row="1">
+                                                            <Run Text="{Binding Annotation.Title, Mode=OneWay}"/>
+                                                        </TextBlock>
+
+                                                        <markdig:MarkdownViewer Grid.Column="1" Grid.Row="2"
+                                                                                FontFamily="Consolas" Markdown="{Binding Annotation.Message}" />
                                                     </StackPanel>
-                                                </StackPanel>
+                                                </Grid>
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
                                 </Expander>
                             </StackPanel>
-
-                            <!--
-                                <ItemsControl ItemsSource="{Binding Value}">
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate>
-                                            <StackPanel>
-
-                                                <Expander Margin="0 0 4 0" Foreground="{DynamicResource GitHubVsToolWindowText}" IsExpanded="{Binding IsExpanded, Mode=OneTime}">
-                                                    <Expander.Header>
-                                                        <StackPanel Orientation="Horizontal">
-                                                            <ghfvs:OcticonImage Margin="0 0 0 0" MinWidth="20" Icon="search" Foreground="CornflowerBlue" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Notice}}"/>
-                                                            <ghfvs:OcticonImage Margin="0 0 0 0" MinWidth="20" Icon="alert" Foreground="#f1c647" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Warning}}"/>
-                                                            <ghfvs:OcticonImage Margin="0 0 0 0" MinWidth="20" Icon="x" Foreground="#cb2431" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
-                                                            <TextBlock FontWeight="SemiBold" Margin="2 0">
-                                                                <Run Text="{Binding Annotation.Title, Mode=OneWay}"/>
-                                                            </TextBlock>
-                                                        </StackPanel>
-                                                    </Expander.Header>
-                                                    <StackPanel Margin="21 4 0 4">
-                                                        <TextBlock Margin="5 4 0 0">
-                                                            <Run Text="{Binding Annotation.Path, Mode=OneWay}"/>
-                                                            <Run FontWeight="SemiBold" Text="{Binding LineDescription, Mode=OneWay}"/>
-                                                        </TextBlock>
-                                                        <markdig:MarkdownViewer Margin="5 0 0 0" Markdown="{Binding Annotation.Message}"/>
-                                                    </StackPanel>
-                                                </Expander>
-                                            </StackPanel>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
-                            </StackPanel>
-                            -->
-
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
             </StackPanel>
-        </StackPanel>
+        </DockPanel>
     </ScrollViewer>
 
 </UserControl>

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
@@ -42,20 +42,49 @@
                            Margin="0"
                            Text="{Binding PullRequestTitle}"
                            TextWrapping="Wrap"/>
-                <StackPanel Orientation="Horizontal" Margin="0 4">
-                </StackPanel>
+                <Rectangle Fill="{DynamicResource GitHubHeaderSeparatorBrush}" Height="1" Margin="0 4"/>
 
                 <ItemsControl ItemsSource="{Binding AnnotationsDictionary}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <StackPanel>
-                                <Label Content="{Binding Key}"></Label>
+                                <Expander>
+                                    <Expander.Header>
+                                        <Label Content="{Binding Key}"></Label>
+                                    </Expander.Header>
 
+                                    <ItemsControl ItemsSource="{Binding Value}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <StackPanel Margin="22 0 0 0">
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <ghfvs:OcticonImage Margin="0 0 0 0" MinWidth="20" Icon="search" Foreground="CornflowerBlue" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Notice}}"/>
+                                                        <ghfvs:OcticonImage Margin="0 0 0 0" MinWidth="20" Icon="alert" Foreground="#f1c647" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Warning}}"/>
+                                                        <ghfvs:OcticonImage Margin="0 0 0 0" MinWidth="20" Icon="x" Foreground="#cb2431" Visibility="{Binding Annotation.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
+                                                        <TextBlock FontWeight="SemiBold" Margin="2 0">
+                                                        <Run Text="{Binding Annotation.Title, Mode=OneWay}"/>
+                                                        </TextBlock>
+                                                    </StackPanel>
+
+                                                    <StackPanel Margin="21 4 0 4">
+                                                        <TextBlock Margin="5 4 0 0">
+                                                        <Run Text="{Binding Annotation.Path, Mode=OneWay}"/>
+                                                        <Run FontWeight="SemiBold" Text="{Binding LineDescription, Mode=OneWay}"/>
+                                                        </TextBlock>
+                                                        <markdig:MarkdownViewer Margin="5 0 0 0" Markdown="{Binding Annotation.Message}"/>
+                                                    </StackPanel>
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </Expander>
+                            </StackPanel>
+
+                            <!--
                                 <ItemsControl ItemsSource="{Binding Value}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
                                             <StackPanel>
-                                                <Rectangle Fill="{DynamicResource GitHubHeaderSeparatorBrush}" Height="1" Margin="0 4"/>
 
                                                 <Expander Margin="0 0 4 0" Foreground="{DynamicResource GitHubVsToolWindowText}" IsExpanded="{Binding IsExpanded, Mode=OneTime}">
                                                     <Expander.Header>
@@ -81,6 +110,7 @@
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
                             </StackPanel>
+                            -->
 
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
@@ -72,13 +72,15 @@
                                                     </StackPanel>
 
                                                     <StackPanel Margin="8,0,0,0" Grid.Column="1">
-                                                        <TextBlock FontFamily="Consolas" Foreground="{DynamicResource VsBrush.GrayText}" Grid.Row="0">
-                                                            <Run Text="Line" />
-                                                            <Run Text="{Binding LineDescription, Mode=OneWay}"/>
+                                                        <TextBlock FontWeight="SemiBold" Grid.Row="0">
+                                                            <Run Text="{Binding Annotation.Title, Mode=OneWay}"/>
                                                         </TextBlock>
 
-                                                        <TextBlock FontWeight="SemiBold" Grid.Row="1">
-                                                            <Run Text="{Binding Annotation.Title, Mode=OneWay}"/>
+                                                        <TextBlock FontFamily="Consolas" Foreground="{DynamicResource VsBrush.GrayText}" Grid.Row="1" Visibility="{Binding IsFileInPullRequest, Converter={ghfvs:BooleanToVisibilityConverter}}">
+		                                                    <Hyperlink Command="{Binding OpenAnnotation}">
+                                                                <Run Text="Line" />
+                                                                <Run Text="{Binding LineDescription, Mode=OneWay}"/>
+		                                                    </Hyperlink>
                                                         </TextBlock>
 
                                                         <markdig:MarkdownViewer Grid.Column="1" Grid.Row="2"

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
@@ -31,10 +31,11 @@
             <StackPanel DockPanel.Dock="Top" Margin="8 0" Orientation="Vertical">
                 <TextBlock FontSize="16" VerticalAlignment="Center">
                         <Run FontWeight="SemiBold" Text="{Binding CheckSuiteName, Mode=OneWay}"/>
-                </TextBlock>
-                <TextBlock FontSize="16" VerticalAlignment="Center">
+                        <Run Text="/"/>
                         <Run FontWeight="SemiBold" Text="{Binding CheckRunName, Mode=OneWay}"/>
+
                         <Run>for</Run>
+
                         <Hyperlink Command="{Binding NavigateToPullRequest}">
                             <Run>#</Run><Run Text="{Binding PullRequestNumber, Mode=OneWay}"/>
                         </Hyperlink>
@@ -44,7 +45,7 @@
                            Margin="0"
                            Text="{Binding PullRequestTitle}"
                            TextWrapping="Wrap"/>
-                <Rectangle Fill="{DynamicResource GitHubHeaderSeparatorBrush}" Height="1" Margin="0 4"/>
+                <Rectangle Fill="{DynamicResource GitHubHeaderSeparatorBrush}" Height="1" Margin="-8 4"/>
 
                 <ItemsControl Margin="-4 0"  ItemsSource="{Binding AnnotationsDictionary}">
                     <ItemsControl.ItemTemplate>

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
@@ -27,7 +27,7 @@
     </Control.Resources>
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <DockPanel>
+        <StackPanel>
             <StackPanel DockPanel.Dock="Top" Margin="8 0" Orientation="Vertical">
                 <TextBlock FontSize="16" VerticalAlignment="Center">
                         <Run FontWeight="SemiBold" Text="{Binding CheckSuiteName, Mode=OneWay}"/>
@@ -93,7 +93,7 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
             </StackPanel>
-        </DockPanel>
+        </StackPanel>
     </ScrollViewer>
 
 </UserControl>

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestAnnotationsView.xaml
@@ -83,6 +83,11 @@
 		                                                    </Hyperlink>
                                                         </TextBlock>
 
+                                                        <TextBlock FontFamily="Consolas" Foreground="{DynamicResource VsBrush.GrayText}" Grid.Row="1" Visibility="{Binding IsFileInPullRequest, Converter={ghfvs:BooleanToInverseVisibilityConverter}}">
+                                                            <Run Text="Line" />
+                                                            <Run Text="{Binding LineDescription, Mode=OneWay}"/>
+                                                        </TextBlock>
+
                                                         <markdig:MarkdownViewer Grid.Column="1" Grid.Row="2"
                                                                                 FontFamily="Consolas" Markdown="{Binding Annotation.Message}" />
                                                     </StackPanel>


### PR DESCRIPTION
Small PR targeting my branch that polishes the Annotations details list:

**Before**
![image](https://user-images.githubusercontent.com/1174461/48572216-ab960a00-e8bd-11e8-80f4-d2d7adf180fd.png)

**After**
![image](https://user-images.githubusercontent.com/1174461/48571815-ab493f00-e8bc-11e8-9eb7-99aedb8df7e1.png)

For reference, this is what I was building towards:

![image](https://user-images.githubusercontent.com/1174461/48572303-edbf4b80-e8bd-11e8-981a-476c4e0c5a37.png)

EDIT: There are a couple deviations here so I'll explain the reasoning behind them

1. I included the annotation title to be the header instead of the line number. In my initial designs, I didn't realize that we could include titles as a potential thing to surface. 🤔I'm not sure if the line number should have a higher hierarchy than the title so I'm open to other opinions.
1. I made the line number a hyperlink to open up the corresponding annotation in the diff view. [My original design](https://user-images.githubusercontent.com/1174461/48582371-35070580-e8d9-11e8-8844-48edf7e9859c.png) used a list box where you could double click the annotation to open it, but I was having layout issues.