### PR TITLE
Fixing the calculation to determine if a line is available for comment

### DIFF
--- a/src/GitHub.Exports.Reactive/Services/IInlineCommentPeekService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IInlineCommentPeekService.cs
@@ -12,12 +12,12 @@ namespace GitHub.Services
     public interface IInlineCommentPeekService
     {
         /// <summary>
-        /// Gets the line number for a peek session tracking point.
+        /// Gets the 0-based line number for a peek session tracking point.
         /// </summary>
         /// <param name="session">The peek session.</param>
         /// <param name="point">The peek session tracking point</param>
         /// <returns>
-        /// A tuple containing the line number and whether the line number represents a line in the
+        /// A tuple containing the 0-based line number and whether the line number represents a line in the
         /// left hand side of a diff view.
         /// </returns>
         Tuple<int, bool> GetLineNumber(IPeekSession session, ITrackingPoint point);

--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
@@ -196,7 +196,7 @@ namespace GitHub.InlineReviews.ViewModels
 
             AvailableForComment =
                 file.Diff.Any(chunk => chunk.Lines
-                    .Any(line => line.NewLineNumber == lineNumber));
+                    .Any(line => line.NewLineNumber - 1 == lineNumber));
 
             var thread = file.InlineCommentThreads?.FirstOrDefault(x =>
                 x.LineNumber == lineNumber &&


### PR DESCRIPTION
Fixes #2105 
Related #2080 

Before adding inline annotations, wherever an inline dialog would be is somewhere a comment could be created. After adding inline annotations we had to add code to hide the add comment control if it was not a line that could be commented on. Again a 1-based vs 0-based line numbering scheme bit me.

Fixing the issue and adding more comments.