### PR TITLE
Check Run Annotations should be able to disable the Add Comment functionality

### DIFF
--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
@@ -40,6 +40,7 @@ namespace GitHub.InlineReviews.ViewModels
         ITrackingPoint triggerPoint;
         string relativePath;
         DiffSide side;
+        bool availableForComment;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InlineCommentPeekViewModel"/> class.
@@ -85,6 +86,12 @@ namespace GitHub.InlineReviews.ViewModels
                     FromLine = peekService.GetLineNumber(peekSession, triggerPoint).Item1,
                 }),
                 Observable.Return(previousCommentCommand.Enabled));
+        }
+
+        public bool AvailableForComment
+        {
+            get { return availableForComment; }
+            private set { this.RaiseAndSetIfChanged(ref availableForComment, value); }
         }
 
         /// <summary>
@@ -186,6 +193,11 @@ namespace GitHub.InlineReviews.ViewModels
             var lineAndLeftBuffer = peekService.GetLineNumber(peekSession, triggerPoint);
             var lineNumber = lineAndLeftBuffer.Item1;
             var leftBuffer = lineAndLeftBuffer.Item2;
+
+            AvailableForComment =
+                file.Diff.Any(chunk => chunk.Lines
+                    .Any(line => line.NewLineNumber == lineNumber));
+
             var thread = file.InlineCommentThreads?.FirstOrDefault(x =>
                 x.LineNumber == lineNumber &&
                 ((leftBuffer && x.DiffLineType == DiffChangeType.Delete) || (!leftBuffer && x.DiffLineType != DiffChangeType.Delete)));

--- a/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml
+++ b/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml
@@ -113,7 +113,9 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
-                <ghfvs:CommentThreadView x:Name="threadView" DataContext="{Binding Thread}"/>
+                <ghfvs:CommentThreadView x:Name="threadView"
+                                         Visibility="{Binding AvailableForComment, Converter={ghfvs:BooleanToVisibilityConverter}}"
+                                         DataContext="{Binding Thread}"/>
             </StackPanel>
         </ScrollViewer>
     </DockPanel>

--- a/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml
+++ b/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml
@@ -114,7 +114,7 @@
                 </ItemsControl>
 
                 <ghfvs:CommentThreadView x:Name="threadView"
-                                         Visibility="{Binding AvailableForComment, Converter={ghfvs:BooleanToVisibilityConverter}}"
+                                         Visibility="{Binding DataContext.AvailableForComment, Converter={ghfvs:BooleanToVisibilityConverter}, ElementName=annotationsView}"
                                          DataContext="{Binding Thread}"/>
             </StackPanel>
         </ScrollViewer>


### PR DESCRIPTION
This pull request targets #1900 

In the diff view, a user can sometimes have annotations that fall outside of the diff lines.
Viewing the annotation presents the user with an "Add comment" box that will always error if the user attempts to add a comment.

![image](https://user-images.githubusercontent.com/417571/48910493-1b683f80-ee3e-11e8-90e9-f67ccb46e828.png)

- [ ] I'm attempting to hide the `CommentThreadView` but I'm having some trouble. The property `AvailableForComment` is being set to false, but the `CommentThreadView` still appears.