### PR TITLE
Pull requests button disappears when changing from a non-GitHub to a GitHub repository

### DIFF
--- a/src/GitHub.TeamFoundation.14/Base/EnsureLoggedInSection.cs
+++ b/src/GitHub.TeamFoundation.14/Base/EnsureLoggedInSection.cs
@@ -45,7 +45,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             if (ActiveRepo == null || ActiveRepoUri == null)
                 return;
 
-            var isgithub = await IsAGitHubRepo();
+            var isgithub = await IsAGitHubRepo(ActiveRepoUri);
             if (!isgithub)
                 return;
 

--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerNavigationItemBase.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerNavigationItemBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Drawing;
+using System.Threading.Tasks;
 using GitHub.Api;
 using GitHub.Extensions;
 using GitHub.Logging;
@@ -39,10 +40,14 @@ namespace GitHub.VisualStudio.Base
             SubscribeToRepoChanges();
         }
 
-        public override async void Invalidate()
+        public override void Invalidate()
         {
             IsVisible = false;
+            InvalidateAsync().Forget(log);
+        }
 
+        async Task InvalidateAsync()
+        {
             var uri = ActiveRepoUri;
             var isVisible = await IsAGitHubRepo(uri);
             if (ActiveRepoUri != uri)

--- a/src/GitHub.TeamFoundation.14/Home/ForkNavigationItem.cs
+++ b/src/GitHub.TeamFoundation.14/Home/ForkNavigationItem.cs
@@ -97,7 +97,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             {
                 IsVisible = false;
 
-                if ((packageSettings?.ForkButton ?? false) && await IsAGitHubDotComRepo())
+                if ((packageSettings?.ForkButton ?? false) && await IsAGitHubDotComRepo(ActiveRepoUri))
                 {
                     var connection = await ConnectionManager.GetConnection(ActiveRepo);
                     IsVisible = connection?.IsLoggedIn ?? false;

--- a/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
+++ b/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
@@ -64,7 +64,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
 
             base.RepoChanged();
 
-            IsVisible = await IsAGitHubRepo();
+            IsVisible = await IsAGitHubRepo(ActiveRepoUri);
 
             if (IsVisible)
             {
@@ -93,7 +93,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
 
         public override async void Refresh()
         {
-            IsVisible = await IsAGitHubRepo();
+            IsVisible = await IsAGitHubRepo(ActiveRepoUri);
             if (IsVisible)
             {
                 IsLoggedIn = await IsUserAuthenticated();

--- a/src/GitHub.TeamFoundation.14/Home/IssuesNavigationItem.cs
+++ b/src/GitHub.TeamFoundation.14/Home/IssuesNavigationItem.cs
@@ -40,7 +40,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
         {
             IsVisible = false;
 
-            var visible = await IsAGitHubRepo();
+            var visible = await IsAGitHubRepo(ActiveRepoUri);
             if (visible)
             {
                 var repo = await SimpleApiClient.GetRepository();

--- a/src/GitHub.TeamFoundation.14/Home/WikiNavigationItem.cs
+++ b/src/GitHub.TeamFoundation.14/Home/WikiNavigationItem.cs
@@ -38,7 +38,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
 
         public override async void Invalidate()
         {
-            var visible = await IsAGitHubRepo();
+            var visible = await IsAGitHubRepo(ActiveRepoUri);
             if (visible)
             {
                 var repo = await SimpleApiClient.GetRepository();

--- a/src/GitHub.VisualStudio.UI/Base/TeamExplorerItemBase.cs
+++ b/src/GitHub.VisualStudio.UI/Base/TeamExplorerItemBase.cs
@@ -123,12 +123,8 @@ namespace GitHub.VisualStudio.Base
             }
         }
 
-        protected async Task<RepositoryOrigin> GetRepositoryOrigin()
+        protected async Task<RepositoryOrigin> GetRepositoryOrigin(UriString uri)
         {
-            if (ActiveRepo == null)
-                return RepositoryOrigin.NonGitRepository;
-
-            var uri = ActiveRepoUri;
             if (uri == null)
                 return RepositoryOrigin.Other;
 
@@ -154,15 +150,15 @@ namespace GitHub.VisualStudio.Base
             return RepositoryOrigin.Other;
         }
 
-        protected async Task<bool> IsAGitHubRepo()
+        protected async Task<bool> IsAGitHubRepo(UriString uri)
         {
-            var origin = await GetRepositoryOrigin();
+            var origin = await GetRepositoryOrigin(uri);
             return origin == RepositoryOrigin.DotCom || origin == RepositoryOrigin.Enterprise;
         }
 
-        protected async Task<bool> IsAGitHubDotComRepo()
+        protected async Task<bool> IsAGitHubDotComRepo(UriString uri)
         {
-            var origin = await GetRepositoryOrigin();
+            var origin = await GetRepositoryOrigin(uri);
             return origin == RepositoryOrigin.DotCom;
         }
 


### PR DESCRIPTION
There can be delay before `IsAGitHubRepo` returns its result. If the repository changes before the call returns, the button can end up with the visibility for the wrong repository.

This fix only sets the button visibility if the repository hasn't changed. Button is invalidated multiple times, so one of them returns the visibility for the correct repository.

### What this PR does

- Don't change button visibility if repo changed after async call was made

### What this PR doesn't do

This is probably only one of a number of issues like this. This is a point fix for the pull requests button disappearing (this is likely to have the most impact). Unfortunately the Team Explorer integration code has become fix upon fix and is difficult to work with and test.

Ideally we would create a view-model that controls visibility of all repository related buttons and UI inside Team Explorer. This would be a large (but worthwhile) refactoring, but is out of scope for this fix.

### How to repro

1. Open a Git repository that isn't on GitHub (e.g. one from Azure DevOps)
2. Open a Git repository that is on GitHub
3. Expect the pull request button to appear and then disappear 

This is what it ends up looking like:

![image](https://user-images.githubusercontent.com/11719160/49521347-2b037180-f89d-11e8-8992-fe639515b250.png)

### How to test

1. Open a Git repository that isn't on GitHub (e.g. one from Azure DevOps)
2. Open a Git repository that is on GitHub
3. Expect the pull request button to appear and remain!
