### PR TITLE
Create patch release v2.5.10

### DIFF
--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -414,6 +414,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll">
+      <Link>System.ValueTuple.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/GitHub.VisualStudio/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio/source.extension.vsixmanifest
@@ -40,6 +40,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.VisualStudio.UI" Path="|GitHub.VisualStudio.UI|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Rothko.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Newtonsoft.Json.dll" AssemblyName="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="System.ValueTuple.dll" AssemblyName="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
   </Assets>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25824.0,)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
This is a new PR to great a patch release .vsix artifact.

### What this PR does

- Package `System.ValueTuple, v4.0.3.0` with VSIX

### How to test

In order to reproduce this issue, I believe we need to test on a machine that doesn't have .NET 4.7.0 installed. To check that .NET 4.7.0 or later _isn't_ installed, execute the following using PowerShell. This will return `False` if  .NET 4.7.0 isn't installed.

```
Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\' | Get-ItemPropertyValue -Name Release | Foreach-Object { $_ -ge 460798 }
```

See here for details of how this works:
https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#ps_a

### Test plan

1. Execute PowerShell script above and expect `False`
2. Install GitHub for Visual Studio `v2.5.9`
3. Launch Visual Studio 2015
4. Open the `Team Explorer - Connect` page
5. Attempt to login to GitHub
6. Expect error or Visual Studio to crash
7. Install GitHub for Visual Studio `v2.5.10`
8. Attempt to login to GitHub
9. Expect login to succeed
