### PR TITLE
Fix CA2007 ConfigureAwait warnings.

### DIFF
--- a/src/GitHub.Api/SimpleApiClient.cs
+++ b/src/GitHub.Api/SimpleApiClient.cs
@@ -45,7 +45,7 @@ namespace GitHub.Api
             // to read. This way, lock queues will only form once on first load
             if (owner != null)
                 return repositoryCache;
-            return await GetRepositoryInternal();
+            return await GetRepositoryInternal().ConfigureAwait(false);
         }
         
         public bool IsAuthenticated()
@@ -58,7 +58,7 @@ namespace GitHub.Api
 
         async Task<Repository> GetRepositoryInternal()
         {
-            await sem.WaitAsync();
+            await sem.WaitAsync().ConfigureAwait(false);
             try
             {
                 if (owner == null)
@@ -68,11 +68,11 @@ namespace GitHub.Api
 
                     if (ownerLogin != null && repositoryName != null)
                     {
-                        var repo = await Client.Repository.Get(ownerLogin, repositoryName);
+                        var repo = await Client.Repository.Get(ownerLogin, repositoryName).ConfigureAwait(false);
                         if (repo != null)
                         {
-                            hasWiki = await HasWikiInternal(repo);
-                            isEnterprise = isEnterprise ?? await IsEnterpriseInternal();
+                            hasWiki = await HasWikiInternal(repo).ConfigureAwait(false);
+                            isEnterprise = isEnterprise ?? await IsEnterpriseInternal().ConfigureAwait(false);
                             repositoryCache = repo;
                         }
                         owner = ownerLogin;
@@ -103,7 +103,7 @@ namespace GitHub.Api
         {
             if (!isEnterprise.HasValue)
             {
-                isEnterprise = await IsEnterpriseInternal();
+                isEnterprise = await IsEnterpriseInternal().ConfigureAwait(false);
             }
 
             return isEnterprise ?? false;
@@ -126,7 +126,7 @@ namespace GitHub.Api
             if (probe == null)
                 return false;
 #endif
-            var ret = await probe.ProbeAsync(repo);
+            var ret = await probe.ProbeAsync(repo).ConfigureAwait(false);
             return (ret == WikiProbeResult.Ok);
         }
 
@@ -141,7 +141,7 @@ namespace GitHub.Api
             if (probe == null)
                 return false;
 #endif
-            var ret = await probe.Probe(HostAddress.WebUri);
+            var ret = await probe.Probe(HostAddress.WebUri).ConfigureAwait(false);
             return (ret == EnterpriseProbeResult.Ok);
         }
     }

--- a/src/GitHub.App/Collections/SequentialListSource.cs
+++ b/src/GitHub.App/Collections/SequentialListSource.cs
@@ -82,7 +82,7 @@ namespace GitHub.Collections
         {
             dispatcher?.VerifyAccess();
 
-            var page = await EnsureLoaded(pageNumber);
+            var page = await EnsureLoaded(pageNumber).ConfigureAwait(false);
 
             if (page == null)
             {

--- a/src/GitHub.App/Collections/VirtualizingList.cs
+++ b/src/GitHub.App/Collections/VirtualizingList.cs
@@ -206,7 +206,7 @@ namespace GitHub.Collections
             try
             {
                 pages.Add(number, placeholderPage);
-                var page = await source.GetPage(number);
+                var page = await source.GetPage(number).ConfigureAwait(false);
 
                 if (page != null)
                 {

--- a/src/GitHub.App/Extensions/FileExtensions.cs
+++ b/src/GitHub.App/Extensions/FileExtensions.cs
@@ -9,7 +9,7 @@ namespace GitHub.Extensions
         {
             using (var writer = fileInfo.AppendText())
             {
-                await writer.WriteAsync(text);
+                await writer.WriteAsync(text).ConfigureAwait(false);
             }
         }
 
@@ -17,7 +17,7 @@ namespace GitHub.Extensions
         {
             using (var reader = fileInfo.OpenText())
             {
-                return await reader.ReadToEndAsync();
+                return await reader.ReadToEndAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/GitHub.App/Factories/ApiClientFactory.cs
+++ b/src/GitHub.App/Factories/ApiClientFactory.cs
@@ -35,7 +35,7 @@ namespace GitHub.Factories
         {
             return new ApiClient(
                 hostAddress,
-                new ObservableGitHubClient(await CreateGitHubClient(hostAddress)));
+                new ObservableGitHubClient(await CreateGitHubClient(hostAddress).ConfigureAwait(false)));
         }
 
         protected IKeychain Keychain { get; private set; }

--- a/src/GitHub.App/Factories/ModelServiceFactory.cs
+++ b/src/GitHub.App/Factories/ModelServiceFactory.cs
@@ -36,15 +36,15 @@ namespace GitHub.Factories
         {
             ModelService result;
 
-            await cacheLock.WaitAsync();
+            await cacheLock.WaitAsync().ConfigureAwait(false);
 
             try
             {
                 if (!cache.TryGetValue(connection, out result))
                 {
                     result = new ModelService(
-                        await apiClientFactory.Create(connection.HostAddress),
-                        await hostCacheFactory.Create(connection.HostAddress),
+                        await apiClientFactory.Create(connection.HostAddress).ConfigureAwait(false),
+                        await hostCacheFactory.Create(connection.HostAddress).ConfigureAwait(false),
                         avatarProvider);
                     result.InsertUser(AccountCacheItem.Create(connection.User));
                     cache.Add(connection, result);

--- a/src/GitHub.App/Services/DialogService.cs
+++ b/src/GitHub.App/Services/DialogService.cs
@@ -68,7 +68,7 @@ namespace GitHub.Services
 
             var viewModel = factory.CreateViewModel<IRepositoryRecloneViewModel>();
             viewModel.SelectedRepository = repository;
-            return (string)await showDialog.ShowWithFirstConnection(viewModel);
+            return (string)await showDialog.ShowWithFirstConnection(viewModel).ConfigureAwait(false);
         }
 
         public async Task ShowCreateGist(IConnection connection)
@@ -77,12 +77,12 @@ namespace GitHub.Services
 
             if (connection != null)
             {
-                await viewModel.InitializeAsync(connection);
-                await showDialog.Show(viewModel);
+                await viewModel.InitializeAsync(connection).ConfigureAwait(true);
+                await showDialog.Show(viewModel).ConfigureAwait(false);
             }
             else
             {
-                await showDialog.ShowWithFirstConnection(viewModel);
+                await showDialog.ShowWithFirstConnection(viewModel).ConfigureAwait(false);
             }
         }
 
@@ -91,14 +91,14 @@ namespace GitHub.Services
             Guard.ArgumentNotNull(connection, nameof(connection));
 
             var viewModel = factory.CreateViewModel<IRepositoryCreationViewModel>();
-            await viewModel.InitializeAsync(connection);
-            await showDialog.Show(viewModel);
+            await viewModel.InitializeAsync(connection).ConfigureAwait(true);
+            await showDialog.Show(viewModel).ConfigureAwait(false);
         }
 
         public async Task<IConnection> ShowLoginDialog()
         {
             var viewModel = factory.CreateViewModel<ILoginViewModel>();
-            return (IConnection)await showDialog.Show(viewModel);
+            return (IConnection)await showDialog.Show(viewModel).ConfigureAwait(false);
         }
 
         public async Task ShowForkDialog(LocalRepositoryModel repository, IConnection connection)
@@ -107,8 +107,8 @@ namespace GitHub.Services
             Guard.ArgumentNotNull(connection, nameof(connection));
 
             var viewModel = factory.CreateViewModel<IForkRepositoryViewModel>();
-            await viewModel.InitializeAsync(repository, connection);
-            await showDialog.Show(viewModel);
+            await viewModel.InitializeAsync(repository, connection).ConfigureAwait(true);
+            await showDialog.Show(viewModel).ConfigureAwait(false);
         }
     }
 }

--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -454,7 +454,7 @@ namespace GitHub.Services
                 // The PR base branch might no longer exist, so we fetch using `refs/pull/<PR>/head` first.
                 // This will often fetch the base commits, even when the base branch no longer exists.
                 var headRef = $"refs/pull/{pullNumber}/head";
-                await Fetch(repo, targetCloneUrl, headRef);
+                await Fetch(repo, targetCloneUrl, headRef).ConfigureAwait(false);
                 headCommit = repo.Lookup<Commit>(headSha);
                 if (headCommit == null)
                 {
@@ -465,7 +465,7 @@ namespace GitHub.Services
             var baseCommit = repo.Lookup<Commit>(baseSha);
             if (baseCommit == null)
             {
-                await Fetch(repo, targetCloneUrl, baseRef);
+                await Fetch(repo, targetCloneUrl, baseRef).ConfigureAwait(false);
                 baseCommit = repo.Lookup<Commit>(baseSha);
                 if (baseCommit == null)
                 {

--- a/src/GitHub.App/Services/GitHubContextService.cs
+++ b/src/GitHub.App/Services/GitHubContextService.cs
@@ -411,7 +411,7 @@ namespace GitHub.Services
 
             if (context.Line != null)
             {
-                await Task.Delay(1000);
+                await Task.Delay(1000).ConfigureAwait(true);
                 var activeView = FindActiveView();
                 SetSelection(activeView, context);
             }

--- a/src/GitHub.App/Services/GitHubCredentialProvider.cs
+++ b/src/GitHub.App/Services/GitHubCredentialProvider.cs
@@ -38,7 +38,7 @@ namespace GitHub.Services
 
             try
             {
-                var credentials = ThreadHelper.JoinableTaskFactory.Run(async () => await keychain.Load(host));
+                var credentials = ThreadHelper.JoinableTaskFactory.Run(async () => await keychain.Load(host).ConfigureAwait(false));
                 return new UsernamePasswordCredentials
                 {
                     Username = credentials.Item1,

--- a/src/GitHub.App/Services/ImageDownloader.cs
+++ b/src/GitHub.App/Services/ImageDownloader.cs
@@ -65,7 +65,7 @@ namespace GitHub.Services
 
             try
             {
-                return await DownloadImageBytesAsync(imageUri);
+                return await DownloadImageBytesAsync(imageUri).ConfigureAwait(false);
             }
             catch (NonImageContentException e)
             {
@@ -83,7 +83,7 @@ namespace GitHub.Services
                 Method = HttpMethod.Get,
             };
 
-            var response = await HttpClient.Send(request);
+            var response = await HttpClient.Send(request).ConfigureAwait(false);
             return GetSuccessfulBytes(imageUri, response);
         }
 

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -100,13 +100,14 @@ namespace GitHub.Services
                 }
                 else
                 {
-                    var file = await session.GetFile(relativePath);
+                    var file = await session.GetFile(relativePath).ConfigureAwait(true);
                     fileName = await pullRequestService.ExtractToTempFile(
                         session.LocalRepository,
                         session.PullRequest,
                         file.RelativePath,
                         file.CommitSha,
-                        pullRequestService.GetEncoding(session.LocalRepository, file.RelativePath));
+                        pullRequestService.GetEncoding(session.LocalRepository, file.RelativePath))
+                            .ConfigureAwait(false);
                     commitSha = file.CommitSha;
                 }
 
@@ -125,9 +126,9 @@ namespace GitHub.Services
                 }
 
                 if (workingDirectory)
-                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsOpenFileInSolution);
+                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsOpenFileInSolution).ConfigureAwait(false);
                 else
-                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsViewFile);
+                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsViewFile).ConfigureAwait(false);
 
                 return wpfTextView;
             }
@@ -147,8 +148,8 @@ namespace GitHub.Services
             try
             {
                 var workingDirectory = headSha == null;
-                var file = await session.GetFile(relativePath, headSha ?? "HEAD");
-                var mergeBase = await pullRequestService.GetMergeBase(session.LocalRepository, session.PullRequest);
+                var file = await session.GetFile(relativePath, headSha ?? "HEAD").ConfigureAwait(true);
+                var mergeBase = await pullRequestService.GetMergeBase(session.LocalRepository, session.PullRequest).ConfigureAwait(true);
                 var encoding = pullRequestService.GetEncoding(session.LocalRepository, file.RelativePath);
                 var rightFile = workingDirectory ?
                     Path.Combine(session.LocalRepository.LocalPath, relativePath) :
@@ -157,7 +158,7 @@ namespace GitHub.Services
                         session.PullRequest,
                         relativePath,
                         file.CommitSha,
-                        encoding);
+                        encoding).ConfigureAwait(true);
 
                 var diffViewer = FocusExistingDiffViewer(session, mergeBase, rightFile);
                 if (diffViewer != null)
@@ -170,8 +171,8 @@ namespace GitHub.Services
                     session.PullRequest,
                     relativePath,
                     mergeBase,
-                    encoding);
-                var leftPath = await GetBaseFileName(session, file);
+                    encoding).ConfigureAwait(true);
+                var leftPath = await GetBaseFileName(session, file).ConfigureAwait(true);
                 var rightPath = file.RelativePath;
                 var leftLabel = $"{leftPath};{session.GetBaseBranchDisplay()}";
                 var rightLabel = workingDirectory ? rightPath : $"{rightPath};PR {session.PullRequest.Number}";
@@ -259,9 +260,9 @@ namespace GitHub.Services
                 }
 
                 if (workingDirectory)
-                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsCompareWithSolution);
+                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsCompareWithSolution).ConfigureAwait(true);
                 else
-                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsViewChanges);
+                    await usageTracker.IncrementCounter(x => x.NumberOfPRDetailsViewChanges).ConfigureAwait(true);
 
                 if (openThread.line != -1)
                 {
@@ -300,7 +301,7 @@ namespace GitHub.Services
         /// <inheritdoc/>
         public async Task<IDifferenceViewer> OpenDiff(IPullRequestSession session, string relativePath, string headSha, int nextInlineTagFromLine)
         {
-            var diffViewer = await OpenDiff(session, relativePath, headSha, scrollToFirstDraftOrDiff: false);
+            var diffViewer = await OpenDiff(session, relativePath, headSha, scrollToFirstDraftOrDiff: false).ConfigureAwait(true);
 
             var param = (object) new InlineCommentNavigationParams
             {
@@ -309,7 +310,7 @@ namespace GitHub.Services
 
             // HACK: We need to wait here for the inline comment tags to initialize so we can find the next inline comment.
             // There must be a better way of doing this.
-            await Task.Delay(1500);
+            await Task.Delay(1500).ConfigureAwait(true);
             RaiseWhenAvailable(Guids.CommandSetString, PkgCmdIDList.NextInlineCommentId, param);
 
             return diffViewer;

--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -138,11 +138,11 @@ namespace GitHub.Services
 
                 if (isDotCom)
                 {
-                    await usageTracker.IncrementCounter(x => x.NumberOfGitHubOpens);
+                    await usageTracker.IncrementCounter(x => x.NumberOfGitHubOpens).ConfigureAwait(true);
                 }
                 else
                 {
-                    await usageTracker.IncrementCounter(x => x.NumberOfEnterpriseOpens);
+                    await usageTracker.IncrementCounter(x => x.NumberOfEnterpriseOpens).ConfigureAwait(true);
                 }
             }
             else
@@ -152,11 +152,11 @@ namespace GitHub.Services
 
                 if (isDotCom)
                 {
-                    await usageTracker.IncrementCounter(x => x.NumberOfGitHubClones);
+                    await usageTracker.IncrementCounter(x => x.NumberOfGitHubClones).ConfigureAwait(true);
                 }
                 else
                 {
-                    await usageTracker.IncrementCounter(x => x.NumberOfEnterpriseClones);
+                    await usageTracker.IncrementCounter(x => x.NumberOfEnterpriseClones).ConfigureAwait(true);
                 }
             }
 
@@ -211,13 +211,13 @@ namespace GitHub.Services
 
             try
             {
-                await vsGitServices.Clone(cloneUrl, repositoryPath, true, progress);
-                await usageTracker.IncrementCounter(x => x.NumberOfClones);
+                await vsGitServices.Clone(cloneUrl, repositoryPath, true, progress).ConfigureAwait(false);
+                await usageTracker.IncrementCounter(x => x.NumberOfClones).ConfigureAwait(false);
 
                 if (repositoryPath.StartsWith(DefaultClonePath, StringComparison.OrdinalIgnoreCase))
                 {
                     // Count the number of times users clone into the Default Repository Location
-                    await usageTracker.IncrementCounter(x => x.NumberOfClonesToDefaultClonePath);
+                    await usageTracker.IncrementCounter(x => x.NumberOfClonesToDefaultClonePath).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)

--- a/src/GitHub.App/Services/RepositoryForkService.cs
+++ b/src/GitHub.App/Services/RepositoryForkService.cs
@@ -56,7 +56,7 @@ namespace GitHub.Services
                             var originUri = repo.RemoteRepo != null ? new Uri(repo.RemoteRepo.CloneUrl) : null;
                             var upstreamUri = addUpstream ? sourceRepository.CloneUrl.ToUri() : null;
 
-                            await SwitchRemotes(repo.ActiveRepo, originUri, upstreamUri, trackMasterUpstream);
+                            await SwitchRemotes(repo.ActiveRepo, originUri, upstreamUri, trackMasterUpstream).ConfigureAwait(false);
                         }
                     }
 
@@ -77,12 +77,12 @@ namespace GitHub.Services
 
                         if (addUpstream)
                         {
-                            var remote = await gitClient.GetHttpRemote(activeRepo, "origin");
+                            var remote = await gitClient.GetHttpRemote(activeRepo, "origin").ConfigureAwait(false);
                             currentOrigin = new Uri(remote.Url);
                         }
 
                         await SwitchRemotes(activeRepo, updateOrigin ? destinationRepository.CloneUrl.ToUri() : null,
-                            currentOrigin, trackMasterUpstream);
+                            currentOrigin, trackMasterUpstream).ConfigureAwait(false);
                     }
 
                     if (updateOrigin)
@@ -104,21 +104,21 @@ namespace GitHub.Services
 
             log.Verbose("Set remote origin to {OriginUri}", originUri);
 
-            await gitClient.SetRemote(repository, "origin", originUri);
+            await gitClient.SetRemote(repository, "origin", originUri).ConfigureAwait(false);
 
             if (upstreamUri != null)
             {
                 log.Verbose("Set remote upstream to {UpstreamUri}", upstreamUri);
 
-                await gitClient.SetRemote(repository, "upstream", upstreamUri);
+                await gitClient.SetRemote(repository, "upstream", upstreamUri).ConfigureAwait(false);
 
-                await gitClient.Fetch(repository, "upstream");
+                await gitClient.Fetch(repository, "upstream").ConfigureAwait(false);
 
                 if (trackMasterUpstream)
                 {
                     log.Verbose("set master tracking to upstream");
 
-                    await gitClient.SetTrackingBranch(repository, "master", "upstream");
+                    await gitClient.SetTrackingBranch(repository, "master", "upstream").ConfigureAwait(false);
                 }
             }
         }

--- a/src/GitHub.App/Services/RepositoryPublishService.cs
+++ b/src/GitHub.App/Services/RepositoryPublishService.cs
@@ -47,10 +47,10 @@ namespace GitHub.Services
                              {
                                  using (repo.LocalRepo)
                                  {
-                                     await gitClient.SetRemote(repo.LocalRepo, "origin", new Uri(repo.RemoteRepo.CloneUrl));
-                                     await gitClient.Push(repo.LocalRepo, "master", "origin");
-                                     await gitClient.Fetch(repo.LocalRepo, "origin");
-                                     await gitClient.SetTrackingBranch(repo.LocalRepo, "master", "origin");
+                                     await gitClient.SetRemote(repo.LocalRepo, "origin", new Uri(repo.RemoteRepo.CloneUrl)).ConfigureAwait(false);
+                                     await gitClient.Push(repo.LocalRepo, "master", "origin").ConfigureAwait(false);
+                                     await gitClient.Fetch(repo.LocalRepo, "origin").ConfigureAwait(false);
+                                     await gitClient.SetTrackingBranch(repo.LocalRepo, "master", "origin").ConfigureAwait(false);
                                      return repo.RemoteRepo;
                                  }
                              });

--- a/src/GitHub.App/Services/RepositoryService.cs
+++ b/src/GitHub.App/Services/RepositoryService.cs
@@ -45,8 +45,8 @@ namespace GitHub.Services
                 { nameof(name), name },
             };
 
-            var graphql = await graphqlFactory.CreateConnection(address);
-            var result = await graphql.Run(readParentOwnerLogin, vars);
+            var graphql = await graphqlFactory.CreateConnection(address).ConfigureAwait(false);
+            var result = await graphql.Run(readParentOwnerLogin, vars).ConfigureAwait(false);
             return result != null ? (result.Item1, result.Item2) : ((string, string)?)null;
         }
     }

--- a/src/GitHub.App/Services/TeamExplorerContext.cs
+++ b/src/GitHub.App/Services/TeamExplorerContext.cs
@@ -86,7 +86,7 @@ namespace GitHub.Services
         {
             if (refreshJoinableTask != null)
             {
-                await refreshJoinableTask.JoinAsync(); // make sure StartRefresh has completed
+                await refreshJoinableTask.JoinAsync().ConfigureAwait(false); // make sure StartRefresh has completed
             }
 
             await (refreshJoinableTask = JoinableTaskFactory.RunAsync(RefreshAsync));
@@ -99,7 +99,7 @@ namespace GitHub.Services
                 await TaskScheduler.Default; // switch to threadpool
 
                 var repo = gitExt.ActiveRepositories?.FirstOrDefault();
-                string newSolutionPath = await GetSolutionPath();
+                string newSolutionPath = await GetSolutionPath().ConfigureAwait(true);
                 if (repo == null && newSolutionPath == solutionPath)
                 {
                     // Ignore when ActiveRepositories is empty and solution hasn't changed.
@@ -149,7 +149,7 @@ namespace GitHub.Services
         async Task<string> GetSolutionPath()
         {
             await JoinableTaskFactory.SwitchToMainThreadAsync();
-            var dte = await dteAsync.GetValueAsync();
+            var dte = await dteAsync.GetValueAsync().ConfigureAwait(true);
             return dte.Solution?.FullName;
         }
 

--- a/src/GitHub.App/ViewModels/Dialog/ForkRepositoryExecuteViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/ForkRepositoryExecuteViewModel.cs
@@ -67,7 +67,7 @@ namespace GitHub.ViewModels.Dialog
 
         public async Task InitializeAsync(LocalRepositoryModel sourceRepository, IAccount destinationAccount, IConnection connection)
         {
-            var modelService = await modelServiceFactory.CreateAsync(connection);
+            var modelService = await modelServiceFactory.CreateAsync(connection).ConfigureAwait(true);
             apiClient = modelService.ApiClient;
 
             DestinationAccount = destinationAccount;

--- a/src/GitHub.App/ViewModels/Dialog/ForkRepositorySelectViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/ForkRepositorySelectViewModel.cs
@@ -66,7 +66,7 @@ namespace GitHub.ViewModels.Dialog
 
             try
             {
-                var modelService = await modelServiceFactory.CreateAsync(connection);
+                var modelService = await modelServiceFactory.CreateAsync(connection).ConfigureAwait(true);
 
                 Observable.CombineLatest(
                     modelService.GetAccounts(),

--- a/src/GitHub.App/ViewModels/Dialog/ForkRepositoryViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/ForkRepositoryViewModel.cs
@@ -49,18 +49,18 @@ namespace GitHub.ViewModels.Dialog
         {
             Repository = repository;
             Connection = connection;
-            await ShowSelectPage();
+            await ShowSelectPage().ConfigureAwait(false);
         }
 
         async Task ShowSelectPage()
         {
-            await selectPage.InitializeAsync(Repository, Connection);
+            await selectPage.InitializeAsync(Repository, Connection).ConfigureAwait(true);
             Content = selectPage;
         }
 
         async Task ShowExecutePage(IAccount account)
         {
-            await executePage.InitializeAsync(Repository, account, Connection);
+            await executePage.InitializeAsync(Repository, account, Connection).ConfigureAwait(true);
             Content = executePage;
         }
 

--- a/src/GitHub.App/ViewModels/Dialog/GistCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/GistCreationViewModel.cs
@@ -60,7 +60,7 @@ namespace GitHub.ViewModels.Dialog
 
         public async Task InitializeAsync(IConnection connection)
         {
-            var modelService = await modelServiceFactory.CreateAsync(connection);
+            var modelService = await modelServiceFactory.CreateAsync(connection).ConfigureAwait(true);
             apiClient = modelService.ApiClient;
 
             // This class is only instantiated after we are logged into to a github account, so we should be safe to grab the first one here as the defaut.

--- a/src/GitHub.App/ViewModels/Dialog/LoginTabViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/LoginTabViewModel.cs
@@ -151,26 +151,26 @@ namespace GitHub.ViewModels.Dialog
         {
             Guard.ArgumentNotNull(hostAddress, nameof(hostAddress));
 
-            if (await ConnectionManager.GetConnection(hostAddress) != null)
+            if (await ConnectionManager.GetConnection(hostAddress).ConfigureAwait(false) != null)
             {
-                await ConnectionManager.LogOut(hostAddress);
+                await ConnectionManager.LogOut(hostAddress).ConfigureAwait(false);
             }
 
-            return await ConnectionManager.LogIn(hostAddress, UsernameOrEmail, Password);
+            return await ConnectionManager.LogIn(hostAddress, UsernameOrEmail, Password).ConfigureAwait(false);
         }
 
         protected async Task<IConnection> LoginToHostViaOAuth(HostAddress address)
         {
             oauthCancel = new CancellationTokenSource();
 
-            if (await ConnectionManager.GetConnection(address) != null)
+            if (await ConnectionManager.GetConnection(address).ConfigureAwait(false) != null)
             {
-                await ConnectionManager.LogOut(address);
+                await ConnectionManager.LogOut(address).ConfigureAwait(false);
             }
 
             try
             {
-                return await ConnectionManager.LogInViaOAuth(address, oauthCancel.Token);
+                return await ConnectionManager.LogInViaOAuth(address, oauthCancel.Token).ConfigureAwait(false);
             }
             finally
             {
@@ -183,9 +183,9 @@ namespace GitHub.ViewModels.Dialog
         {
             UsernameOrEmail = null;
             Password = null;
-            await UsernameOrEmailValidator.ResetAsync();
-            await PasswordValidator.ResetAsync();
-            await ResetValidation();
+            await UsernameOrEmailValidator.ResetAsync().ConfigureAwait(true);
+            await PasswordValidator.ResetAsync().ConfigureAwait(true);
+            await ResetValidation().ConfigureAwait(true);
         }
 
         protected virtual Task ResetValidation()

--- a/src/GitHub.App/ViewModels/Dialog/LoginToGitHubForEnterpriseViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/LoginToGitHubForEnterpriseViewModel.cs
@@ -131,7 +131,7 @@ namespace GitHub.ViewModels.Dialog
         protected override async Task ResetValidation()
         {
             EnterpriseUrl = null;
-            await EnterpriseUrlValidator.ResetAsync();
+            await EnterpriseUrlValidator.ResetAsync().ConfigureAwait(false);
         }
 
         async Task EnterpriseUrlChanged(string url, bool valid)
@@ -150,9 +150,9 @@ namespace GitHub.ViewModels.Dialog
 
             ProbeStatus = EnterpriseProbeStatus.Checking;
 
-            if (await enterpriseCapabilities.Probe(uri) == EnterpriseProbeResult.Ok)
+            if (await enterpriseCapabilities.Probe(uri).ConfigureAwait(true) == EnterpriseProbeResult.Ok)
             {
-                loginMethods = await enterpriseCapabilities.ProbeLoginMethods(uri);
+                loginMethods = await enterpriseCapabilities.ProbeLoginMethods(uri).ConfigureAwait(true);
                 enterpriseInstance = true;
             }
 
@@ -173,12 +173,12 @@ namespace GitHub.ViewModels.Dialog
         {
             Guard.ArgumentNotNull(hostAddress, nameof(hostAddress));
 
-            if (await ConnectionManager.GetConnection(hostAddress) != null)
+            if (await ConnectionManager.GetConnection(hostAddress).ConfigureAwait(false) != null)
             {
-                await ConnectionManager.LogOut(hostAddress);
+                await ConnectionManager.LogOut(hostAddress).ConfigureAwait(false);
             }
 
-            return await ConnectionManager.LogInWithToken(hostAddress, token);
+            return await ConnectionManager.LogInWithToken(hostAddress, token).ConfigureAwait(false);
         }
     }
 }

--- a/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
@@ -243,25 +243,25 @@ namespace GitHub.ViewModels.GitHubPane
 
             if (uri.AbsolutePath == "/pulls")
             {
-                await ShowPullRequests();
+                await ShowPullRequests().ConfigureAwait(true);
             }
             else if (uri.AbsolutePath == "/pull/new")
             {
-                await ShowCreatePullRequest();
+                await ShowCreatePullRequest().ConfigureAwait(true);
             }
             else if ((match = pullUri.Match(uri.AbsolutePath))?.Success == true)
             {
                 var owner = match.Groups["owner"].Value;
                 var repo = match.Groups["repo"].Value;
                 var number = int.Parse(match.Groups["number"].Value);
-                await ShowPullRequest(owner, repo, number);
+                await ShowPullRequest(owner, repo, number).ConfigureAwait(true);
             }
             else if ((match = pullNewReviewUri.Match(uri.AbsolutePath))?.Success == true)
             {
                 var owner = match.Groups["owner"].Value;
                 var repo = match.Groups["repo"].Value;
                 var number = int.Parse(match.Groups["number"].Value);
-                await ShowPullRequestReviewAuthoring(owner, repo, number);
+                await ShowPullRequestReviewAuthoring(owner, repo, number).ConfigureAwait(true);
             }
             else if ((match = pullUserReviewsUri.Match(uri.AbsolutePath))?.Success == true)
             {
@@ -269,7 +269,7 @@ namespace GitHub.ViewModels.GitHubPane
                 var repo = match.Groups["repo"].Value;
                 var number = int.Parse(match.Groups["number"].Value);
                 var login = match.Groups["login"].Value;
-                await ShowPullRequestReviews(owner, repo, number, login);
+                await ShowPullRequestReviews(owner, repo, number, login).ConfigureAwait(true);
             }
             else if ((match = pullCheckRunsUri.Match(uri.AbsolutePath))?.Success == true)
             {
@@ -278,7 +278,7 @@ namespace GitHub.ViewModels.GitHubPane
                 var number = int.Parse(match.Groups["number"].Value);
                 var id = match.Groups["id"].Value;
 
-                await ShowPullRequestCheckRun(owner, repo, number, id);
+                await ShowPullRequestCheckRun(owner, repo, number, id).ConfigureAwait(true);
             }
             else
             {
@@ -289,7 +289,7 @@ namespace GitHub.ViewModels.GitHubPane
 
             if (queries["refresh"] == "true")
             {
-                await navigator.Content.Refresh();
+                await navigator.Content.Refresh().ConfigureAwait(true);
             }
         }
 
@@ -362,7 +362,7 @@ namespace GitHub.ViewModels.GitHubPane
 
         async Task CreateInitializeTask(IServiceProvider paneServiceProvider)
         {
-            await UpdateContent(teamExplorerContext.ActiveRepository);
+            await UpdateContent(teamExplorerContext.ActiveRepository).ConfigureAwait(true);
             teamExplorerContext.WhenAnyValue(x => x.ActiveRepository)
                .Skip(1)
                .ObserveOn(RxApp.MainThreadScheduler)
@@ -393,7 +393,7 @@ namespace GitHub.ViewModels.GitHubPane
             Guard.ArgumentNotNull(initialize, nameof(initialize));
 
             if (Content != navigator) return;
-            await navigating.WaitAsync();
+            await navigating.WaitAsync().ConfigureAwait(true);
 
             try
             {
@@ -405,7 +405,7 @@ namespace GitHub.ViewModels.GitHubPane
                 {
                     viewModel = viewModelFactory.CreateViewModel<TViewModel>();
                     navigator.NavigateTo(viewModel);
-                    await initialize(viewModel);
+                    await initialize(viewModel).ConfigureAwait(true);
                 }
                 else if (navigator.Content != viewModel)
                 {
@@ -453,8 +453,8 @@ namespace GitHub.ViewModels.GitHubPane
 
             var repositoryUrl = repository.CloneUrl.ToRepositoryUrl();
             var isDotCom = HostAddress.IsGitHubDotComUri(repositoryUrl);
-            var client = await apiClientFactory.Create(repository.CloneUrl);
-            var isEnterprise = isDotCom ? false : await client.IsEnterprise();
+            var client = await apiClientFactory.Create(repository.CloneUrl).ConfigureAwait(true);
+            var isEnterprise = isDotCom ? false : await client.IsEnterprise().ConfigureAwait(true);
             var notGitHubRepo = true;
 
             if (isDotCom || isEnterprise)
@@ -463,7 +463,7 @@ namespace GitHub.ViewModels.GitHubPane
 
                 notGitHubRepo = false;
 
-                Connection = await connectionManager.GetConnection(hostAddress);
+                Connection = await connectionManager.GetConnection(hostAddress).ConfigureAwait(true);
                 Connection?.WhenAnyValue(
                     x => x.IsLoggedIn,
                     x => x.IsLoggingIn,
@@ -475,11 +475,11 @@ namespace GitHub.ViewModels.GitHubPane
 
                 if (Connection?.IsLoggedIn == true)
                 {
-                    if (await IsValidRepository(client) == true)
+                    if (await IsValidRepository(client).ConfigureAwait(true) == true)
                     {
                         log.Debug("Found a GitHub repository: {CloneUrl}", repository?.CloneUrl);
                         Content = navigator;
-                        await ShowDefaultPage();
+                        await ShowDefaultPage().ConfigureAwait(true);
                     }
                     else
                     {
@@ -515,7 +515,7 @@ namespace GitHub.ViewModels.GitHubPane
         {
             try
             {
-                var repo = await client.GetRepository();
+                var repo = await client.GetRepository().ConfigureAwait(false);
                 return repo.Id != 0;
             }
             catch

--- a/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/IssueListViewModelBase.cs
@@ -138,7 +138,7 @@ namespace GitHub.ViewModels.GitHubPane
                 var parent = await repositoryService.FindParent(
                     HostAddress.Create(repository.CloneUrl),
                     repository.Owner,
-                    repository.Name);
+                    repository.Name).ConfigureAwait(true);
 
                 if (parent == null)
                 {
@@ -167,7 +167,7 @@ namespace GitHub.ViewModels.GitHubPane
                     AuthorFilter.WhenAnyValue(x => x.Selected).Skip(1).SelectUnit())
                     .Subscribe(_ => FilterChanged());
 
-                await Refresh();
+                await Refresh().ConfigureAwait(true);
             }
             catch (Exception ex)
             {
@@ -297,7 +297,7 @@ namespace GitHub.ViewModels.GitHubPane
 
         async Task OpenItemImpl(IIssueListItemViewModelBase item)
         {
-            if (item != null) await DoOpenItem(item);
+            if (item != null) await DoOpenItem(item).ConfigureAwait(true);
         }
 
         void UpdateState(bool loading, int count)

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestAnnotationItemViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestAnnotationItemViewModel.cs
@@ -30,7 +30,8 @@ namespace GitHub.ViewModels.GitHubPane
             IsFileInPullRequest = isFileInPullRequest;
 
             OpenAnnotation = ReactiveCommand.CreateFromTask<Unit>(
-                async _ => await editorService.OpenDiff(session, annotation.Path, checkSuite.HeadSha, annotation.EndLine - 1),
+                async _ => await editorService.OpenDiff(session, annotation.Path, checkSuite.HeadSha, annotation.EndLine - 1)
+                    .ConfigureAwait(true),
                 Observable.Return(IsFileInPullRequest));
         }
 

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestAnnotationsViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestAnnotationsViewModel.cs
@@ -66,7 +66,7 @@ namespace GitHub.ViewModels.GitHubPane
                 RemoteRepositoryOwner = owner;
                 PullRequestNumber = pullRequestNumber;
                 CheckRunId = checkRunId;
-                session = await sessionManager.GetSession(owner, repo, pullRequestNumber);
+                session = await sessionManager.GetSession(owner, repo, pullRequestNumber).ConfigureAwait(true);
                 Load(session.PullRequest);
             }
             finally

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestCreationViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestCreationViewModel.cs
@@ -142,7 +142,7 @@ namespace GitHub.ViewModels.GitHubPane
 
         public async Task InitializeAsync(LocalRepositoryModel repository, IConnection connection)
         {
-            modelService = await modelServiceFactory.CreateAsync(connection);
+            modelService = await modelServiceFactory.CreateAsync(connection).ConfigureAwait(true);
             activeLocalRepo = repository;
             SourceBranch = gitService.GetBranch(repository);
 

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
@@ -303,9 +303,9 @@ namespace GitHub.ViewModels.GitHubPane
                 RemoteRepositoryOwner = owner;
                 Number = number;
                 WebUrl = localRepository.CloneUrl.ToRepositoryUrl(owner).Append("pull/" + number);
-                modelService = await modelServiceFactory.CreateAsync(connection);
-                Session = await sessionManager.GetSession(owner, repo, number);
-                await Load(Session.PullRequest);
+                modelService = await modelServiceFactory.CreateAsync(connection).ConfigureAwait(true);
+                Session = await sessionManager.GetSession(owner, repo, number).ConfigureAwait(true);
+                await Load(Session.PullRequest).ConfigureAwait(true);
                 teamExplorerContext.StatusChanged += RefreshIfActive;
             }
             catch (Exception ex)
@@ -352,7 +352,7 @@ namespace GitHub.ViewModels.GitHubPane
 
                 Checks = PullRequestCheckViewModel.Build(viewViewModelFactory, pullRequest)?.ToList();
 
-                await Files.InitializeAsync(Session);
+                await Files.InitializeAsync(Session).ConfigureAwait(true);
 
                 var localBranches = await pullRequestsService.GetLocalBranches(LocalRepository, pullRequest).ToList();
 
@@ -455,8 +455,8 @@ namespace GitHub.ViewModels.GitHubPane
                 Error = null;
                 OperationError = null;
                 IsBusy = true;
-                await Session.Refresh();
-                await Load(Session.PullRequest);
+                await Session.Refresh().ConfigureAwait(true);
+                await Load(Session.PullRequest).ConfigureAwait(true);
             }
             catch (Exception ex)
             {
@@ -584,7 +584,7 @@ namespace GitHub.ViewModels.GitHubPane
                 OperationError = null;
                 usageTracker.IncrementCounter(x => x.NumberOfSyncSubmodules).Forget();
 
-                var result = await syncSubmodulesCommand.SyncSubmodules();
+                var result = await syncSubmodulesCommand.SyncSubmodules().ConfigureAwait(true);
                 var complete = result.Item1;
                 var summary = result.Item2;
                 if (!complete)

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModel.cs
@@ -58,35 +58,36 @@ namespace GitHub.ViewModels.GitHubPane
 
             OpenFirstComment = ReactiveCommand.CreateFromTask<IPullRequestFileNode>(async file =>
             {
-                var thread = await GetFirstCommentThread(file);
+                var thread = await GetFirstCommentThread(file).ConfigureAwait(true);
 
                 if (thread != null)
                 {
-                    await editorService.OpenDiff(pullRequestSession, file.RelativePath, thread);
+                    await editorService.OpenDiff(pullRequestSession, file.RelativePath, thread).ConfigureAwait(true);
                 }
             });
 
             OpenFirstAnnotationNotice = ReactiveCommand.CreateFromTask<IPullRequestFileNode>(
-                async file => await OpenFirstAnnotation(editorService, file, CheckAnnotationLevel.Notice));
+                async file => await OpenFirstAnnotation(editorService, file, CheckAnnotationLevel.Notice).ConfigureAwait(true));
 
             OpenFirstAnnotationWarning = ReactiveCommand.CreateFromTask<IPullRequestFileNode>(
-                async file => await OpenFirstAnnotation(editorService, file, CheckAnnotationLevel.Warning));
+                async file => await OpenFirstAnnotation(editorService, file, CheckAnnotationLevel.Warning).ConfigureAwait(true));
 
             OpenFirstAnnotationFailure = ReactiveCommand.CreateFromTask<IPullRequestFileNode>(
-                async file => await OpenFirstAnnotation(editorService, file, CheckAnnotationLevel.Failure));
+                async file => await OpenFirstAnnotation(editorService, file, CheckAnnotationLevel.Failure).ConfigureAwait(true));
         }
 
         private async Task OpenFirstAnnotation(IPullRequestEditorService editorService, IPullRequestFileNode file,
             CheckAnnotationLevel checkAnnotationLevel)
         {
-            var annotationModel = await GetFirstAnnotation(file, checkAnnotationLevel);
+            var annotationModel = await GetFirstAnnotation(file, checkAnnotationLevel).ConfigureAwait(true);
 
             if (annotationModel != null)
             {
                 //AnnotationModel.EndLine is a 1-based number
                 //EditorService.OpenDiff takes a 0-based line number to start searching AFTER and will open the next tag
                 var nextInlineCommentFromLine = annotationModel.EndLine - 2;
-                await editorService.OpenDiff(pullRequestSession, file.RelativePath, annotationModel.HeadSha, nextInlineCommentFromLine);
+                await editorService.OpenDiff(pullRequestSession, file.RelativePath, annotationModel.HeadSha, nextInlineCommentFromLine)
+                    .ConfigureAwait(true);
             }
         }
 
@@ -139,7 +140,7 @@ namespace GitHub.ViewModels.GitHubPane
                         changedFile.Sha,
                         changedFile.Status,
                         GetOldFileName(changedFile, changes));
-                    var file = await session.GetFile(changedFile.FileName);
+                    var file = await session.GetFile(changedFile.FileName).ConfigureAwait(true);
 
                     if (file != null)
                     {
@@ -233,7 +234,7 @@ namespace GitHub.ViewModels.GitHubPane
 
         async Task<IInlineCommentThreadModel> GetFirstCommentThread(IPullRequestFileNode file)
         {
-            var sessionFile = await pullRequestSession.GetFile(file.RelativePath);
+            var sessionFile = await pullRequestSession.GetFile(file.RelativePath).ConfigureAwait(false);
             var threads = sessionFile.InlineCommentThreads.AsEnumerable();
 
             if (commentFilter != null)
@@ -247,7 +248,7 @@ namespace GitHub.ViewModels.GitHubPane
         async Task<InlineAnnotationModel> GetFirstAnnotation(IPullRequestFileNode file,
             CheckAnnotationLevel annotationLevel)
         {
-            var sessionFile = await pullRequestSession.GetFile(file.RelativePath);
+            var sessionFile = await pullRequestSession.GetFile(file.RelativePath).ConfigureAwait(false);
             var annotations = sessionFile.InlineAnnotations;
 
             return annotations.OrderBy(model => model.EndLine).FirstOrDefault(model => model.AnnotationLevel == annotationLevel);

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewAuthoringViewModel.cs
@@ -202,8 +202,8 @@ namespace GitHub.ViewModels.GitHubPane
             {
                 Error = null;
                 IsBusy = true;
-                await session.Refresh();
-                await Load(session.PullRequest);
+                await session.Refresh().ConfigureAwait(true);
+                await Load(session.PullRequest).ConfigureAwait(true);
             }
             catch (Exception ex)
             {
@@ -252,7 +252,7 @@ namespace GitHub.ViewModels.GitHubPane
                 Body = Model.Body;
 
                 sessionSubscription?.Dispose();
-                await UpdateFileComments();
+                await UpdateFileComments().ConfigureAwait(true);
                 sessionSubscription = session.PullRequestChanged.Subscribe(_ => UpdateFileComments().Forget());
             }
             finally
@@ -275,7 +275,7 @@ namespace GitHub.ViewModels.GitHubPane
                 Model.Id = session.PendingReviewId;
             }
 
-            foreach (var file in await session.GetAllFiles())
+            foreach (var file in await session.GetAllFiles().ConfigureAwait(true))
             {
                 foreach (var thread in file.InlineCommentThreads)
                 {
@@ -294,7 +294,7 @@ namespace GitHub.ViewModels.GitHubPane
             }
 
             FileComments = result;
-            await Files.InitializeAsync(session, FilterComments);
+            await Files.InitializeAsync(session, FilterComments).ConfigureAwait(true);
         }
 
         async Task DoSubmit(Octokit.PullRequestReviewEvent e)
@@ -329,7 +329,7 @@ namespace GitHub.ViewModels.GitHubPane
                 {
                     if (pullRequestService.ConfirmCancelPendingReview())
                     {
-                        await session.CancelReview();
+                        await session.CancelReview().ConfigureAwait(true);
                         Close();
                     }
                 }

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewCommentViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewCommentViewModel.cs
@@ -52,13 +52,13 @@ namespace GitHub.ViewModels.GitHubPane
             {
                 if (thread == null)
                 {
-                    var file = await session.GetFile(RelativePath, model.Thread.CommitSha);
+                    var file = await session.GetFile(RelativePath, model.Thread.CommitSha).ConfigureAwait(true);
                     thread = file.InlineCommentThreads.FirstOrDefault(t => t.Comments.Any(c => c.Comment.Id == model.Id));
                 }
 
                 if (thread != null && thread.LineNumber != -1)
                 {
-                    await editorService.OpenDiff(session, RelativePath, thread);
+                    await editorService.OpenDiff(session, RelativePath, thread).ConfigureAwait(true);
                 }
             }
             catch (Exception)

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestUserReviewsViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestUserReviewsViewModel.cs
@@ -104,8 +104,8 @@ namespace GitHub.ViewModels.GitHubPane
                 RemoteRepositoryOwner = owner;
                 PullRequestNumber = pullRequestNumber;
                 this.login = login;
-                session = await sessionManager.GetSession(owner, repo, pullRequestNumber);
-                await Load(session.PullRequest);                
+                session = await sessionManager.GetSession(owner, repo, pullRequestNumber).ConfigureAwait(true);
+                await Load(session.PullRequest).ConfigureAwait(true);
             }
             finally
             {
@@ -120,8 +120,8 @@ namespace GitHub.ViewModels.GitHubPane
             {
                 Error = null;
                 IsBusy = true;
-                await session.Refresh();
-                await Load(session.PullRequest);
+                await session.Refresh().ConfigureAwait(true);
+                await Load(session.PullRequest).ConfigureAwait(true);
             }
             catch (Exception ex)
             {
@@ -144,7 +144,6 @@ namespace GitHub.ViewModels.GitHubPane
 
             try
             {
-                await Task.Delay(0);
                 PullRequestTitle = pullRequest.Title;
 
                 var reviews = new List<IPullRequestReviewViewModel>();

--- a/src/GitHub.App/ViewModels/TeamExplorer/RepositoryPublishViewModel.cs
+++ b/src/GitHub.App/ViewModels/TeamExplorer/RepositoryPublishViewModel.cs
@@ -69,7 +69,7 @@ namespace GitHub.ViewModels.TeamExplorer
 
             accounts = this.WhenAnyValue(x => x.SelectedConnection)
                 .Where(x => x != null)
-                .SelectMany(async c => (await modelServiceFactory.CreateAsync(c)).GetAccounts())
+                .SelectMany(async c => (await modelServiceFactory.CreateAsync(c).ConfigureAwait(true)).GetAccounts())
                 .Switch()
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .ToProperty(this, x => x.Accounts, initialValue: new ReadOnlyCollection<IAccount>(Array.Empty<IAccount>()));
@@ -109,8 +109,8 @@ namespace GitHub.ViewModels.TeamExplorer
                 {
                     var name = RepositoryName;
                     RepositoryName = null;
-                    await RepositoryNameValidator.ResetAsync();
-                    await SafeRepositoryNameWarningValidator.ResetAsync();
+                    await RepositoryNameValidator.ResetAsync().ConfigureAwait(true);
+                    await SafeRepositoryNameWarningValidator.ResetAsync().ConfigureAwait(true);
                     RepositoryName = name;
                 });
         }

--- a/src/GitHub.App/ViewModels/UserFilterViewModel.cs
+++ b/src/GitHub.App/ViewModels/UserFilterViewModel.cs
@@ -120,7 +120,7 @@ namespace GitHub.ViewModels
 
             while (true)
             {
-                var page = await load(after);
+                var page = await load(after).ConfigureAwait(true);
 
                 foreach (var item in page.Items)
                 {

--- a/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports.Reactive/Extensions/ConnectionManagerExtensions.cs
@@ -13,8 +13,10 @@ namespace GitHub.Extensions
             LocalRepositoryModel repository,
             IModelServiceFactory factory)
         {
-            var connection = await cm.GetConnection(repository);
-            return connection?.IsLoggedIn == true ? await factory.CreateAsync(connection) : null;
+            var connection = await cm.GetConnection(repository).ConfigureAwait(false);
+            return connection?.IsLoggedIn == true ?
+                await factory.CreateAsync(connection).ConfigureAwait(false) :
+                null;
         }
     }
 }

--- a/src/GitHub.Exports/Extensions/ConnectionManagerExtensions.cs
+++ b/src/GitHub.Exports/Extensions/ConnectionManagerExtensions.cs
@@ -13,7 +13,7 @@ namespace GitHub.Extensions
         {
             Guard.ArgumentNotNull(cm, nameof(cm));
 
-            var connections = await cm.GetLoadedConnections();
+            var connections = await cm.GetLoadedConnections().ConfigureAwait(false);
             return connections.Any(x => x.ConnectionError == null);
         }
 
@@ -22,7 +22,7 @@ namespace GitHub.Extensions
             Guard.ArgumentNotNull(cm, nameof(cm));
             Guard.ArgumentNotNull(address, nameof(address));
 
-            var connections = await cm.GetLoadedConnections();
+            var connections = await cm.GetLoadedConnections().ConfigureAwait(false);
             return connections.Any(x => x.HostAddress == address && x.ConnectionError == null);
         }
 
@@ -30,7 +30,7 @@ namespace GitHub.Extensions
         {
             Guard.ArgumentNotNull(cm, nameof(cm));
 
-            var connections = await cm.GetLoadedConnections();
+            var connections = await cm.GetLoadedConnections().ConfigureAwait(false);
             return connections.FirstOrDefault(x => x.IsLoggedIn);
         }
 

--- a/src/GitHub.Exports/Services/WikiProbe.cs
+++ b/src/GitHub.Exports/Services/WikiProbe.cs
@@ -39,7 +39,8 @@ namespace GitHub.Services
 
             var ret = await httpClient
                 .Send(request, CancellationToken.None)
-                .Catch();
+                .Catch()
+                .ConfigureAwait(false);
 
             if (ret == null)
                 return WikiProbeResult.Failed;

--- a/src/GitHub.Extensions/TaskExtensions.cs
+++ b/src/GitHub.Extensions/TaskExtensions.cs
@@ -15,7 +15,7 @@ namespace GitHub.Extensions
 
             try
             {
-                return await source;
+                return await source.ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -31,7 +31,7 @@ namespace GitHub.Extensions
 
             try
             {
-                await source;
+                await source.ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/GitHub.InlineReviews/InlineReviewsPackage.cs
+++ b/src/GitHub.InlineReviews/InlineReviewsPackage.cs
@@ -27,8 +27,7 @@ namespace GitHub.InlineReviews
             CancellationToken cancellationToken,
             IProgress<ServiceProgressData> progress)
         {
-            var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
-            var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
+            var componentModel = (IComponentModel)await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(false);
             var exports = componentModel.DefaultExportProvider;
 
             // Avoid delays when there is ongoing UI activity.
@@ -44,7 +43,7 @@ namespace GitHub.InlineReviews
                 return;
             }
 
-            var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
+            var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(true));
             var exports = componentModel.DefaultExportProvider;
             var commands = new IVsCommandBase[]
             {
@@ -54,7 +53,7 @@ namespace GitHub.InlineReviews
             };
 
             await JoinableTaskFactory.SwitchToMainThreadAsync();
-            var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
+            var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)).ConfigureAwait(true));
             menuService.AddCommands(commands);
         }
     }

--- a/src/GitHub.InlineReviews/Margins/InlineCommentMargin.cs
+++ b/src/GitHub.InlineReviews/Margins/InlineCommentMargin.cs
@@ -67,7 +67,7 @@ namespace GitHub.InlineReviews.Margins
 
         async Task RefreshCurrentSession()
         {
-            var sessionFile = await FindSessionFile();
+            var sessionFile = await FindSessionFile().ConfigureAwait(true);
             hasChanges = sessionFile?.Diff != null && sessionFile.Diff.Count > 0;
 
             await Task.Yield(); // HACK: Give diff view a chance to initialize.
@@ -102,7 +102,7 @@ namespace GitHub.InlineReviews.Margins
 
         async Task<IPullRequestSessionFile> FindSessionFile()
         {
-            await sessionManager.EnsureInitialized();
+            await sessionManager.EnsureInitialized().ConfigureAwait(false);
 
             var session = sessionManager.CurrentSession;
             if (session == null)
@@ -116,7 +116,7 @@ namespace GitHub.InlineReviews.Margins
                 return null;
             }
 
-            return await session.GetFile(relativePath);
+            return await session.GetFile(relativePath).ConfigureAwait(false);
         }
 
         bool IsDiffView() => textView.Roles.Contains("DIFF");

--- a/src/GitHub.InlineReviews/Margins/PullRequestFileMargin.cs
+++ b/src/GitHub.InlineReviews/Margins/PullRequestFileMargin.cs
@@ -75,7 +75,7 @@ namespace GitHub.InlineReviews.Margins
 
         async Task RefreshCurrentSession()
         {
-            var sessionFile = await FindSessionFile();
+            var sessionFile = await FindSessionFile().ConfigureAwait(true);
             if (sessionFile != null)
             {
                 viewModel.FileName = Path.GetFileName(sessionFile.RelativePath);
@@ -91,7 +91,7 @@ namespace GitHub.InlineReviews.Margins
 
         async Task<IPullRequestSessionFile> FindSessionFile()
         {
-            await sessionManager.EnsureInitialized();
+            await sessionManager.EnsureInitialized().ConfigureAwait(false);
 
             var session = sessionManager.CurrentSession;
             if (session == null)
@@ -105,7 +105,7 @@ namespace GitHub.InlineReviews.Margins
                 return null;
             }
 
-            return await session.GetFile(relativePath);
+            return await session.GetFile(relativePath).ConfigureAwait(false);
         }
 
         public FrameworkElement VisualElement => visualElement;

--- a/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
+++ b/src/GitHub.InlineReviews/PullRequestStatusBarPackage.cs
@@ -27,7 +27,7 @@ namespace GitHub.InlineReviews
 
         async Task InitializeStatusBar()
         {
-            var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
+            var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(false));
             var exports = componentModel.DefaultExportProvider;
             var barManager = exports.GetExportedValue<PullRequestStatusBarManager>();
 

--- a/src/GitHub.InlineReviews/Services/DiffService.cs
+++ b/src/GitHub.InlineReviews/Services/DiffService.cs
@@ -31,7 +31,7 @@ namespace GitHub.InlineReviews.Services
             string headSha,
             string path)
         {
-            var patch = await gitClient.Compare(repo, baseSha, headSha, path);
+            var patch = await gitClient.Compare(repo, baseSha, headSha, path).ConfigureAwait(false);
 
             if (patch != null)
             {
@@ -51,7 +51,7 @@ namespace GitHub.InlineReviews.Services
             string path,
             byte[] contents)
         {
-            var changes = await gitClient.CompareWith(repo, baseSha, headSha, path, contents);
+            var changes = await gitClient.CompareWith(repo, baseSha, headSha, path, contents).ConfigureAwait(false);
 
             if (changes?.Patch != null)
             {

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -65,7 +65,7 @@ namespace GitHub.InlineReviews.Services
         {
             if (files == null)
             {
-                files = await CreateAllFiles();
+                files = await CreateAllFiles().ConfigureAwait(false);
             }
 
             return files;
@@ -76,7 +76,7 @@ namespace GitHub.InlineReviews.Services
             string relativePath,
             string commitSha = "HEAD")
         {
-            await getFilesLock.WaitAsync();
+            await getFilesLock.WaitAsync().ConfigureAwait(false);
 
             try
             {
@@ -87,7 +87,7 @@ namespace GitHub.InlineReviews.Services
                 if (!fileIndex.TryGetValue(key, out file))
                 {
                     file = new PullRequestSessionFile(normalizedPath, commitSha);
-                    await UpdateFile(file);
+                    await UpdateFile(file).ConfigureAwait(false);
                     fileIndex.Add(key, file);
                 }
 
@@ -104,7 +104,7 @@ namespace GitHub.InlineReviews.Services
         {
             if (mergeBase == null)
             {
-                mergeBase = await service.GetPullRequestMergeBase(LocalRepository, PullRequest);
+                mergeBase = await service.GetPullRequestMergeBase(LocalRepository, PullRequest).ConfigureAwait(false);
             }
 
             return mergeBase;
@@ -142,8 +142,8 @@ namespace GitHub.InlineReviews.Services
                     body,
                     commitId,
                     path,
-                    position);
-                await Update(model);
+                    position).ConfigureAwait(false);
+                await Update(model).ConfigureAwait(false);
             }
             else
             {
@@ -153,8 +153,8 @@ namespace GitHub.InlineReviews.Services
                     body,
                     commitId,
                     path,
-                    position);
-                await Update(model);
+                    position).ConfigureAwait(false);
+                await Update(model).ConfigureAwait(false);
             }
         }
 
@@ -165,9 +165,9 @@ namespace GitHub.InlineReviews.Services
                 LocalRepository,
                 RepositoryOwner,
                 pullRequestId,
-                commentDatabaseId);
+                commentDatabaseId).ConfigureAwait(false);
 
-            await Update(model);
+            await Update(model).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -177,9 +177,9 @@ namespace GitHub.InlineReviews.Services
                 LocalRepository,
                 RepositoryOwner,
                 commentNodeId,
-                body);
+                body).ConfigureAwait(false);
 
-            await Update(model);
+            await Update(model).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -193,8 +193,8 @@ namespace GitHub.InlineReviews.Services
                     LocalRepository,
                     PullRequest.Id,
                     body,
-                    inReplyTo);
-                await Update(model);
+                    inReplyTo).ConfigureAwait(false);
+                await Update(model).ConfigureAwait(false);
             }
             else
             {
@@ -202,8 +202,8 @@ namespace GitHub.InlineReviews.Services
                     LocalRepository,
                     PendingReviewId,
                     body,
-                    inReplyTo);
-                await Update(model);
+                    inReplyTo).ConfigureAwait(false);
+                await Update(model).ConfigureAwait(false);
             }
         }
 
@@ -217,9 +217,9 @@ namespace GitHub.InlineReviews.Services
 
             var model = await service.CreatePendingReview(
                 LocalRepository,
-                await GetPullRequestNodeId());
+                await GetPullRequestNodeId().ConfigureAwait(false)).ConfigureAwait(false);
 
-            await Update(model);
+            await Update(model).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -230,8 +230,9 @@ namespace GitHub.InlineReviews.Services
                 throw new InvalidOperationException("There is no pending review to cancel.");
             }
 
-            var pullRequest = await service.CancelPendingReview(LocalRepository, PendingReviewId);
-            await Update(pullRequest);
+            var pullRequest = await service.CancelPendingReview(LocalRepository, PendingReviewId)
+                .ConfigureAwait(false);
+            await Update(pullRequest).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -246,7 +247,7 @@ namespace GitHub.InlineReviews.Services
                     PullRequest.Id,
                     PullRequest.HeadRefSha,
                     body,
-                    e);
+                    e).ConfigureAwait(false);
             }
             else
             {
@@ -254,10 +255,10 @@ namespace GitHub.InlineReviews.Services
                     LocalRepository,
                     PendingReviewId,
                     body,
-                    e);
+                    e).ConfigureAwait(false);
             }
 
-            await Update(model);
+            await Update(model).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -268,8 +269,8 @@ namespace GitHub.InlineReviews.Services
                 address,
                 RepositoryOwner,
                 LocalRepository.Name,
-                PullRequest.Number);
-            await Update(model);
+                PullRequest.Number).ConfigureAwait(false);
+            await Update(model).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -280,7 +281,7 @@ namespace GitHub.InlineReviews.Services
 
             foreach (var file in this.fileIndex.Values.ToList())
             {
-                await UpdateFile(file);
+                await UpdateFile(file).ConfigureAwait(false);
             }
 
             UpdatePendingReview();
@@ -299,16 +300,15 @@ namespace GitHub.InlineReviews.Services
             review.Comments = review.Comments
                 .Concat(new[] { comment })
                 .ToList();
-            await Update(PullRequest);
+            await Update(PullRequest).ConfigureAwait(false);
         }
 
         async Task UpdateFile(PullRequestSessionFile file)
         {
-            await Task.Delay(0);
-            var mergeBaseSha = await GetMergeBase();
+            var mergeBaseSha = await GetMergeBase().ConfigureAwait(false);
             file.BaseSha = PullRequest.BaseRefSha;
             file.CommitSha = file.IsTrackingHead ? PullRequest.HeadRefSha : file.CommitSha;
-            file.Diff = await service.Diff(LocalRepository, mergeBaseSha, file.CommitSha, file.RelativePath);
+            file.Diff = await service.Diff(LocalRepository, mergeBaseSha, file.CommitSha, file.RelativePath).ConfigureAwait(false);
             file.InlineCommentThreads = service.BuildCommentThreads(PullRequest, file.RelativePath, file.Diff, file.CommitSha);
             file.InlineAnnotations = service.BuildAnnotations(PullRequest, file.RelativePath);
         }
@@ -336,7 +336,7 @@ namespace GitHub.InlineReviews.Services
 
             foreach (var path in FilePaths)
             {
-                var file = await GetFile(path);
+                var file = await GetFile(path).ConfigureAwait(false);
                 result.Add(file);
             }
 
@@ -355,7 +355,7 @@ namespace GitHub.InlineReviews.Services
                 pullRequestNodeId = await service.GetGraphQLPullRequestId(
                     LocalRepository,
                     RepositoryOwner,
-                    PullRequest.Number);
+                    PullRequest.Number).ConfigureAwait(false);
             }
 
             return pullRequestNodeId;

--- a/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
@@ -91,7 +91,7 @@ namespace GitHub.InlineReviews.Services
                 NoRemoteOriginCallout();
             }
 
-            var showStatus = await IsDotComOrEnterpriseRepository(repository);
+            var showStatus = await IsDotComOrEnterpriseRepository(repository).ConfigureAwait(true);
             if (!showStatus)
             {
                 ShowStatus(null);
@@ -145,7 +145,7 @@ namespace GitHub.InlineReviews.Services
                 return true;
             }
 
-            var connection = await connectionManager.Value.GetConnection(repository);
+            var connection = await connectionManager.Value.GetConnection(repository).ConfigureAwait(false);
             if (connection != null)
             {
                 // This is an enterprise repository

--- a/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
+++ b/src/GitHub.InlineReviews/Tags/InlineCommentTagger.cs
@@ -193,7 +193,7 @@ namespace GitHub.InlineReviews.Tags
                 var commitSha = bufferInfo.Side == DiffSide.Left ? "HEAD" : bufferInfo.CommitSha;
                 session = bufferInfo.Session;
                 relativePath = bufferInfo.RelativePath;
-                file = await session.GetFile(relativePath, commitSha);
+                file = await session.GetFile(relativePath, commitSha).ConfigureAwait(false);
                 fileSubscription = file.LinesChanged.Subscribe(LinesChanged);
                 side = bufferInfo.Side ?? DiffSide.Right;
                 NotifyTagsChanged();
@@ -201,7 +201,7 @@ namespace GitHub.InlineReviews.Tags
             else
             {
                 side = DiffSide.Right;
-                await InitializeLiveFile();
+                await InitializeLiveFile().ConfigureAwait(false);
                 sessionManagerSubscription = sessionManager
                     .WhenAnyValue(x => x.CurrentSession)
                     .Skip(1)
@@ -218,7 +218,7 @@ namespace GitHub.InlineReviews.Tags
 
             if (relativePath != null)
             {
-                file = await sessionManager.GetLiveFile(relativePath, view, buffer);
+                file = await sessionManager.GetLiveFile(relativePath, view, buffer).ConfigureAwait(true);
 
                 var options = view.Options;
                 visibleSubscription =

--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
@@ -144,16 +144,16 @@ namespace GitHub.InlineReviews.ViewModels
                 var commitSha = info.Side == DiffSide.Left ? "HEAD" : info.CommitSha;
                 relativePath = info.RelativePath;
                 side = info.Side ?? DiffSide.Right;
-                file = await info.Session.GetFile(relativePath, commitSha);
+                file = await info.Session.GetFile(relativePath, commitSha).ConfigureAwait(true);
                 session = info.Session;
-                await UpdateThread();
+                await UpdateThread().ConfigureAwait(true);
             }
             else
             {
                 relativePath = sessionManager.GetRelativePath(buffer);
                 side = DiffSide.Right;
-                file = await sessionManager.GetLiveFile(relativePath, peekSession.TextView, buffer);
-                await SessionChanged(sessionManager.CurrentSession);
+                file = await sessionManager.GetLiveFile(relativePath, peekSession.TextView, buffer).ConfigureAwait(true);
+                await SessionChanged(sessionManager.CurrentSession).ConfigureAwait(true);
                 sessionSubscription = sessionManager.WhenAnyValue(x => x.CurrentSession)
                     .Skip(1)
                     .Subscribe(x => SessionChanged(x).Forget());
@@ -171,7 +171,7 @@ namespace GitHub.InlineReviews.ViewModels
 
                 if (lines.Contains(Tuple.Create(lineNumber, side)))
                 {
-                    await UpdateThread();
+                    await UpdateThread().ConfigureAwait(false);
                 }
             }
             catch (Exception e)
@@ -210,11 +210,11 @@ namespace GitHub.InlineReviews.ViewModels
 
             if (thread?.Comments.Count > 0)
             {
-                await threadModel.InitializeAsync(session, file, thread, true);
+                await threadModel.InitializeAsync(session, file, thread, true).ConfigureAwait(true);
             }
             else
             {
-                await threadModel.InitializeNewAsync(session, file, lineNumber, side, true);
+                await threadModel.InitializeNewAsync(session, file, lineNumber, side, true).ConfigureAwait(true);
             }
 
             Thread = threadModel;
@@ -233,7 +233,7 @@ namespace GitHub.InlineReviews.ViewModels
             }
             else
             {
-                await UpdateThread();
+                await UpdateThread().ConfigureAwait(true);
             }
         }
     }

--- a/src/GitHub.StartPage/StartPagePackage.cs
+++ b/src/GitHub.StartPage/StartPagePackage.cs
@@ -40,13 +40,13 @@ namespace GitHub.StartPage
         public async Task<CodeContainer> AcquireCodeContainerAsync(IProgress<ServiceProgressData> downloadProgress, CancellationToken cancellationToken)
         {
 
-            return await RunAcquisition(downloadProgress, cancellationToken, null);
+            return await RunAcquisition(downloadProgress, cancellationToken, null).ConfigureAwait(false);
         }
 
         public async Task<CodeContainer> AcquireCodeContainerAsync(RemoteCodeContainer onlineCodeContainer, IProgress<ServiceProgressData> downloadProgress, CancellationToken cancellationToken)
         {
             var repository = new RepositoryModel(onlineCodeContainer.Name, UriString.ToUriString(onlineCodeContainer.DisplayUrl));
-            return await RunAcquisition(downloadProgress, cancellationToken, repository);
+            return await RunAcquisition(downloadProgress, cancellationToken, repository).ConfigureAwait(false);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "cancellationToken")]
@@ -56,8 +56,8 @@ namespace GitHub.StartPage
 
             try
             {
-                var uiProvider = await Task.Run(() => Package.GetGlobalService(typeof(IGitHubServiceProvider)) as IGitHubServiceProvider);
-                request = await ShowCloneDialog(uiProvider, downloadProgress, repository);
+                var uiProvider = await Task.Run(() => Package.GetGlobalService(typeof(IGitHubServiceProvider)) as IGitHubServiceProvider).ConfigureAwait(true);
+                request = await ShowCloneDialog(uiProvider, downloadProgress, repository).ConfigureAwait(true);
             }
             catch (Exception e)
             {
@@ -93,11 +93,11 @@ namespace GitHub.StartPage
 
             if (repository == null)
             {
-                result = await dialogService.ShowCloneDialog(null);
+                result = await dialogService.ShowCloneDialog(null).ConfigureAwait(true);
             }
             else
             {
-                var basePath = await dialogService.ShowReCloneDialog(repository);
+                var basePath = await dialogService.ShowReCloneDialog(repository).ConfigureAwait(true);
 
                 if (basePath != null)
                 {
@@ -110,7 +110,7 @@ namespace GitHub.StartPage
             {
                 try
                 {
-                    await cloneService.CloneOrOpenRepository(result, progress);
+                    await cloneService.CloneOrOpenRepository(result, progress).ConfigureAwait(true);
                     usageTracker.IncrementCounter(x => x.NumberOfStartPageClones).Forget();
                 }
                 catch

--- a/src/GitHub.TeamFoundation.14/Base/EnsureLoggedInSection.cs
+++ b/src/GitHub.TeamFoundation.14/Base/EnsureLoggedInSection.cs
@@ -45,13 +45,13 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             if (ActiveRepo == null || ActiveRepoUri == null)
                 return;
 
-            var isgithub = await IsAGitHubRepo(ActiveRepoUri);
+            var isgithub = await IsAGitHubRepo(ActiveRepoUri).ConfigureAwait(true);
             if (!isgithub)
                 return;
 
             teServices.ClearNotifications();
             var add = HostAddress.Create(ActiveRepoUri);
-            bool loggedIn = await connectionManager.IsLoggedIn(add);
+            bool loggedIn = await connectionManager.IsLoggedIn(add).ConfigureAwait(true);
             if (!loggedIn)
             {
                 var msg = string.Format(CultureInfo.CurrentUICulture, Resources.NotLoggedInMessage, add.Title, add.Title);

--- a/src/GitHub.TeamFoundation.14/Base/TeamExplorerNavigationItemBase.cs
+++ b/src/GitHub.TeamFoundation.14/Base/TeamExplorerNavigationItemBase.cs
@@ -49,7 +49,7 @@ namespace GitHub.VisualStudio.Base
         async Task InvalidateAsync()
         {
             var uri = ActiveRepoUri;
-            var isVisible = await IsAGitHubRepo(uri);
+            var isVisible = await IsAGitHubRepo(uri).ConfigureAwait(true);
             if (ActiveRepoUri != uri)
             {
                 log.Information("Not setting button visibility because repository changed from {BeforeUrl} to {AfterUrl}", uri, ActiveRepoUri);

--- a/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
+++ b/src/GitHub.TeamFoundation.14/Connect/GitHubConnectSection.cs
@@ -144,7 +144,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
         async Task DoClone()
         {
             var dialogService = ServiceProvider.GetService<IDialogService>();
-            var result = await dialogService.ShowCloneDialog(SectionConnection);
+            var result = await dialogService.ShowCloneDialog(SectionConnection).ConfigureAwait(true);
 
             if (result != null)
             {
@@ -152,7 +152,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                 {
                     ServiceProvider.GitServiceProvider = TEServiceProvider;
                     var cloneService = ServiceProvider.GetService<IRepositoryCloneService>();
-                    await cloneService.CloneOrOpenRepository(result);
+                    await cloneService.CloneOrOpenRepository(result).ConfigureAwait(true);
 
                     usageTracker.IncrementCounter(x => x.NumberOfGitHubConnectSectionClones).Forget();
                 }
@@ -327,8 +327,8 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                     try
                     {
                         // TODO: Cache the icon state.
-                        var api = await apiFactory.Create(newrepo.CloneUrl);
-                        var repo = await api.GetRepository();
+                        var api = await apiFactory.Create(newrepo.CloneUrl).ConfigureAwait(true);
+                        var repo = await api.GetRepository().ConfigureAwait(true);
                         newrepo.SetIcon(repo.Private, repo.Fork);
                     }
                     catch (Exception ex)
@@ -352,8 +352,8 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
                         try
                         {
                             // TODO: Cache the icon state.
-                            var api = await apiFactory.Create(r.CloneUrl);
-                            var repo = await api.GetRepository();
+                            var api = await apiFactory.Create(r.CloneUrl).ConfigureAwait(true);
+                            var repo = await api.GetRepository().ConfigureAwait(true);
                             r.SetIcon(repo.Private, repo.Fork);
                         }
                         catch (Exception ex)
@@ -430,7 +430,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Connect
         {
             // TODO: This is wasteful as we can be calling it multiple times for a single changed
             // signal, once from each section. Needs refactoring.
-            await localRepositories.Refresh();
+            await localRepositories.Refresh().ConfigureAwait(true);
             RaisePropertyChanged("Repositories"); // trigger a re-check of the visibility of the listview based on item count
         }
 

--- a/src/GitHub.TeamFoundation.14/Home/ForkNavigationItem.cs
+++ b/src/GitHub.TeamFoundation.14/Home/ForkNavigationItem.cs
@@ -71,12 +71,12 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
 
         public override async void Execute()
         {
-            var connection = await connectionManager.GetConnection(ActiveRepo);
+            var connection = await connectionManager.GetConnection(ActiveRepo).ConfigureAwait(true);
 
             if (connection?.IsLoggedIn == true)
             {
                 usageTracker.IncrementCounter(model => model.NumberOfShowRepoForkDialogClicks).Forget();
-                await dialogService.ShowForkDialog(ActiveRepo, connection);
+                await dialogService.ShowForkDialog(ActiveRepo, connection).ConfigureAwait(true);
             }
         }
 
@@ -86,9 +86,9 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
             {
                 IsVisible = false;
 
-                if (await IsAGitHubDotComRepo(ActiveRepoUri))
+                if (await IsAGitHubDotComRepo(ActiveRepoUri).ConfigureAwait(true))
                 {
-                    var connection = await ConnectionManager.GetConnection(ActiveRepo);
+                    var connection = await ConnectionManager.GetConnection(ActiveRepo).ConfigureAwait(true);
                     IsVisible = connection?.IsLoggedIn ?? false;
                 }
             }

--- a/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
+++ b/src/GitHub.TeamFoundation.14/Home/GitHubHomeSection.cs
@@ -64,7 +64,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
 
             base.RepoChanged();
 
-            IsVisible = await IsAGitHubRepo(ActiveRepoUri);
+            IsVisible = await IsAGitHubRepo(ActiveRepoUri).ConfigureAwait(true);
 
             if (IsVisible)
             {
@@ -81,9 +81,9 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
 
                 Debug.Assert(SimpleApiClient != null,
                     "If we're in this block, simpleApiClient cannot be null. It was created by UpdateStatus");
-                var repo = await SimpleApiClient.GetRepository();
+                var repo = await SimpleApiClient.GetRepository().ConfigureAwait(true);
                 Icon = GetIcon(repo.Private, true, repo.Fork);
-                IsLoggedIn = await IsUserAuthenticated();
+                IsLoggedIn = await IsUserAuthenticated().ConfigureAwait(true);
             }
             else
             {
@@ -93,10 +93,10 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
 
         public override async void Refresh()
         {
-            IsVisible = await IsAGitHubRepo(ActiveRepoUri);
+            IsVisible = await IsAGitHubRepo(ActiveRepoUri).ConfigureAwait(true);
             if (IsVisible)
             {
-                IsLoggedIn = await IsUserAuthenticated();
+                IsLoggedIn = await IsUserAuthenticated().ConfigureAwait(true);
             }
 
             base.Refresh();

--- a/src/GitHub.TeamFoundation.14/Home/IssuesNavigationItem.cs
+++ b/src/GitHub.TeamFoundation.14/Home/IssuesNavigationItem.cs
@@ -40,10 +40,10 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
         {
             IsVisible = false;
 
-            var visible = await IsAGitHubRepo(ActiveRepoUri);
+            var visible = await IsAGitHubRepo(ActiveRepoUri).ConfigureAwait(true);
             if (visible)
             {
-                var repo = await SimpleApiClient.GetRepository();
+                var repo = await SimpleApiClient.GetRepository().ConfigureAwait(true);
                 visible = repo.HasIssues;
             }
             IsVisible = visible;

--- a/src/GitHub.TeamFoundation.14/Home/WikiNavigationItem.cs
+++ b/src/GitHub.TeamFoundation.14/Home/WikiNavigationItem.cs
@@ -38,10 +38,10 @@ namespace GitHub.VisualStudio.TeamExplorer.Home
 
         public override async void Invalidate()
         {
-            var visible = await IsAGitHubRepo(ActiveRepoUri);
+            var visible = await IsAGitHubRepo(ActiveRepoUri).ConfigureAwait(true);
             if (visible)
             {
-                var repo = await SimpleApiClient.GetRepository();
+                var repo = await SimpleApiClient.GetRepository().ConfigureAwait(true);
                 visible = repo.HasWiki && SimpleApiClient.HasWiki();
             }
             IsVisible = visible;

--- a/src/GitHub.TeamFoundation.14/Services/TeamExplorerServices.cs
+++ b/src/GitHub.TeamFoundation.14/Services/TeamExplorerServices.cs
@@ -69,9 +69,9 @@ namespace GitHub.Services
         public async Task ShowRepositorySettingsRemotesAsync()
         {
             var te = serviceProvider.TryGetService<ITeamExplorer>();
-            var page = await NavigateToPageAsync(te, repositorySettingsPageId);
+            var page = await NavigateToPageAsync(te, repositorySettingsPageId).ConfigureAwait(true);
             var remotes = page?.GetSection(remotesSectionId);
-            await BringIntoViewAsync(remotes);
+            await BringIntoViewAsync(remotes).ConfigureAwait(true);
         }
 
         public void ShowMessage(string message)

--- a/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitExt.cs
@@ -82,7 +82,7 @@ namespace GitHub.VisualStudio.Base
 
         async Task InitializeAsync()
         {
-            gitExt = await GetServiceAsync<IGitExt>();
+            gitExt = await GetServiceAsync<IGitExt>().ConfigureAwait(false);
             if (gitService == null)
             {
                 log.Error("Couldn't find IGitExt service");
@@ -90,7 +90,7 @@ namespace GitHub.VisualStudio.Base
             }
 
             // Refresh on background thread
-            await Task.Run(() => RefreshActiveRepositories());
+            await Task.Run(() => RefreshActiveRepositories()).ConfigureAwait(false);
 
             gitExt.PropertyChanged += (s, e) =>
             {
@@ -144,7 +144,7 @@ namespace GitHub.VisualStudio.Base
         {
             JoinableTaskFactory.Context.Factory.Run(async () =>
             {
-                await JoinableTaskCollection.JoinTillEmptyAsync();
+                await JoinableTaskCollection.JoinTillEmptyAsync().ConfigureAwait(false);
             });
         }
 

--- a/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
@@ -80,9 +80,9 @@ namespace GitHub.Services
             Assumes.Present(teamExplorer);
 
 #if TEAMEXPLORER14
-            await StartClonenOnConnectPageAsync(teamExplorer, cloneUrl, clonePath, recurseSubmodules);
+            await StartClonenOnConnectPageAsync(teamExplorer, cloneUrl, clonePath, recurseSubmodules).ConfigureAwait(true);
             NavigateToHomePage(teamExplorer); // Show progress on Team Explorer - Home
-            await WaitForCloneOnHomePageAsync(teamExplorer);
+            await WaitForCloneOnHomePageAsync(teamExplorer).ConfigureAwait(true);
 #elif TEAMEXPLORER15 || TEAMEXPLORER16
             // The ServiceProgressData type is in a Visual Studio 2019 assembly that we don't currently have access to.
             // Using reflection to call the CloneAsync in order to avoid conflicts with the Visual Studio 2017 version.
@@ -94,7 +94,7 @@ namespace GitHub.Services
             var cloneTask = (Task)cloneAsyncMethod.Invoke(gitExt, cloneParameters);
 
             NavigateToHomePage(teamExplorer); // Show progress on Team Explorer - Home
-            await cloneTask;
+            await cloneTask.ConfigureAwait(true);
 #endif
             // Change Team Explorer context to the newly cloned repository
             teamExplorerServices.Value.OpenRepository(clonePath);
@@ -103,7 +103,7 @@ namespace GitHub.Services
         static async Task StartClonenOnConnectPageAsync(
             ITeamExplorer teamExplorer, string cloneUrl, string clonePath, bool recurseSubmodules)
         {
-            var connectPage = await NavigateToPageAsync(teamExplorer, new Guid(TeamExplorerPageIds.Connect));
+            var connectPage = await NavigateToPageAsync(teamExplorer, new Guid(TeamExplorerPageIds.Connect)).ConfigureAwait(true);
             Assumes.Present(connectPage);
             var gitExt = connectPage.GetService<IGitRepositoriesExt>();
             Assumes.Present(gitExt);

--- a/src/GitHub.TeamFoundation.14/Sync/GitHubPublishSection.cs
+++ b/src/GitHub.TeamFoundation.14/Sync/GitHubPublishSection.cs
@@ -69,7 +69,7 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
             {
                 IsVisible = true;
                 ShowGetStarted = true;
-                loggedIn = await connectionManager.IsLoggedIn();
+                loggedIn = await connectionManager.IsLoggedIn().ConfigureAwait(true);
                 ShowLogin = !loggedIn;
                 ShowSignup = !loggedIn;
             }
@@ -92,11 +92,11 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
 
         public async Task Connect()
         {
-            loggedIn = await connectionManager.IsLoggedIn();
+            loggedIn = await connectionManager.IsLoggedIn().ConfigureAwait(true);
             if (loggedIn)
                 ShowPublish();
             else
-                await Login();
+                await Login().ConfigureAwait(true);
         }
 
         public void SignUp()
@@ -175,8 +175,8 @@ namespace GitHub.VisualStudio.TeamExplorer.Sync
 
         async Task Login()
         {
-            await dialogService.ShowLoginDialog();
-            loggedIn = await connectionManager.IsLoggedIn();
+            await dialogService.ShowLoginDialog().ConfigureAwait(true);
+            loggedIn = await connectionManager.IsLoggedIn().ConfigureAwait(true);
             if (loggedIn)
                 ShowPublish();
         }

--- a/src/GitHub.VisualStudio.UI/Base/TeamExplorerItemBase.cs
+++ b/src/GitHub.VisualStudio.UI/Base/TeamExplorerItemBase.cs
@@ -129,7 +129,7 @@ namespace GitHub.VisualStudio.Base
                 return RepositoryOrigin.Other;
 
             Debug.Assert(apiFactory != null, "apiFactory cannot be null. Did you call the right constructor?");
-            SimpleApiClient = await apiFactory.Create(uri);
+            SimpleApiClient = await apiFactory.Create(uri).ConfigureAwait(false);
 
             var isdotcom = HostAddress.IsGitHubDotComUri(uri.ToRepositoryUrl());
 
@@ -139,9 +139,10 @@ namespace GitHub.VisualStudio.Base
             }
             else
             {
-                var repo = await SimpleApiClient.GetRepository();
+                var repo = await SimpleApiClient.GetRepository().ConfigureAwait(false);
 
-                if ((repo.FullName == ActiveRepoName || repo.Id == 0) && await SimpleApiClient.IsEnterprise())
+                if ((repo.FullName == ActiveRepoName || repo.Id == 0) &&
+                    await SimpleApiClient.IsEnterprise().ConfigureAwait(false))
                 {
                     return RepositoryOrigin.Enterprise;
                 }
@@ -152,13 +153,13 @@ namespace GitHub.VisualStudio.Base
 
         protected async Task<bool> IsAGitHubRepo(UriString uri)
         {
-            var origin = await GetRepositoryOrigin(uri);
+            var origin = await GetRepositoryOrigin(uri).ConfigureAwait(false);
             return origin == RepositoryOrigin.DotCom || origin == RepositoryOrigin.Enterprise;
         }
 
         protected async Task<bool> IsAGitHubDotComRepo(UriString uri)
         {
-            var origin = await GetRepositoryOrigin(uri);
+            var origin = await GetRepositoryOrigin(uri).ConfigureAwait(false);
             return origin == RepositoryOrigin.DotCom;
         }
 
@@ -173,7 +174,7 @@ namespace GitHub.VisualStudio.Base
                 if (uri == null)
                     return false;
 
-                SimpleApiClient = await apiFactory.Create(uri);
+                SimpleApiClient = await apiFactory.Create(uri).ConfigureAwait(false);
             }
 
             return SimpleApiClient?.IsAuthenticated() ?? false;

--- a/src/GitHub.VisualStudio/Commands/BlameLinkCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/BlameLinkCommand.cs
@@ -35,17 +35,17 @@ namespace GitHub.VisualStudio.Commands
         /// </summary>
         public async override Task Execute()
         {
-            var isgithub = await IsGitHubRepo();
+            var isgithub = await IsGitHubRepo().ConfigureAwait(false);
             if (!isgithub)
                 return;
 
-            var link = await GenerateLink(LinkType.Blame);
+            var link = await GenerateLink(LinkType.Blame).ConfigureAwait(false);
             if (link == null)
                 return;
             var browser = ServiceProvider.TryGetService<IVisualStudioBrowser>();
             browser?.OpenUrl(link.ToUri());
 
-            await UsageTracker.IncrementCounter(x => x.NumberOfOpenInGitHub);
+            await UsageTracker.IncrementCounter(x => x.NumberOfOpenInGitHub).ConfigureAwait(false);
         }
     }
 }

--- a/src/GitHub.VisualStudio/Commands/CopyLinkCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/CopyLinkCommand.cs
@@ -37,11 +37,11 @@ namespace GitHub.VisualStudio.Commands
         /// </summary>
         public async override Task Execute()
         {
-            var isgithub = await IsGitHubRepo();
+            var isgithub = await IsGitHubRepo().ConfigureAwait(false);
             if (!isgithub)
                 return;
 
-            var link = await GenerateLink(LinkType.Blob);
+            var link = await GenerateLink(LinkType.Blob).ConfigureAwait(false);
             if (link == null)
                 return;
             try
@@ -49,7 +49,7 @@ namespace GitHub.VisualStudio.Commands
                 Clipboard.SetText(link);
                 var ns = ServiceProvider.TryGetService<IStatusBarNotificationService>();
                 ns?.ShowMessage(Resources.LinkCopiedToClipboardMessage);
-                await UsageTracker.IncrementCounter(x => x.NumberOfLinkToGitHub);
+                await UsageTracker.IncrementCounter(x => x.NumberOfLinkToGitHub).ConfigureAwait(false);
             }
             catch
             {

--- a/src/GitHub.VisualStudio/Commands/CreateGistCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/CreateGistCommand.cs
@@ -98,8 +98,8 @@ namespace GitHub.VisualStudio.Commands
         /// </summary>
         public override async Task Execute()
         {
-            var connection = await FindConnectionAsync();
-            await dialogService.Value.ShowCreateGist(connection);
+            var connection = await FindConnectionAsync().ConfigureAwait(true);
+            await dialogService.Value.ShowCreateGist(connection).ConfigureAwait(true);
         }
 
         protected override void QueryStatus()
@@ -117,7 +117,7 @@ namespace GitHub.VisualStudio.Commands
 
         async Task<IConnection> FindConnectionAsync()
         {
-            var connections = await connectionManager.Value.GetLoadedConnections();
+            var connections = await connectionManager.Value.GetLoadedConnections().ConfigureAwait(false);
             return connections.FirstOrDefault(x => x.IsLoggedIn && x.HostAddress.IsGitHubDotCom() == isGitHubDotCom);
         }
 

--- a/src/GitHub.VisualStudio/Commands/GoToSolutionOrPullRequestFileCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/GoToSolutionOrPullRequestFileCommand.cs
@@ -89,7 +89,7 @@ namespace GitHub.Commands
                 if (isEditableDiff)
                 {
                     // Navigating from editable diff to code view
-                    await usageTracker.Value.IncrementCounter(x => x.NumberOfNavigateToCodeView);
+                    await usageTracker.Value.IncrementCounter(x => x.NumberOfNavigateToCodeView).ConfigureAwait(true);
 
                     // Open active document in Code View
                     pullRequestEditorService.Value.OpenActiveDocumentInCodeView(sourceView);
@@ -106,9 +106,10 @@ namespace GitHub.Commands
                     }
 
                     // Navigate from PR file to solution
-                    await usageTracker.Value.IncrementCounter(x => x.NumberOfPRDetailsNavigateToEditor);
+                    await usageTracker.Value.IncrementCounter(x => x.NumberOfPRDetailsNavigateToEditor).ConfigureAwait(true);
 
-                    var fileTextView = await pullRequestEditorService.Value.OpenFile(info.Session, info.RelativePath, true);
+                    var fileTextView = await pullRequestEditorService.Value.OpenFile(info.Session, info.RelativePath, true)
+                        .ConfigureAwait(true);
                     if (fileTextView == null)
                     {
                         ShowErrorInStatusBar("Couldn't find active target view");
@@ -140,9 +141,11 @@ namespace GitHub.Commands
                 }
 
                 // Navigate from solution file to PR diff file
-                await usageTracker.Value.IncrementCounter(x => x.NumberOfNavigateToPullRequestFileDiff);
+                await usageTracker.Value.IncrementCounter(x => x.NumberOfNavigateToPullRequestFileDiff)
+                    .ConfigureAwait(true);
 
-                var diffViewer = await pullRequestEditorService.Value.OpenDiff(session, relativePath, "HEAD", scrollToFirstDiff: false);
+                var diffViewer = await pullRequestEditorService.Value.OpenDiff(session, relativePath, "HEAD", scrollToFirstDiff: false)
+                    .ConfigureAwait(true);
                 if (diffViewer == null)
                 {
                     ShowErrorInStatusBar("Couldn't find active diff viewer");

--- a/src/GitHub.VisualStudio/Commands/LinkCommandBase.cs
+++ b/src/GitHub.VisualStudio/Commands/LinkCommandBase.cs
@@ -107,21 +107,21 @@ namespace GitHub.VisualStudio.Commands
             if (uri == null)
                 return false;
 
-            var simpleApiClient = await ApiFactory.Create(uri);
+            var simpleApiClient = await ApiFactory.Create(uri).ConfigureAwait(false);
 
             var isdotcom = HostAddress.IsGitHubDotComUri(uri.ToRepositoryUrl());
             if (!isdotcom)
             {
-                var repo = await simpleApiClient.GetRepository();
+                var repo = await simpleApiClient.GetRepository().ConfigureAwait(false);
                 var activeRepoFullName = ActiveRepo.Owner + '/' + ActiveRepo.Name;
-                return (repo.FullName == activeRepoFullName || repo.Id == 0) && await simpleApiClient.IsEnterprise();
+                return (repo.FullName == activeRepoFullName || repo.Id == 0) && await simpleApiClient.IsEnterprise().ConfigureAwait(false);
             }
             return isdotcom;
         }
 
         protected async Task<bool> IsCurrentFileInGitHubRepository()
         {
-            if (!await IsGitHubRepo())
+            if (!await IsGitHubRepo().ConfigureAwait(false))
                 return false;
 
             var activeDocument = ServiceProvider.TryGetService<IActiveDocumentSnapshot>();
@@ -180,7 +180,7 @@ namespace GitHub.VisualStudio.Commands
             if (repo.CloneUrl == null)
                 return null;
 
-            var sha = await gitService.GetLatestPushedSha(path ?? repo.LocalPath);
+            var sha = await gitService.GetLatestPushedSha(path ?? repo.LocalPath).ConfigureAwait(false);
             // this also incidentally checks whether the repo has a valid LocalPath
             if (String.IsNullOrEmpty(sha))
                 return repo.CloneUrl.ToRepositoryUrl().AbsoluteUri;

--- a/src/GitHub.VisualStudio/Commands/OpenFromClipboardCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/OpenFromClipboardCommand.cs
@@ -101,7 +101,7 @@ namespace GitHub.VisualStudio.Commands
                 var branchName = currentBranch.Name;
 
                 // AnnotateFile expects a branch name so we use the current branch
-                if (await gitHubContextService.Value.TryAnnotateFile(repositoryDir, branchName, context))
+                if (await gitHubContextService.Value.TryAnnotateFile(repositoryDir, branchName, context).ConfigureAwait(true))
                 {
                     return;
                 }

--- a/src/GitHub.VisualStudio/Commands/OpenFromUrlCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/OpenFromUrlCommand.cs
@@ -38,10 +38,10 @@ namespace GitHub.VisualStudio.Commands
 
         public override async Task Execute(string url)
         {
-            var cloneDialogResult = await dialogService.Value.ShowCloneDialog(null, url);
+            var cloneDialogResult = await dialogService.Value.ShowCloneDialog(null, url).ConfigureAwait(true);
             if (cloneDialogResult != null)
             {
-                await repositoryCloneService.Value.CloneOrOpenRepository(cloneDialogResult);
+                await repositoryCloneService.Value.CloneOrOpenRepository(cloneDialogResult).ConfigureAwait(true);
             }
         }
     }

--- a/src/GitHub.VisualStudio/Commands/OpenLinkCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/OpenLinkCommand.cs
@@ -34,17 +34,17 @@ namespace GitHub.VisualStudio.Commands
         /// </summary>
         public async override Task Execute()
         {
-            var isgithub = await IsGitHubRepo();
+            var isgithub = await IsGitHubRepo().ConfigureAwait(false);
             if (!isgithub)
                 return;
 
-            var link = await GenerateLink(LinkType.Blob);
+            var link = await GenerateLink(LinkType.Blob).ConfigureAwait(false);
             if (link == null)
                 return;
             var browser = ServiceProvider.TryGetService<IVisualStudioBrowser>();
             browser?.OpenUrl(link.ToUri());
 
-            await UsageTracker.IncrementCounter(x => x.NumberOfOpenInGitHub);
+            await UsageTracker.IncrementCounter(x => x.NumberOfOpenInGitHub).ConfigureAwait(false);
         }
     }
 }

--- a/src/GitHub.VisualStudio/Commands/OpenPullRequestsCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/OpenPullRequestsCommand.cs
@@ -43,8 +43,8 @@ namespace GitHub.VisualStudio.Commands
         {
             try
             {
-                var host = await serviceProvider.TryGetService<IGitHubToolWindowManager>().ShowGitHubPane();
-                await host.ShowPullRequests();
+                var host = await serviceProvider.TryGetService<IGitHubToolWindowManager>().ShowGitHubPane().ConfigureAwait(true);
+                await host.ShowPullRequests().ConfigureAwait(true);
             }
             catch (Exception ex)
             {

--- a/src/GitHub.VisualStudio/Commands/ShowCurrentPullRequestCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/ShowCurrentPullRequestCommand.cs
@@ -47,7 +47,7 @@ namespace GitHub.VisualStudio.Commands
             try
             {
                 var pullRequestSessionManager = serviceProvider.ExportProvider.GetExportedValueOrDefault<IPullRequestSessionManager>();
-                await pullRequestSessionManager.EnsureInitialized();
+                await pullRequestSessionManager.EnsureInitialized().ConfigureAwait(true);
 
                 var session = pullRequestSessionManager?.CurrentSession;
                 if (session == null)
@@ -57,8 +57,8 @@ namespace GitHub.VisualStudio.Commands
 
                 var pullRequest = session.PullRequest;
                 var manager = serviceProvider.TryGetService<IGitHubToolWindowManager>();
-                var host = await manager.ShowGitHubPane();
-                await host.ShowPullRequest(session.RepositoryOwner, host.LocalRepository.Name, pullRequest.Number);
+                var host = await manager.ShowGitHubPane().ConfigureAwait(true);
+                await host.ShowPullRequest(session.RepositoryOwner, host.LocalRepository.Name, pullRequest.Number).ConfigureAwait(true);
             }
             catch (Exception ex)
             {

--- a/src/GitHub.VisualStudio/Commands/ShowGitHubPaneCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/ShowGitHubPaneCommand.cs
@@ -43,7 +43,7 @@ namespace GitHub.VisualStudio.Commands
         {
             try
             {
-                var host = await serviceProvider.TryGetService<IGitHubToolWindowManager>().ShowGitHubPane();
+                var host = await serviceProvider.TryGetService<IGitHubToolWindowManager>().ShowGitHubPane().ConfigureAwait(true);
             }
             catch (Exception ex)
             {

--- a/src/GitHub.VisualStudio/Commands/SyncSubmodulesCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/SyncSubmodulesCommand.cs
@@ -53,7 +53,7 @@ namespace GitHub.VisualStudio.Commands
         {
             try
             {
-                var complete = await SyncSubmodules();
+                var complete = await SyncSubmodules().ConfigureAwait(true);
             }
             catch (Exception ex)
             {
@@ -85,7 +85,7 @@ namespace GitHub.VisualStudio.Commands
             {
                 writer.WriteLine(line);
                 statusBarNotificationService.ShowMessage(line);
-            });
+            }).ConfigureAwait(true);
 
             if (!complete)
             {

--- a/src/GitHub.VisualStudio/GitContextPackage.cs
+++ b/src/GitHub.VisualStudio/GitContextPackage.cs
@@ -27,7 +27,7 @@ namespace GitHub.VisualStudio
                 return;
             }
 
-            var gitExt = (IVSGitExt)await GetServiceAsync(typeof(IVSGitExt));
+            var gitExt = (IVSGitExt)await GetServiceAsync(typeof(IVSGitExt)).ConfigureAwait(true);
             var context = UIContext.FromUIContextGuid(new Guid(Guids.UIContext_Git));
             RefreshContext(context, gitExt);
             gitExt.ActiveRepositoriesChanged += () =>

--- a/src/GitHub.VisualStudio/Services/GitHubServiceProvider.cs
+++ b/src/GitHub.VisualStudio/Services/GitHubServiceProvider.cs
@@ -77,7 +77,8 @@ namespace GitHub.VisualStudio
 
         public async Task Initialize()
         {
-            IComponentModel componentModel = await asyncServiceProvider.GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
+            IComponentModel componentModel = await asyncServiceProvider.GetServiceAsync(typeof(SComponentModel))
+                .ConfigureAwait(false) as IComponentModel;
 
             Log.Assert(componentModel != null, "Service of type SComponentModel not found");
             if (componentModel == null)

--- a/src/GitHub.VisualStudio/Services/ShowDialogService.cs
+++ b/src/GitHub.VisualStudio/Services/ShowDialogService.cs
@@ -52,11 +52,11 @@ namespace GitHub.VisualStudio.UI.Services
             {
                 if (!connection.Scopes.Matches(scopes))
                 {
-                    await dialogViewModel.StartWithLogout(viewModel, connection);
+                    await dialogViewModel.StartWithLogout(viewModel, connection).ConfigureAwait(true);
                 }
                 else
                 {
-                    await viewModel.InitializeAsync(connection);
+                    await viewModel.InitializeAsync(connection).ConfigureAwait(true);
                     dialogViewModel.Start(viewModel);
                 }
 
@@ -78,7 +78,7 @@ namespace GitHub.VisualStudio.UI.Services
                 var task = dialogViewModel.StartWithConnection(viewModel);
                 var window = new GitHubDialogWindow(dialogViewModel);
                 window.ShowModal();
-                await task;
+                await task.ConfigureAwait(true);
             }
 
             return result;

--- a/src/GitHub.VisualStudio/Services/UsageService.cs
+++ b/src/GitHub.VisualStudio/Services/UsageService.cs
@@ -44,7 +44,7 @@ namespace GitHub.Services
 
         public async Task<Guid> GetUserGuid()
         {
-            await Initialize();
+            await Initialize().ConfigureAwait(false);
 
             if (!userGuid.HasValue)
             {
@@ -52,7 +52,7 @@ namespace GitHub.Services
                 {
                     if (File.Exists(userStorePath))
                     {
-                        var json = await ReadAllTextAsync(userStorePath);
+                        var json = await ReadAllTextAsync(userStorePath).ConfigureAwait(false);
                         var data = SimpleJson.DeserializeObject<UserData>(json);
                         userGuid = data.UserGuid;
                     }
@@ -71,7 +71,7 @@ namespace GitHub.Services
                 {
                     var data = new UserData { UserGuid = userGuid.Value };
                     var json = SimpleJson.SerializeObject(data);
-                    await WriteAllTextAsync(userStorePath, json);
+                    await WriteAllTextAsync(userStorePath, json).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -87,7 +87,7 @@ namespace GitHub.Services
             return new Timer(
                 async _ =>
                 {
-                    try { await callback(); }
+                    try { await callback().ConfigureAwait(false); }
                     catch (Exception ex) { log.Warning(ex, "Failed submitting usage data"); }
                 },
                 null,
@@ -97,9 +97,11 @@ namespace GitHub.Services
 
         public async Task<UsageData> ReadLocalData()
         {
-            await Initialize();
+            await Initialize().ConfigureAwait(false);
 
-            var json = File.Exists(storePath) ? await ReadAllTextAsync(storePath) : null;
+            var json = File.Exists(storePath) ?
+                await ReadAllTextAsync(storePath).ConfigureAwait(false) :
+                null;
 
             try
             {
@@ -121,7 +123,7 @@ namespace GitHub.Services
                 Directory.CreateDirectory(Path.GetDirectoryName(storePath));
                 var json = SimpleJson.SerializeObject(data);
 
-                await WriteAllTextAsync(storePath, json);
+                await WriteAllTextAsync(storePath, json).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -147,13 +149,13 @@ namespace GitHub.Services
         async Task<string> ReadAllTextAsync(string path)
         {
             // Avoid IOException when metrics updated multiple times in quick succession
-            await semaphoreSlim.WaitAsync();
+            await semaphoreSlim.WaitAsync().ConfigureAwait(false);
             try
             {
                 using (var s = File.OpenRead(path))
                 using (var r = new StreamReader(s, Encoding.UTF8))
                 {
-                    return await r.ReadToEndAsync();
+                    return await r.ReadToEndAsync().ConfigureAwait(false);
                 }
             }
             finally
@@ -165,13 +167,13 @@ namespace GitHub.Services
         async Task WriteAllTextAsync(string path, string text)
         {
             // Avoid IOException when metrics updated multiple times in quick succession
-            await semaphoreSlim.WaitAsync();
+            await semaphoreSlim.WaitAsync().ConfigureAwait(false);
             try
             {
                 using (var s = new FileStream(path, FileMode.Create))
                 using (var w = new StreamWriter(s, Encoding.UTF8))
                 {
-                    await w.WriteAsync(text);
+                    await w.WriteAsync(text).ConfigureAwait(false);
                 }
             }
             finally

--- a/src/GitHub.VisualStudio/Services/UsageTracker.cs
+++ b/src/GitHub.VisualStudio/Services/UsageTracker.cs
@@ -46,15 +46,15 @@ namespace GitHub.Services
 
         public async Task IncrementCounter(Expression<Func<UsageModel.MeasuresModel, int>> counter)
         {
-            await Initialize();
-            var data = await service.ReadLocalData();
-            var usage = await GetCurrentReport(data);
+            await Initialize().ConfigureAwait(false);
+            var data = await service.ReadLocalData().ConfigureAwait(false);
+            var usage = await GetCurrentReport(data).ConfigureAwait(false);
             var property = (MemberExpression)counter.Body;
             var propertyInfo = (PropertyInfo)property.Member;
             log.Verbose("Increment counter {Name}", propertyInfo.Name);
             var value = (int)propertyInfo.GetValue(usage.Measures);
             propertyInfo.SetValue(usage.Measures, value + 1);
-            await service.WriteLocalData(data);
+            await service.WriteLocalData(data).ConfigureAwait(false);
         }
 
         IDisposable StartTimer()
@@ -79,11 +79,11 @@ namespace GitHub.Services
 
         async Task TimerTick()
         {
-            await Initialize();
+            await Initialize().ConfigureAwait(false);
 
             if (firstTick)
             {
-                await IncrementCounter(x => x.NumberOfStartups);
+                await IncrementCounter(x => x.NumberOfStartups).ConfigureAwait(false);
                 firstTick = false;
             }
 
@@ -94,7 +94,7 @@ namespace GitHub.Services
                 return;
             }
 
-            var data = await service.ReadLocalData();
+            var data = await service.ReadLocalData().ConfigureAwait(false);
 
             var changed = false;
             for (var i = data.Reports.Count - 1; i >= 0; --i)
@@ -103,7 +103,7 @@ namespace GitHub.Services
                 {
                     try
                     {
-                        await client.PostUsage(data.Reports[i]);
+                        await client.PostUsage(data.Reports[i]).ConfigureAwait(false);
                         data.Reports.RemoveAt(i);
                         changed = true;
                     }
@@ -116,7 +116,7 @@ namespace GitHub.Services
 
             if (changed)
             {
-                await service.WriteLocalData(data);
+                await service.WriteLocalData(data).ConfigureAwait(false);
             }
         }
 
@@ -126,7 +126,7 @@ namespace GitHub.Services
 
             if (current == null)
             {
-                var guid = await service.GetUserGuid();
+                var guid = await service.GetUserGuid().ConfigureAwait(false);
                 current = UsageModel.Create(guid);
                 data.Reports.Add(current);
             }

--- a/src/GitHub.VisualStudio/UI/GitHubPane.cs
+++ b/src/GitHub.VisualStudio/UI/GitHubPane.cs
@@ -93,14 +93,15 @@ namespace GitHub.VisualStudio.UI
                 ShowInitializing();
 
                 // Allow MEF to initialize its cache asynchronously
-                var provider = (IGitHubServiceProvider)await asyncPackage.GetServiceAsync(typeof(IGitHubServiceProvider));
+                var provider = (IGitHubServiceProvider)await asyncPackage.GetServiceAsync(typeof(IGitHubServiceProvider))
+                    .ConfigureAwait(true);
 
                 var teServiceHolder = provider.GetService<ITeamExplorerServiceHolder>();
                 teServiceHolder.ServiceProvider = this;
 
                 var factory = provider.GetService<IViewViewModelFactory>();
                 var viewModel = provider.ExportProvider.GetExportedValue<IGitHubPaneViewModel>();
-                await viewModel.InitializeAsync(this);
+                await viewModel.InitializeAsync(this).ConfigureAwait(true);
 
                 View = factory.CreateView<IGitHubPaneViewModel>();
                 View.DataContext = viewModel;


### PR DESCRIPTION
Fixes all instances of the `CA2007: Do not directly await a Task without calling ConfigureAwait` warning in the codebase.

I've tried to use the correct parameter to `ConfigureAwait(()`, in that I pass `true` when the instructions following the await in the method require code to be run on the UI thread. If I've got this wrong anywhere, this could cause a crash so the features affected need testing.