### PR TITLE
Fixes to locate inline tags

### DIFF
--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -298,13 +298,13 @@ namespace GitHub.Services
         }
 
         /// <inheritdoc/>
-        public async Task<IDifferenceViewer> OpenDiff(IPullRequestSession session, string relativePath, string headSha, int fromLine)
+        public async Task<IDifferenceViewer> OpenDiff(IPullRequestSession session, string relativePath, string headSha, int nextInlineTagFromLine)
         {
             var diffViewer = await OpenDiff(session, relativePath, headSha, scrollToFirstDraftOrDiff: false);
 
             var param = (object) new InlineCommentNavigationParams
             {
-                FromLine = fromLine,
+                FromLine = nextInlineTagFromLine,
             };
 
             // HACK: We need to wait here for the inline comment tags to initialize so we can find the next inline comment.

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModel.cs
@@ -83,7 +83,10 @@ namespace GitHub.ViewModels.GitHubPane
 
             if (annotationModel != null)
             {
-                await editorService.OpenDiff(pullRequestSession, file.RelativePath, annotationModel.HeadSha, annotationModel.EndLine);
+                //AnnotationModel.EndLine is a 1-based number
+                //EditorService.OpenDiff takes a 0-based line number to start searching AFTER and will open the next tag
+                var nextInlineCommentFromLine = annotationModel.EndLine - 2;
+                await editorService.OpenDiff(pullRequestSession, file.RelativePath, annotationModel.HeadSha, nextInlineCommentFromLine);
             }
         }
 
@@ -247,7 +250,7 @@ namespace GitHub.ViewModels.GitHubPane
             var sessionFile = await pullRequestSession.GetFile(file.RelativePath);
             var annotations = sessionFile.InlineAnnotations;
 
-            return annotations.FirstOrDefault(model => model.AnnotationLevel == annotationLevel);
+            return annotations.OrderBy(model => model.EndLine).FirstOrDefault(model => model.AnnotationLevel == annotationLevel);
         }
 
         /// <summary>

--- a/src/GitHub.Exports.Reactive/Models/InlineAnnotationModel.cs
+++ b/src/GitHub.Exports.Reactive/Models/InlineAnnotationModel.cs
@@ -35,12 +35,12 @@ namespace GitHub.Models
         public string Path => annotation.Path;
 
         /// <summary>
-        /// Gets the start line of the annotation.
+        /// Gets the 1-based start line of the annotation.
         /// </summary>
         public int StartLine => annotation.StartLine;
 
         /// <summary>
-        /// Gets the end line of the annotation.
+        /// Gets the 1-based end line of the annotation.
         /// </summary>
         public int EndLine => annotation.EndLine;
         

--- a/src/GitHub.Exports.Reactive/Services/IPullRequestEditorService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IPullRequestEditorService.cs
@@ -55,9 +55,9 @@ namespace GitHub.Services
         /// The commit SHA of the right hand side of the diff. Pass null to compare with the
         /// working directory, or "HEAD" to compare with the HEAD commit of the pull request.
         /// </param>
-        /// <param name="fromLine">The line number to open</param>
+        /// <param name="nextInlineTagFromLine">The 0-based line number to execute NextInlineCommentCommand from</param>
         /// <returns>The opened diff viewer.</returns>
-        Task<IDifferenceViewer> OpenDiff(IPullRequestSession session, string relativePath, string headSha, int fromLine);
+        Task<IDifferenceViewer> OpenDiff(IPullRequestSession session, string relativePath, string headSha, int nextInlineTagFromLine);
 
         /// <summary>
         /// Find the active text view.

--- a/src/GitHub.Exports/Models/AnnotationModel.cs
+++ b/src/GitHub.Exports/Models/AnnotationModel.cs
@@ -6,12 +6,12 @@
     public class CheckRunAnnotationModel
     {
         /// <summary>
-        /// The starting line number (1 indexed).
+        /// The starting 1-based line number (1 indexed).
         /// </summary>
         public int StartLine { get; set; }
 
         /// <summary>
-        /// The ending line number (1 indexed).
+        /// The ending 1-based line number (1 indexed).
         /// </summary>
         public int EndLine { get; set; }
 

--- a/src/GitHub.InlineReviews/Commands/NextInlineCommentCommand.cs
+++ b/src/GitHub.InlineReviews/Commands/NextInlineCommentCommand.cs
@@ -53,7 +53,7 @@ namespace GitHub.InlineReviews.Commands
             if (tags.Count > 0)
             {
                 var cursorPoint = GetCursorPoint(textViews[0], parameter);
-                var next = tags.FirstOrDefault(x => x.Point >= cursorPoint) ?? tags.First();
+                var next = tags.FirstOrDefault(x => x.Point > cursorPoint) ?? tags.First();
                 ShowPeekComments(parameter, next.TextView, next.Tag, textViews);
             }
 


### PR DESCRIPTION
Before this pull request:
1. Previous Comment works. Next Comment does not work.
1. Opening an annotation by clicking the link in the pull request file list consistently opens the second annotation in the file, not the first.

Fixes:
1. As part of #1864, `NextInlineCommand.cs(56)` was changed from `>` to `>=`. This was returned to it's previous state.
2. A fix was made to correct the annotation line number sent to `EditorService.OpenDiff`. Comments were added to explain the changes.