### PR TITLE
Check we don't reference DesignTime assemblies

### DIFF
--- a/src/GitHub.VisualStudio.UI/GitHub.VisualStudio.UI.csproj
+++ b/src/GitHub.VisualStudio.UI/GitHub.VisualStudio.UI.csproj
@@ -24,5 +24,6 @@
   <ItemGroup>
     <PackageReference Include="Markdig.Signed" version="0.13.0" />
     <PackageReference Include="Markdig.Wpf.Signed" version="0.2.1" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.27" />
   </ItemGroup>
 </Project>

--- a/test/GitHub.VisualStudio.UnitTests/GitHubAssemblyTests.cs
+++ b/test/GitHub.VisualStudio.UnitTests/GitHubAssemblyTests.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+using System.Reflection;
+using NUnit.Framework;
+
+public class GitHubAssemblyTests
+{
+    [Theory]
+    public void GitHub_Assembly_Should_Not_Reference_DesignTime_Assembly(string assemblyFile)
+    {
+        var asm = Assembly.LoadFrom(assemblyFile);
+        foreach (var referencedAssembly in asm.GetReferencedAssemblies())
+        {
+            Assert.That(referencedAssembly.Name, Does.Not.EndWith(".DesignTime"),
+                "DesignTime assemblies should be embedded not referenced");
+        }
+    }
+
+    [DatapointSource]
+    string[] GitHubAssemblies => Directory.GetFiles(AssemblyDirectory, "GitHub.*.dll");
+
+    string AssemblyDirectory => Path.GetDirectoryName(GetType().Assembly.Location);
+}


### PR DESCRIPTION
Check that no `GitHub.*` assemblies reference any assembly that ends with `.DesignTime`. Types from `DesignTime` assemblies should be embedded not referenced.

### What this PR does

- Force types from `.DesignTime` assemblies to be embedded
  - Add a `PackageReference`  to `Microsoft.VisualStudio.SDK.EmbedInteropTypes`
- Added test to make sure we don't end up referencing a `.DesignTime` assembly again (see [failing](https://ci.appveyor.com/project/github-windows/visualstudio/builds/20621558/tests) test)

