### PR TITLE
Deprecate using Visual Studio to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To be able to use the GitHub API, you'll need to:
 - [Register a new developer application](https://github.com/settings/developers) in your profile.
 - Open [src/GitHub.Api/ApiClientConfiguration_User.cs](src/GitHub.Api/ApiClientConfiguration_User.cs) and fill out the clientId/clientSecret fields for your application. **Note this has recently changed location, so you may need to re-do this**
 
-Build using Visual Studio 2017 or:
+Build using `cmd.exe`:
 
 ```txt
 build.cmd


### PR DESCRIPTION
I've been running into issues trying to build the extension using Visual Studio IDE and better luck using `cmd.exe` instead. Since building with Visual Studio hasn't been consistently successful, I propose we encourage folks to build from command prompt.

It is still possible to install the Debug build to the experimental instance with Visual Studio by going to `Debug > Start Debugging / Start without Debugging` in the menu bar.

/cc @meaghanlewis since you helped me troubleshoot my issue earlier