### PR TITLE
Fixing InlineCommentTagger Crash

### DIFF
--- a/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
@@ -95,12 +95,11 @@ namespace GitHub.InlineReviews.Tags
                     Dictionary<int, InlineAnnotationModel[]> spanAnnotationsByLine = null;
                     if (side == DiffSide.Right)
                     {
-                        var spanAnnotations = file.InlineAnnotations.Where(x =>
+                        var spanAnnotations = file.InlineAnnotations?.Where(x =>
                                 x.EndLine - 1 >= startLine &&
                                 x.EndLine - 1 <= endLine);
 
-                        spanAnnotationsByLine = spanAnnotations
-                            .GroupBy(model => model.EndLine)
+                        spanAnnotationsByLine = spanAnnotations?.GroupBy(model => model.EndLine)
                             .ToDictionary(models => models.Key - 1, models => models.ToArray());
                     }
 


### PR DESCRIPTION
As pointed out by @jcansdale

```
System.ArgumentNullException: Value cannot be null. Parameter name: source at System.Linq.Enumerable.Where[TSource](IEnumerable`1 source, Func`2 predicate)
at GitHub.InlineReviews.Tags.InlineCommentTagger.GetTags(NormalizedSnapshotSpanCollection spans) in C:\projects\visualstudio\src\GitHub.InlineReviews\Tags\InlineCommentTagger.cs:line 98
at Microsoft.VisualStudio.Text.Tagging.Implementation.TagAggregator`1.<GetTagsForBuffer>d__39.MoveNext() --- End of stack trace from previous location where exception was thrown
--- at Microsoft.VisualStudio.Telemetry.WindowsErrorReporting.WatsonReport.GetClrWatsonExceptionInfo(Exception exceptionObject)
```