### PR TITLE
Set RxApp.DefaultExceptionHandler.

### DIFF
--- a/src/GitHub.Exports.Reactive/ViewModels/ViewModelBase.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/ViewModelBase.cs
@@ -1,6 +1,8 @@
 ﻿using System;
-using GitHub.UI;
+using System.Reactive;
+using GitHub.Logging;
 using ReactiveUI;
+using Serilog;
 
 namespace GitHub.ViewModels
 {
@@ -13,5 +15,15 @@ namespace GitHub.ViewModels
     /// </remarks>
     public abstract class ViewModelBase : ReactiveObject, IViewModel
     {
+        static readonly ILogger logger = LogManager.ForContext<ViewModelBase>();
+
+        static ViewModelBase()
+        {
+            // We don't really have a better place to hook this up as we don't want to force-load
+            // rx on package load.
+            RxApp.DefaultExceptionHandler = Observer.Create<Exception>(
+                ex => logger.Error(ex, "Unhandled rxui error"),
+                ex => logger.Error(ex, "Unhandled rxui error"));
+        }
     }
 }


### PR DESCRIPTION
Previously, exceptions thrown in `ReactiveCommand` execute methods would crash the application. Add a handler to `RxApp.DefaultExceptionHandler` to handle these exceptions and log them rather than crashing VS.

We hook this up in the `ViewModelBase` static constructor don't want to force-load rx on package load.