### PR TITLE
Begin polish for conversation view

### DIFF
--- a/src/GitHub.VisualStudio.UI/Styles/ThemeDark.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeDark.xaml
@@ -12,8 +12,8 @@
 
   <Color x:Key="GitHubActionLinkItemColor">#FF0097FB</Color>
   <SolidColorBrush x:Key="GitHubActionLinkItemBrush" Color="{StaticResource GitHubActionLinkItemColor}" PresentationOptions:Freeze="true" />
-  
-  <Color x:Key="GitHubHeaderSeparatorColor">#FF2D2D30</Color>
+
+  <Color x:Key="GitHubHeaderSeparatorColor">#FF3f3f46</Color>
   <SolidColorBrush x:Key="GitHubHeaderSeparatorBrush" Color="{StaticResource GitHubHeaderSeparatorColor}" PresentationOptions:Freeze="true" />
 
   <Color x:Key="GitHubPaneTitleColor">#FFFFFFFF</Color>

--- a/src/GitHub.VisualStudio.UI/Styles/ThemeLight.xaml
+++ b/src/GitHub.VisualStudio.UI/Styles/ThemeLight.xaml
@@ -13,7 +13,7 @@
   <Color x:Key="GitHubActionLinkItemColor">#FF0E70C0</Color>
   <SolidColorBrush x:Key="GitHubActionLinkItemBrush" Color="{StaticResource GitHubActionLinkItemColor}" PresentationOptions:Freeze="true" />
 
-  <Color x:Key="GitHubHeaderSeparatorColor">#FFEEEEF2</Color>
+  <Color x:Key="GitHubHeaderSeparatorColor">#FFcccedb</Color>
   <SolidColorBrush x:Key="GitHubHeaderSeparatorBrush" Color="{StaticResource GitHubHeaderSeparatorColor}" PresentationOptions:Freeze="true" />
   
   <Color x:Key="GitHubPaneTitleColor">#FF1B293E</Color>

--- a/src/GitHub.VisualStudio.UI/Views/CommentThreadView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/CommentThreadView.xaml
@@ -33,7 +33,7 @@
     <ItemsControl ItemsSource="{Binding Comments}">
         <ItemsControl.ItemTemplate>
             <DataTemplate>
-                <local:CommentView Margin="0 4"/>
+                <local:CommentView />
             </DataTemplate>
         </ItemsControl.ItemTemplate>
     </ItemsControl>

--- a/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
@@ -94,7 +94,7 @@
 
             <markdig:MarkdownViewer Grid.Column="1" Grid.Row="1"
                                     Name="bodyMarkdown"
-                                    Margin="0 2 0 0"
+                                    Margin="20 4 0 0"
                                     Foreground="{DynamicResource VsBrush.WindowText}"
                                     Markdown="{Binding Body}"/>
 

--- a/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
@@ -155,7 +155,7 @@
                               AcceptsReturn="True"
                               AcceptsTab="True"
                               IsReadOnly="{Binding IsReadOnly}"
-                              Margin="4"
+                              Margin="4 8"
                               Text="{Binding Body, UpdateSourceTrigger=PropertyChanged}"
                               TextWrapping="Wrap"
                               VerticalAlignment="Center"
@@ -205,7 +205,7 @@
 
             <StackPanel Name="buttonPanel"
                         Grid.Column="1" Grid.Row="3" 
-                        Margin="4 8" 
+                        Margin="4 4 4 8" 
                         HorizontalAlignment="Left"
                         Orientation="Horizontal"
                         IsVisibleChanged="buttonPanel_IsVisibleChanged">

--- a/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
@@ -37,7 +37,7 @@
 
     <Grid IsEnabled="{Binding IsSubmitting, Converter={ui:InverseBooleanConverter}}">
         <!-- Displays an existing comment-->
-        <StackPanel Orientation="Vertical" Margin="4">
+        <StackPanel Orientation="Vertical">
             <StackPanel.Style>
                 <Style TargetType="FrameworkElement">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -49,7 +49,7 @@
                 </Style>
             </StackPanel.Style>
 
-            <DockPanel>
+            <DockPanel Margin="4">
               <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" >
                 <views:ActorAvatarView Width="16" 
                                        Height="16" 
@@ -111,9 +111,15 @@
                         </Style.Triggers>
                     </Style>
                 </DockPanel.Style>
+
                 <ui:OcticonImage DockPanel.Dock="Left" Icon="alert" Margin="0 0 4 0"/>
                 <TextBlock Text="{Binding ErrorMessage}" TextWrapping="Wrap"/>
             </DockPanel>
+
+            <Border BorderThickness="0,1,0,0"
+                    BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}"
+                    Margin="0,4,0,0"
+                    Padding="0,4,0,0" />
         </StackPanel>
 
         <!-- Displays edit view or a reply placeholder-->
@@ -144,16 +150,13 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
-            <Separator Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Margin="0 0 0 4" 
-                       Background="{DynamicResource GitHubButtonBorderBrush}"/>
-
             <ui:PromptTextBox Name="body"
                               Grid.Column="1"
                               Grid.Row="1"
                               AcceptsReturn="True"
                               AcceptsTab="True"
                               IsReadOnly="{Binding IsReadOnly}"
-                              Margin="4 0"
+                              Margin="4 0 4 4"
                               Text="{Binding Body, UpdateSourceTrigger=PropertyChanged}"
                               TextWrapping="Wrap"
                               VerticalAlignment="Center"

--- a/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
@@ -55,11 +55,14 @@
                                        Height="16" 
                                        ViewModel="{Binding Author}"/>
 
-                <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" FontWeight="Bold" Text="{Binding Author.Login}" Margin="4 0"/>
+                <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Margin="4 0">
+                    <Run FontWeight="Bold" Text="{Binding Author.Login}" />
+                    <Run Text="commented" />
+                </TextBlock>
                 <ui:GitHubActionLink Content="{Binding CreatedAt, Converter={ui:DurationToStringConverter}}"
-                                     Command="{Binding OpenOnGitHub}"
-                                     Foreground="{DynamicResource GitHubVsToolWindowText}"
-                                     Opacity="0.75" />
+                                 Command="{Binding OpenOnGitHub}"
+                                 Foreground="{DynamicResource GitHubVsToolWindowText}"
+                                 Opacity="0.75" />
                 <Border Background="{DynamicResource VsBrush.InfoBackground}"
                         BorderBrush="{DynamicResource VsBrush.AccentPale}"
                         BorderThickness="1"

--- a/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
@@ -94,7 +94,7 @@
 
             <markdig:MarkdownViewer Grid.Column="1" Grid.Row="1"
                                     Name="bodyMarkdown"
-                                    Margin="20 4 0 0"
+                                    Margin="24 4 0 0"
                                     Foreground="{DynamicResource VsBrush.WindowText}"
                                     Markdown="{Binding Body}"/>
 

--- a/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/CommentView.xaml
@@ -37,7 +37,7 @@
 
     <Grid IsEnabled="{Binding IsSubmitting, Converter={ui:InverseBooleanConverter}}">
         <!-- Displays an existing comment-->
-        <StackPanel Orientation="Vertical">
+        <StackPanel Orientation="Vertical" Margin="0 4 0 0">
             <StackPanel.Style>
                 <Style TargetType="FrameworkElement">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -118,8 +118,7 @@
 
             <Border BorderThickness="0,1,0,0"
                     BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}"
-                    Margin="0,4,0,0"
-                    Padding="0,4,0,0" />
+                    Margin="0,8,0,0" />
         </StackPanel>
 
         <!-- Displays edit view or a reply placeholder-->
@@ -156,7 +155,7 @@
                               AcceptsReturn="True"
                               AcceptsTab="True"
                               IsReadOnly="{Binding IsReadOnly}"
-                              Margin="4 0 4 4"
+                              Margin="4"
                               Text="{Binding Body, UpdateSourceTrigger=PropertyChanged}"
                               TextWrapping="Wrap"
                               VerticalAlignment="Center"

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -81,7 +81,7 @@
 
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="0 16 0 8"/>
 
-        <Border BorderBrush="#D1D5DA" BorderThickness="1">
+        <Border BorderBrush="#D1D5DA" BorderThickness="1" Margin="0 4">
             <StackPanel Orientation="Vertical">
                 <Border Padding="8" Background="#F6F8FA" BorderBrush="#D1D5DA" BorderThickness="0 0 0 1">
                     <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" >

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -75,7 +75,6 @@
                         </Border>
                     </InlineUIContainer>
                 </TextBlock>
-                
             </StackPanel>
         </Grid>
 
@@ -112,6 +111,21 @@
             </StackPanel>
         </Border>
 
+        <StackPanel Orientation="Vertical" Margin="0 8">
+            <StackPanel Orientation="Horizontal">
+                <ghfvs:OcticonImage DockPanel.Dock="Left"
+                                    Margin="0,0,4,0"
+                                    Icon="repo_push"/>
+                <v:ActorAvatarView Width="16" 
+                                       Height="16" 
+                                       ViewModel="{Binding Author}"/>
+                <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Margin="4 0">
+                    <Run FontWeight="Bold" Text="{Binding Author.Login}" />
+                    <Run Text="added some commits" />
+                </TextBlock>
+            </StackPanel>
+        </StackPanel>
+
         <ItemsControl Name="timeline" ItemsSource="{Binding Timeline}">
             <ItemsControl.Resources>
                 <DataTemplate DataType="{x:Type ghfvs:CommitSummariesViewModel}">
@@ -119,46 +133,53 @@
                 </DataTemplate>
 
                 <DataTemplate DataType="{x:Type ghfvs:CommitSummaryViewModel}">
-                    <DockPanel>
-                        <ghfvs:OcticonImage DockPanel.Dock="Left"
-                                            Margin="0,0,2,0"
-                                            Icon="git_commit"/>
-                        <v:ActorAvatarView DockPanel.Dock="Left"
-                                           Width="16"
-                                           Height="16"
-                                           Margin="2"
-                                           ViewModel="{Binding Author}"/>
-                        <TextBlock DockPanel.Dock="Right"
-                                   FontFamily="Consolas"
-                                   Margin="0,0,0,2"
-                                   VerticalAlignment="Center">
-                            <Hyperlink Command="{Binding DataContext.ShowCommit, ElementName=timeline}"
-                                       CommandParameter="{Binding Oid}">
-                                <Run Text="{Binding AbbreviatedOid, Mode=OneWay}"/>
-                            </Hyperlink>
-                        </TextBlock>
-                        <TextBlock Margin="0,0,0,2"
-                                   Text="{Binding Header}" 
-                                   VerticalAlignment="Center"/>
-                    </DockPanel>
+                    <Border Padding="20 0 8 0">
+                        <DockPanel>
+                            <ghfvs:OcticonImage DockPanel.Dock="Left"
+                                                Margin="0,0,2,0"
+                                                Icon="git_commit"/>
+                            <v:ActorAvatarView DockPanel.Dock="Left"
+                                               Width="16"
+                                               Height="16"
+                                               Margin="2"
+                                               ViewModel="{Binding Author}"/>
+                            <TextBlock DockPanel.Dock="Right"
+                                       FontFamily="Consolas"
+                                       Margin="0,0,0,2"
+                                       VerticalAlignment="Center">
+                                <Hyperlink Command="{Binding DataContext.ShowCommit, ElementName=timeline}"
+                                           CommandParameter="{Binding Oid}">
+                                    <Run Text="{Binding AbbreviatedOid, Mode=OneWay}"/>
+                                </Hyperlink>
+                            </TextBlock>
+                            <TextBlock Margin="0,0,0,2"
+                                       Text="{Binding Header}" 
+                                       VerticalAlignment="Center"/>
+                        </DockPanel>
+                    </Border>
                 </DataTemplate>
 
                 <DataTemplate DataType="{x:Type ghfvs:CommentViewModel}">
-                    <v:CommentView/>
-                </DataTemplate>
-
-                <DataTemplate DataType="{x:Type ghfvs:CommentViewModelDesigner}">
-                    <v:CommentView/>
-                </DataTemplate>
-            </ItemsControl.Resources>
-            <ItemsControl.ItemTemplate>
-                <DataTemplate>
                     <Border BorderThickness="0,1,0,0"
                             BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}"
                             Margin="0,8,0,0"
                             Padding="0,8,0,0">
-                        <ContentControl Content="{Binding}"/>
+                        <v:CommentView/>
                     </Border>
+                </DataTemplate>
+
+                <DataTemplate DataType="{x:Type ghfvs:CommentViewModelDesigner}">
+                    <Border BorderThickness="0,1,0,0"
+                            BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}"
+                            Margin="0,8,0,0"
+                            Padding="0,8,0,0">
+                        <v:CommentView />
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.Resources>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <ContentControl Content="{Binding}"/>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -112,18 +112,30 @@
         </Border>
 
         <StackPanel Orientation="Vertical" Margin="0 8">
-            <StackPanel Orientation="Horizontal">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="24" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
                 <ghfvs:OcticonImage DockPanel.Dock="Left"
-                                    Margin="0,0,4,0"
-                                    Icon="repo_push"/>
+                                    Margin="2 0 4 0"
+                                    Width="16"
+                                    Icon="repo_push"
+                                    Grid.Column="0"
+                                    HorizontalAlignment="Center" />
+
                 <v:ActorAvatarView Width="16" 
-                                       Height="16" 
-                                       ViewModel="{Binding Author}"/>
-                <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Margin="4 0">
+                                   Height="16" 
+                                   Grid.Column="1"
+                                   ViewModel="{Binding Author}"/>
+
+                <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Margin="4 0" Grid.Column="2">
                     <Run FontWeight="Bold" Text="{Binding Author.Login}" />
                     <Run Text="added some commits" />
                 </TextBlock>
-            </StackPanel>
+            </Grid>
         </StackPanel>
 
         <ItemsControl Name="timeline" ItemsSource="{Binding Timeline}">
@@ -133,7 +145,7 @@
                 </DataTemplate>
 
                 <DataTemplate DataType="{x:Type ghfvs:CommitSummaryViewModel}">
-                    <Border Padding="20 0 8 0">
+                    <Border Padding="24 0 8 0">
                         <DockPanel>
                             <ghfvs:OcticonImage DockPanel.Dock="Left"
                                                 Foreground="{DynamicResource VsBrush.GrayText}"

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -136,6 +136,7 @@
                     <Border Padding="20 0 8 0">
                         <DockPanel>
                             <ghfvs:OcticonImage DockPanel.Dock="Left"
+                                                Foreground="{DynamicResource VsBrush.GrayText}"
                                                 Margin="0,0,2,0"
                                                 Icon="git_commit"/>
                             <v:ActorAvatarView DockPanel.Dock="Left"

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -148,7 +148,7 @@
                             <Border BorderThickness="0,1,0,0"
                                     BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}"
                                     DockPanel.Dock="Bottom"
-                                    Margin="0,4,0,0"
+                                    Margin="0,8,0,0"
                                     Padding="0,4,0,0" />
                         </StackPanel>
                     </Border>

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -40,6 +40,7 @@
             </Grid.RowDefinitions>
 
             <TextBlock Margin="0 8"
+                       Foreground="{DynamicResource VsBrush.WindowText}"
                        Style="{DynamicResource {x:Static vsui:VsResourceKeys.TextBlockEnvironment200PercentFontSizeStyleKey}}">
                 <Run Text="{Binding Title, Mode=OneWay}"/>
                 <Hyperlink Command="{Binding OpenOnGitHub}">
@@ -48,7 +49,7 @@
             </TextBlock>
 
             <StackPanel Grid.Row="1" Orientation="Horizontal">
-                <TextBlock >
+                <TextBlock Foreground="{DynamicResource VsBrush.WindowText}">
                     <InlineUIContainer BaselineAlignment="Bottom">
                         <v:IssueishStateBadge DataContext="{Binding State}" Margin="0,0,0,-2"/>
                     </InlineUIContainer>
@@ -107,7 +108,7 @@
                     </StackPanel>
                 </Border>
 
-                <markdig:MarkdownViewer Name="bodyMarkdown" Margin="8" Markdown="{Binding Body}"/>
+                <markdig:MarkdownViewer Name="bodyMarkdown" Margin="8" Foreground="{DynamicResource VsBrush.WindowText}" Markdown="{Binding Body}"/>
             </StackPanel>
         </Border>
 
@@ -122,6 +123,7 @@
                 <ghfvs:OcticonImage DockPanel.Dock="Left"
                                     Margin="2 0 4 0"
                                     Width="16"
+                                    Foreground="{DynamicResource VsBrush.WindowText}"
                                     Icon="repo_push"
                                     Grid.Column="0"
                                     HorizontalAlignment="Center" />
@@ -176,6 +178,7 @@
                                 </Hyperlink>
                             </TextBlock>
                             <TextBlock Margin="0,0,0,2"
+                                       Foreground="{DynamicResource VsBrush.WindowText}"
                                        Text="{Binding Header}" 
                                        VerticalAlignment="Center"/>
                         </DockPanel>

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -141,7 +141,17 @@
         <ItemsControl Name="timeline" ItemsSource="{Binding Timeline}">
             <ItemsControl.Resources>
                 <DataTemplate DataType="{x:Type ghfvs:CommitSummariesViewModel}">
-                    <ItemsControl ItemsSource="{Binding Commits}"/>
+                    <Border>
+                        <StackPanel>
+                            <ItemsControl ItemsSource="{Binding Commits}"/>
+
+                            <Border BorderThickness="0,1,0,0"
+                                    BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}"
+                                    DockPanel.Dock="Bottom"
+                                    Margin="0,4,0,0"
+                                    Padding="0,4,0,0" />
+                        </StackPanel>
+                    </Border>
                 </DataTemplate>
 
                 <DataTemplate DataType="{x:Type ghfvs:CommitSummaryViewModel}">
@@ -173,21 +183,11 @@
                 </DataTemplate>
 
                 <DataTemplate DataType="{x:Type ghfvs:CommentViewModel}">
-                    <Border BorderThickness="0,1,0,0"
-                            BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}"
-                            Margin="0,8,0,0"
-                            Padding="0,8,0,0">
-                        <v:CommentView/>
-                    </Border>
+                    <v:CommentView/>
                 </DataTemplate>
 
                 <DataTemplate DataType="{x:Type ghfvs:CommentViewModelDesigner}">
-                    <Border BorderThickness="0,1,0,0"
-                            BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}"
-                            Margin="0,8,0,0"
-                            Padding="0,8,0,0">
-                        <v:CommentView />
-                    </Border>
+                    <v:CommentView />
                 </DataTemplate>
             </ItemsControl.Resources>
             <ItemsControl.ItemTemplate>

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -7,6 +7,7 @@
              xmlns:markdig="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
              xmlns:vsui="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
              xmlns:v="clr-namespace:GitHub.VisualStudio.Views"
+             xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
              mc:Ignorable="d"  d:DesignHeight="1200" d:DesignWidth="800"
              MaxWidth="800">
     <d:DesignData.DataContext>
@@ -80,7 +81,36 @@
 
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="0 16 0 8"/>
 
-        <markdig:MarkdownViewer Name="bodyMarkdown" Markdown="{Binding Body}"/>
+        <Border BorderBrush="#D1D5DA" BorderThickness="1">
+            <StackPanel Orientation="Vertical">
+                <Border Padding="8" Background="#F6F8FA" BorderBrush="#D1D5DA" BorderThickness="0 0 0 1">
+                    <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" >
+                        <v:ActorAvatarView Width="16" 
+                                               Height="16" 
+                                               ViewModel="{Binding Author}"/>
+
+                        <TextBlock Foreground="{DynamicResource GitHubVsToolWindowText}" Margin="4 0">
+                            <Run FontWeight="Bold" Text="{Binding Author.Login}" />
+                            <Run Text="commented" />
+                        </TextBlock>
+                        <ui:GitHubActionLink Content="{Binding CreatedAt, Converter={ui:DurationToStringConverter}}"
+                                         Command="{Binding OpenOnGitHub}"
+                                         Foreground="{DynamicResource GitHubVsToolWindowText}"
+                                         Opacity="0.75" />
+                        <Border Background="{DynamicResource VsBrush.InfoBackground}"
+                                BorderBrush="{DynamicResource VsBrush.AccentPale}"
+                                BorderThickness="1"
+                                CornerRadius="3"
+                                Padding="2 1"
+                                Visibility="{Binding IsPending, Converter={ui:BooleanToVisibilityConverter}, FallbackValue=Collapsed}">
+                          <TextBlock FontSize="10" Text="{x:Static ghfvs:Resources.Pending}" />
+                        </Border>
+                    </StackPanel>
+                </Border>
+
+                <markdig:MarkdownViewer Name="bodyMarkdown" Margin="8" Markdown="{Binding Body}"/>
+            </StackPanel>
+        </Border>
 
         <ItemsControl Name="timeline" ItemsSource="{Binding Timeline}">
             <ItemsControl.Resources>

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -78,7 +78,7 @@
             </StackPanel>
         </Grid>
 
-        <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="0,16"/>
+        <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="0 16 0 8"/>
 
         <markdig:MarkdownViewer Name="bodyMarkdown" Markdown="{Binding Body}"/>
 
@@ -125,8 +125,8 @@
                 <DataTemplate>
                     <Border BorderThickness="0,1,0,0"
                             BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}"
-                            Margin="0,16,0,0"
-                            Padding="0,16,0,0">
+                            Margin="0,8,0,0"
+                            Padding="0,8,0,0">
                         <ContentControl Content="{Binding}"/>
                     </Border>
                 </DataTemplate>

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -81,9 +81,9 @@
 
         <Rectangle DockPanel.Dock="Top" Style="{StaticResource Separator}" Height="2" Margin="0 16 0 8"/>
 
-        <Border BorderBrush="#D1D5DA" BorderThickness="1" Margin="0 4">
+        <Border BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}" BorderThickness="1" Margin="0 4">
             <StackPanel Orientation="Vertical">
-                <Border Padding="8" Background="#F6F8FA" BorderBrush="#D1D5DA" BorderThickness="0 0 0 1">
+                <Border Padding="8" Background="{DynamicResource GitHubBranchNameBackgroundBrush}" BorderBrush="{DynamicResource GitHubHeaderSeparatorBrush}" BorderThickness="0 0 0 1">
                     <StackPanel Orientation="Horizontal" DockPanel.Dock="Left" >
                         <v:ActorAvatarView Width="16" 
                                                Height="16" 


### PR DESCRIPTION
Hello! I wanted to start bringing in some polish work to the pull request conversation view ahead of time. (This branch target's @grokys' `feature/pr-conversation` branch)

**Before**

<img width="897" alt="screen shot 2018-11-19 at 3 01 46 pm" src="https://user-images.githubusercontent.com/1174461/48740594-efb24300-ec0c-11e8-8b48-d5cb2d94c29a.png">

**After**

<img width="1038" alt="screen shot 2018-11-19 at 7 32 55 pm" src="https://user-images.githubusercontent.com/1174461/48749989-0c14a680-ec32-11e8-810a-86782f566dd7.png">

Since this pull request touches the `CommentView.xaml` file, which is shared between the conversation and the threaded comment view, I wanted to make sure things looked consistent between the two. There is one update that affects this view which is adding a separator line between comments:

<img width="892" alt="screen shot 2018-11-19 at 3 31 18 pm" src="https://user-images.githubusercontent.com/1174461/48741568-74eb2700-ec10-11e8-8832-6d97a47b0c57.png">

For reference, here's what it looked like before:

<img width="896" alt="screen shot 2018-11-19 at 3 02 06 pm" src="https://user-images.githubusercontent.com/1174461/48740593-ef19ac80-ec0c-11e8-93aa-9dc0b6089824.png">


Last, I've also made sure that the page worked in Dark and Light themes:

<img width="1041" alt="screen shot 2018-11-19 at 7 33 18 pm" src="https://user-images.githubusercontent.com/1174461/48750006-22226700-ec32-11e8-8209-118608d51ec5.png">
<img width="1039" alt="screen shot 2018-11-19 at 7 32 30 pm" src="https://user-images.githubusercontent.com/1174461/48750007-22226700-ec32-11e8-8633-124799573483.png">