### PR TITLE
Reference System.ValueTuple, Version=4.0.1.0

### DIFF
--- a/src/CredentialManagement/CredentialManagement.csproj
+++ b/src/CredentialManagement/CredentialManagement.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/src/GitHub.App/GitHub.App.csproj
+++ b/src/GitHub.App/GitHub.App.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/src/GitHub.Exports.Reactive/GitHub.Exports.Reactive.csproj
+++ b/src/GitHub.Exports.Reactive/GitHub.Exports.Reactive.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <RootNamespace>GitHub</RootNamespace>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <RootNamespace>GitHub</RootNamespace>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/GitHub.Exports/GitHub.Exports.csproj
+++ b/src/GitHub.Exports/GitHub.Exports.csproj
@@ -38,6 +38,6 @@
     <PackageReference Include="Rothko" Version="0.0.3-ghfvs" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="SerilogAnalyzer" Version="0.12.0.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/GitHub.Extensions.Reactive/GitHub.Extensions.Reactive.csproj
+++ b/src/GitHub.Extensions.Reactive/GitHub.Extensions.Reactive.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <RootNamespace>GitHub</RootNamespace>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/GitHub.Extensions/GitHub.Extensions.csproj
+++ b/src/GitHub.Extensions/GitHub.Extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <RootNamespace>GitHub</RootNamespace>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
+++ b/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
@@ -23,7 +23,7 @@
     <RootNamespace>GitHub.InlineReviews</RootNamespace>
     <AssemblyName>GitHub.InlineReviews</AssemblyName>
     <LangVersion>7.3</LangVersion>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>

--- a/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
+++ b/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
@@ -379,8 +379,8 @@
     <Reference Include="System.Reactive, Version=4.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reactive.4.0.0\lib\net46\System.Reactive.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />

--- a/src/GitHub.InlineReviews/packages.config
+++ b/src/GitHub.InlineReviews/packages.config
@@ -40,7 +40,7 @@
   <package id="Serilog" version="2.5.0" targetFramework="net461" />
   <package id="SerilogAnalyzer" version="0.12.0.0" targetFramework="net461" />
   <package id="System.Reactive" version="4.0.0" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
   <package id="VSSDK.ComponentModelHost" version="12.0.4" targetFramework="net461" />
   <package id="VSSDK.IDE.12" version="12.0.4" targetFramework="net461" />
 </packages>

--- a/src/GitHub.Logging/GitHub.Logging.csproj
+++ b/src/GitHub.Logging/GitHub.Logging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <RootNamespace>GitHub</RootNamespace>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/GitHub.Resources/GitHub.Resources.csproj
+++ b/src/GitHub.Resources/GitHub.Resources.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <RootNamespace>GitHub</RootNamespace>
   </PropertyGroup>
 

--- a/src/GitHub.Services.Vssdk/GitHub.Services.Vssdk.csproj
+++ b/src/GitHub.Services.Vssdk/GitHub.Services.Vssdk.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/src/GitHub.StartPage/GitHub.StartPage.csproj
+++ b/src/GitHub.StartPage/GitHub.StartPage.csproj
@@ -8,6 +8,7 @@
     <UseCodeBase>true</UseCodeBase>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="$(SolutionDir)\src\common\signing.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -22,7 +23,7 @@
     <RootNamespace>GitHub.StartPage</RootNamespace>
     <AssemblyName>GitHub.StartPage</AssemblyName>
     <LangVersion>7.3</LangVersion>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>

--- a/src/GitHub.TeamFoundation.14/GitHub.TeamFoundation.14.csproj
+++ b/src/GitHub.TeamFoundation.14/GitHub.TeamFoundation.14.csproj
@@ -13,13 +13,14 @@
     <RootNamespace>GitHub.TeamFoundation</RootNamespace>
     <AssemblyName>GitHub.TeamFoundation.14</AssemblyName>
     <LangVersion>7.3</LangVersion>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <CodeAnalysisRuleSet>..\common\GitHubVS.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/GitHub.TeamFoundation.15/GitHub.TeamFoundation.15.csproj
+++ b/src/GitHub.TeamFoundation.15/GitHub.TeamFoundation.15.csproj
@@ -13,7 +13,7 @@
     <RootNamespace>GitHub.TeamFoundation</RootNamespace>
     <AssemblyName>GitHub.TeamFoundation.15</AssemblyName>
     <LangVersion>7.3</LangVersion>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <CodeAnalysisRuleSet>..\common\GitHubVS.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -22,6 +22,7 @@
     </NuGetPackageImportStamp>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>

--- a/src/GitHub.TeamFoundation.16/GitHub.TeamFoundation.16.csproj
+++ b/src/GitHub.TeamFoundation.16/GitHub.TeamFoundation.16.csproj
@@ -13,7 +13,7 @@
     <RootNamespace>GitHub.TeamFoundation</RootNamespace>
     <AssemblyName>GitHub.TeamFoundation.16</AssemblyName>
     <LangVersion>7.3</LangVersion>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <CodeAnalysisRuleSet>..\common\GitHubVS.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -22,6 +22,7 @@
     </NuGetPackageImportStamp>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>

--- a/src/GitHub.UI.Reactive/GitHub.UI.Reactive.csproj
+++ b/src/GitHub.UI.Reactive/GitHub.UI.Reactive.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <RootNamespace>GitHub</RootNamespace>
     <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
     <DebugType>full</DebugType>

--- a/src/GitHub.UI/GitHub.UI.csproj
+++ b/src/GitHub.UI/GitHub.UI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/GitHub.VisualStudio.UI/GitHub.VisualStudio.UI.csproj
+++ b/src/GitHub.VisualStudio.UI/GitHub.VisualStudio.UI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <ExtrasEnableWpfProjectSetup>true</ExtrasEnableWpfProjectSetup>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -31,7 +31,7 @@
     <StartProgram Condition=" '$(StartProgram)' == '' ">$(DevEnvDir)\devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
     <LangVersion>7.3</LangVersion>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <ZipPackageCompressionLevel>Normal</ZipPackageCompressionLevel>
     <CodeAnalysisRuleSet>..\common\GitHubVS.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -304,9 +304,6 @@
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -299,6 +299,9 @@
     <Reference Include="System.Reactive, Version=4.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reactive.4.0.0\lib\net46\System.Reactive.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>

--- a/src/GitHub.VisualStudio/packages.config
+++ b/src/GitHub.VisualStudio/packages.config
@@ -56,6 +56,6 @@
   <package id="System.Reactive" version="4.0.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
   <package id="XliffTasks" version="0.2.0-beta-63125-01" targetFramework="net461" />
 </packages>

--- a/test/GitHub.Api.UnitTests/GitHub.Api.UnitTests.csproj
+++ b/test/GitHub.Api.UnitTests/GitHub.Api.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Helpers\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />

--- a/test/GitHub.App.UnitTests/GitHub.App.UnitTests.csproj
+++ b/test/GitHub.App.UnitTests/GitHub.App.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GitHub.Exports.Reactive.UnitTests/GitHub.Exports.Reactive.UnitTests.csproj
+++ b/test/GitHub.Exports.Reactive.UnitTests/GitHub.Exports.Reactive.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GitHub.Exports.UnitTests/GitHub.Exports.UnitTests.csproj
+++ b/test/GitHub.Exports.UnitTests/GitHub.Exports.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GitHub.Extensions.UnitTests/GitHub.Extensions.UnitTests.csproj
+++ b/test/GitHub.Extensions.UnitTests/GitHub.Extensions.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Helpers\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />

--- a/test/GitHub.InlineReviews.UnitTests/GitHub.InlineReviews.UnitTests.csproj
+++ b/test/GitHub.InlineReviews.UnitTests/GitHub.InlineReviews.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GitHub.TeamFoundation.UnitTests/GitHub.TeamFoundation.UnitTests.csproj
+++ b/test/GitHub.TeamFoundation.UnitTests/GitHub.TeamFoundation.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GitHub.UI.UnitTests/GitHub.UI.UnitTests.csproj
+++ b/test/GitHub.UI.UnitTests/GitHub.UI.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GitHub.VisualStudio.UnitTests/GitHub.VisualStudio.UnitTests.csproj
+++ b/test/GitHub.VisualStudio.UnitTests/GitHub.VisualStudio.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Launcher/InstallAndStart.csproj
+++ b/test/Launcher/InstallAndStart.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="VsixTesting.Installer" Version="0.1.46-beta-g3578f97a2e" />

--- a/test/MetricsTests/MetricsServer/App.config
+++ b/test/MetricsTests/MetricsServer/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
     </startup>
 </configuration>

--- a/test/MetricsTests/MetricsServer/MetricsServer.csproj
+++ b/test/MetricsTests/MetricsServer/MetricsServer.csproj
@@ -9,11 +9,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MetricsServer</RootNamespace>
     <AssemblyName>MetricsServer</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -81,7 +82,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/test/MetricsTests/MetricsTests/MetricsTests.csproj
+++ b/test/MetricsTests/MetricsTests/MetricsTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MetricsTests</RootNamespace>
     <AssemblyName>MetricsTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/test/TrackingCollectionTests/TrackingCollectionTests.csproj
+++ b/test/TrackingCollectionTests/TrackingCollectionTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
_This is an attempted fix for #2065 and #2062._

Revert to using the `System.ValueTuple, v4.3.0` NuGet package / assembly `System.ValueTuple, Version=4.0.1.0`.

### What this PR does

- Change to reference the `System.ValueTuple, 4.3.0` NuGet package (down from `4.5.0`)
- Change to build for `.NET Framework 4.6` (down from `4.6.1`)

Issue #2062 sounds very much like this:
https://stackoverflow.com/a/50636962/121348

>  just had this issue myself. Not on Localhost while developing, but only on production server. In the end it turned out to be some sort of conflict between .Net Framework 4.6.1 and me having System.ValueTuple installed from Nuget in version 4.5.0.

> The solution turned out to be, to downgrade the System.ValueTuple Nuget package to 4.3.0. Then it worked, like nothing had ever been an issue.

> I suspect that this only happened on production server, cause of a different version of .net framework installed.

~~@chongchin and @declared-lambda, could you confirm whether not the issue you were experiencing is fixed in this build: [GitHub.VisualStudio.zip](https://github.com/github/VisualStudio/files/2596400/GitHub.VisualStudio.zip)~~

_Update: I've hit a blocker on this one. It looks like `ReactiveUI` uses `System.ValueTuple, v4.5.0`. I think we'll need to package `System.ValueTuple, v4.5.0` with the extension. I'll get a new build ready ASAP_

Fixes #2062
Fixes #2065 