### PR TITLE
WIP: Prefer text instead of icon in checks list

### DIFF
--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestCheckView.xaml
@@ -22,7 +22,7 @@
         </ResourceDictionary>
     </Control.Resources>
 
-    <Grid>
+    <Grid Background="Red">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" SharedSizeGroup="Icon" />
             <ColumnDefinition Width="*" SharedSizeGroup="Title" />
@@ -45,14 +45,14 @@
         <!--
             <Label Grid.Column="3" HorizontalAlignment="Right" Content="{Binding Description}" ToolTip="{Binding Description}" />
         -->
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="2">
-            <Label Visibility="{Binding HasAnnotations, Converter={ghfvs:BooleanToVisibilityConverter}}">
+        <StackPanel Background="Blue" Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="2">
+            <Label HorizontalContentAlignment="Stretch" Visibility="{Binding HasAnnotations, Converter={ghfvs:BooleanToVisibilityConverter}}">
                 <Hyperlink ToolTip="View checks"  Command="{Binding Path=DataContext.ShowAnnotations, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type local:PullRequestDetailView}}}">
                     Checks
                 </Hyperlink>
             </Label>
 
-            <Label Visibility="{Binding DetailsUrl, Converter={ghfvs:NullToVisibilityConverter}}">
+            <Label HorizontalContentAlignment="Stretch" Visibility="{Binding DetailsUrl, Converter={ghfvs:NullToVisibilityConverter}}">
                 <Hyperlink ToolTip="{Binding DetailsUrl}"  Command="{Binding OpenDetailsUrl}">Details</Hyperlink>
             </Label>
         </StackPanel>

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestCheckView.xaml
@@ -22,11 +22,12 @@
         </ResourceDictionary>
     </Control.Resources>
 
-    <Grid Background="Red">
+    <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" SharedSizeGroup="Icon" />
-            <ColumnDefinition Width="*" SharedSizeGroup="Title" />
-            <ColumnDefinition Width="Auto" SharedSizeGroup="Links" />
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
         <Grid.RowDefinitions>
@@ -36,28 +37,22 @@
         <ghfvs:OcticonImage Grid.Column="0" Margin="0 0 4 0" Icon="check" Foreground="#2cbe4e" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Success}}"/>
         <ghfvs:OcticonImage Grid.Column="0" Margin="0 0 4 0" Icon="x" Foreground="#cb2431" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Failure}}"/>
         <ghfvs:OcticonImage Grid.Column="0" Margin="0 0 4 0" Icon="primitive_dot" Foreground="#f1c647" Visibility="{Binding Status, Converter={ghfvs:EqualsToVisibilityConverter Pending}}"/>
-        <!-- 
-            <Image Grid.Column="1" Source="{Binding Avatar}" Height="16" Width="16" />
-        -->
+
         <Label Grid.Column="1" Foreground="{DynamicResource VsBrush.WindowText}">
             <TextBlock TextTrimming="CharacterEllipsis" Text="{Binding Title}" />
         </Label>
-        <!--
-            <Label Grid.Column="3" HorizontalAlignment="Right" Content="{Binding Description}" ToolTip="{Binding Description}" />
-        -->
-        <StackPanel Background="Blue" Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="2">
-            <Label HorizontalContentAlignment="Stretch" Visibility="{Binding HasAnnotations, Converter={ghfvs:BooleanToVisibilityConverter}}">
-                <Hyperlink ToolTip="View checks"
+
+        <Label Grid.Column="2" HorizontalContentAlignment="Stretch" Visibility="{Binding HasAnnotations, Converter={ghfvs:BooleanToVisibilityConverter}}">
+            <Hyperlink ToolTip="View checks"
                            Command="{Binding Path=DataContext.ShowAnnotations, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type local:PullRequestDetailView}}}"
                            CommandParameter="{Binding}">
-                    Checks
-                </Hyperlink>
-            </Label>
-
-            <Label HorizontalContentAlignment="Stretch" Visibility="{Binding DetailsUrl, Converter={ghfvs:NullToVisibilityConverter}}">
-                <Hyperlink ToolTip="{Binding DetailsUrl}"  Command="{Binding OpenDetailsUrl}">Details</Hyperlink>
-            </Label>
-        </StackPanel>
+                Checks
+            </Hyperlink>
+        </Label>
+        
+        <Label Grid.Column="3" HorizontalContentAlignment="Stretch" Visibility="{Binding DetailsUrl, Converter={ghfvs:NullToVisibilityConverter}}">
+            <Hyperlink ToolTip="{Binding DetailsUrl}"  Command="{Binding OpenDetailsUrl}">Details</Hyperlink>
+        </Label>
     </Grid>
 </local:GenericPullRequestCheckView>
 

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestCheckView.xaml
@@ -24,12 +24,9 @@
 
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" SharedSizeGroup="ColumnZero" />
-            <!-- <ColumnDefinition Width="*" SharedSizeGroup="ColumnOne" /> -->
-            <ColumnDefinition Width="Auto" SharedSizeGroup="ColumnTwo" />
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto" SharedSizeGroup="ColumnFour" />
-            <ColumnDefinition MinWidth="50" Width="Auto" SharedSizeGroup="ColumnFive" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="Icon" />
+            <ColumnDefinition Width="*" SharedSizeGroup="Title" />
+            <ColumnDefinition Width="Auto" SharedSizeGroup="Links" />
         </Grid.ColumnDefinitions>
 
         <Grid.RowDefinitions>
@@ -42,19 +39,23 @@
         <!-- 
             <Image Grid.Column="1" Source="{Binding Avatar}" Height="16" Width="16" />
         -->
-        <Label Grid.Column="1" Foreground="{DynamicResource VsBrush.WindowText}" Content="{Binding Title}"/>
+        <Label Grid.Column="1" Foreground="{DynamicResource VsBrush.WindowText}">
+            <TextBlock TextTrimming="CharacterEllipsis" Text="{Binding Title}" />
+        </Label>
         <!--
             <Label Grid.Column="3" HorizontalAlignment="Right" Content="{Binding Description}" ToolTip="{Binding Description}" />
         -->
-        <Label Grid.Column="3" HorizontalAlignment="Right" Visibility="{Binding HasAnnotations, Converter={ghfvs:BooleanToVisibilityConverter}}">
-            <Hyperlink ToolTip="View checks"  Command="{Binding Path=DataContext.ShowAnnotations, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type local:PullRequestDetailView}}}">
-                Checks
-            </Hyperlink>
-        </Label>
-        <Label Grid.Column="4" HorizontalAlignment="Right"
-               Visibility="{Binding DetailsUrl, Converter={ghfvs:NullToVisibilityConverter}}">
-            <Hyperlink ToolTip="{Binding DetailsUrl}"  Command="{Binding OpenDetailsUrl}">Details</Hyperlink>
-        </Label>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="2">
+            <Label Visibility="{Binding HasAnnotations, Converter={ghfvs:BooleanToVisibilityConverter}}">
+                <Hyperlink ToolTip="View checks"  Command="{Binding Path=DataContext.ShowAnnotations, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type local:PullRequestDetailView}}}">
+                    Checks
+                </Hyperlink>
+            </Label>
+
+            <Label Visibility="{Binding DetailsUrl, Converter={ghfvs:NullToVisibilityConverter}}">
+                <Hyperlink ToolTip="{Binding DetailsUrl}"  Command="{Binding OpenDetailsUrl}">Details</Hyperlink>
+            </Label>
+        </StackPanel>
     </Grid>
 </local:GenericPullRequestCheckView>
 

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestCheckView.xaml
@@ -47,7 +47,9 @@
         -->
         <StackPanel Background="Blue" Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="2">
             <Label HorizontalContentAlignment="Stretch" Visibility="{Binding HasAnnotations, Converter={ghfvs:BooleanToVisibilityConverter}}">
-                <Hyperlink ToolTip="View checks"  Command="{Binding Path=DataContext.ShowAnnotations, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type local:PullRequestDetailView}}}">
+                <Hyperlink ToolTip="View checks"
+                           Command="{Binding Path=DataContext.ShowAnnotations, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type local:PullRequestDetailView}}}"
+                           CommandParameter="{Binding}">
                     Checks
                 </Hyperlink>
             </Label>

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestCheckView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestCheckView.xaml
@@ -46,11 +46,10 @@
         <!--
             <Label Grid.Column="3" HorizontalAlignment="Right" Content="{Binding Description}" ToolTip="{Binding Description}" />
         -->
-        <Label Grid.Column="3" HorizontalAlignment="Right">
-            <ghfvs:OcticonButton Command="{Binding Path=DataContext.ShowAnnotations, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type local:PullRequestDetailView}}}"
-                                 CommandParameter="{Binding}"
-                                 Visibility="{Binding HasAnnotations, Converter={ghfvs:BooleanToVisibilityConverter}}"
-                                 Margin="0 0 0 0" Icon="file_code" Foreground="Black" />
+        <Label Grid.Column="3" HorizontalAlignment="Right" Visibility="{Binding HasAnnotations, Converter={ghfvs:BooleanToVisibilityConverter}}">
+            <Hyperlink ToolTip="View checks"  Command="{Binding Path=DataContext.ShowAnnotations, RelativeSource={RelativeSource Mode=FindAncestor,AncestorType={x:Type local:PullRequestDetailView}}}">
+                Checks
+            </Hyperlink>
         </Label>
         <Label Grid.Column="4" HorizontalAlignment="Right"
                Visibility="{Binding DetailsUrl, Converter={ghfvs:NullToVisibilityConverter}}">

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
@@ -252,7 +252,7 @@
                     <ItemsControl ItemsSource="{Binding Checks}" Margin="0 4 12 4">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <StackPanel Grid.IsSharedSizeScope="True" />
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Grid.IsSharedSizeScope="True" />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                     </ItemsControl>

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
@@ -252,7 +252,7 @@
                     <ItemsControl ItemsSource="{Binding Checks}" Margin="0 4 12 4">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" Grid.IsSharedSizeScope="True" />
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch"/>
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                     </ItemsControl>


### PR DESCRIPTION
This pull request updates the checks list to use words instead of an icon. However I cannot figure out how to get the links to flush to the right of the Grid element 😭 

<img width="583" alt="screen shot 2018-11-20 at 2 12 05 pm" src="https://user-images.githubusercontent.com/1174461/48806237-8b57b800-ecce-11e8-8ffa-d3c12156f9b5.png">

If anyone has a clue why, I'd be super grateful for the help 🙏 