### PR TITLE
Renaming the output property to avoid graphql alias issue

### DIFF
--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -97,7 +97,7 @@ namespace GitHub.Services
                         Repositories = viewer.Repositories(null, null, null, null, null, order, affiliation, null, null)
                             .AllPages()
                             .Select(repositorySelection).ToList(),
-                        OrganizationRepositories = viewer.Organizations(null, null, null, null).AllPages().Select(org => new
+                        Organizations = viewer.Organizations(null, null, null, null).AllPages().Select(org => new
                         {
                             org.Login,
                             Repositories = org.Repositories(null, null, null, null, null, order, null, null, null)

--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
@@ -117,7 +117,7 @@ namespace GitHub.ViewModels.Dialog.Clone
                     .Where(r => r.Owner != results.Owner)
                     .OrderBy(r => r.Owner)
                     .Select(x => new RepositoryItemViewModel(x, "Collaborator repositories"));
-                var orgRepositories = results.OrganizationRepositories
+                var orgRepositories = results.Organizations
                     .OrderBy(x => x.Key)
                     .SelectMany(x => x.Value.Select(y => new RepositoryItemViewModel(y, x.Key)));
                 Items = yourRepositories.Concat(collaboratorRepositories).Concat(orgRepositories).ToList();

--- a/src/GitHub.Exports/Models/ViewerRepositoriesModel.cs
+++ b/src/GitHub.Exports/Models/ViewerRepositoriesModel.cs
@@ -7,6 +7,6 @@ namespace GitHub.Models
     {
         public string Owner { get; set; }
         public IReadOnlyList<RepositoryListItemModel> Repositories { get; set; }
-        public IDictionary<string, IReadOnlyList<RepositoryListItemModel>> OrganizationRepositories { get; set; }
+        public IDictionary<string, IReadOnlyList<RepositoryListItemModel>> Organizations { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #2095 
Working around the issue being fixed here: https://github.com/octokit/octokit.graphql.net/pull/173