### PR TITLE
Package System.ValueTuple, v4.0.3.0 with VSIX

### DIFF
--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -414,6 +414,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll">
+      <Link>System.ValueTuple.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -40,6 +40,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.VisualStudio.UI" Path="|GitHub.VisualStudio.UI|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Rothko.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" AssemblyName="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="System.ValueTuple.dll" AssemblyName="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25824.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
_This is an attempted fix for #2065 and #2062._

`System.ValueTuple` isn't included with Visual Studio 2015 so we must include it in the VSIX. Visual Studio 2017 includes assembly version `4.0.1.0`, but `ReactiveUI` references assembly version `4.0.3.0`. We therefor need to package this assembly.

### What this PR does

- Package the assembly from `System.ValueTuple, v2.5.0` NuGet (assembly version `4.0.3.0`)

### How to test

I think the trick will be installing a version of Windows that doesn't have .NET 4.7 installed (Windows 10 will automatically install this).

#### Windows version compatibility

The earliest version of Windows that Visual Studio 2017 supports is:
- Windows 7 SP1 (with latest Windows Updates): Home Premium, Professional, Enterprise, Ultimate
https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2017-system-requirements-vs

Windows 7 Home Premium can be found here:
- https://my.visualstudio.com/downloads
![image](https://user-images.githubusercontent.com/11719160/48781394-d7f1c200-ecd3-11e8-9fd8-9032698fffb3.png)
It should work fine with the x86 version and this might be lighter weight for running in a VM.

The earliest version of Windows that Visual Studio 2015 works with is Windows XP, see:
- https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2015-compatibility-vs

Testing with Windows XP is maybe overkill? 😉 I guess we should decide what the lowest Windows version we want to support is?

#### Visual Studio 2015

1. Install Visual Studio 2015 on Windows 7
2. Install GitHub for Visual Studio
- [ ] Check login dialog works

#### Visual Studio 2017

1. Install Visual Studio 2017 on Windows 7
2. Install GitHub for Visual Studio
- [ ] Check login dialog works

### User feedback

> This build is working as intended. Thanks a lot!
https://github.com/github/VisualStudio/issues/2062#issuecomment-440400874

Was using Windows LTSB.

> When I press "Connect to GitHub", the form appeared. But clicking on the tab "GitHub Enterprise" (to choose the url to our GitHub Enterprise on premise), did not work
https://github.com/github/VisualStudio/issues/2065#issuecomment-440262743

We think this is an unrelated issue.

No response from user on Halp.

### Related

- When i click "Connect" in the GitHub section at TeamExplorer pane, Visual Studio crashes ([Halp](https://halp.githubapp.com/inboxes/editor-tools/discussions/5bf07da8e7ca11e890b102136b6871d7?page=1))

Fixes #2065
Fixes #2062 
