### PR TITLE
Use same msbuild.exe for NuGet and solution build

### DIFF
--- a/scripts/modules.ps1
+++ b/scripts/modules.ps1
@@ -115,7 +115,9 @@ New-Module -ScriptBlock {
     }
 
     function Build-Solution([string]$solution, [string]$target, [string]$configuration, [switch]$ForVSInstaller, [bool]$Deploy = $false) {
-        Run-Command -Fatal { & $nuget restore $solution -NonInteractive -Verbosity detailed }
+        $msbuild = Find-MSBuild
+
+        Run-Command -Fatal { & $nuget restore $solution -NonInteractive -Verbosity detailed -MSBuildPath (Split-Path -parent $msbuild) }
         $flag1 = ""
         $flag2 = ""
         if ($ForVSInstaller) {
@@ -126,8 +128,6 @@ New-Module -ScriptBlock {
             $configuration += "WithoutVsix"
             $flag1 = "/p:Package=Skip"
         }
-
-        $msbuild = Find-MSBuild
 
         Write-Host "$msbuild $solution /target:$target /property:Configuration=$configuration /p:DeployExtension=false /verbosity:minimal /p:VisualStudioVersion=15.0 /bl:output.binlog $flag1 $flag2"
         Run-Command -Fatal { & $msbuild $solution /target:$target /property:Configuration=$configuration /p:DeployExtension=false /verbosity:minimal /p:VisualStudioVersion=15.0 /bl:output.binlog $flag1 $flag2 }


### PR DESCRIPTION
NuGet was defaulting to the Visual Studio 2019 version of MSBuild (and failing). Force it to use the same msbuild.exe we locate for the solution build.

This was happening when Visual Studio 2019 was installed:

![image](https://user-images.githubusercontent.com/11719160/49375642-d7f2b880-f6fc-11e8-81e3-d356385e2836.png)
