### PR TITLE
Prefer a DockPanel over a Grid for forking a repo

### DIFF
--- a/src/GitHub.VisualStudio.UI/Views/Dialog/ForkRepositorySelectView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/ForkRepositorySelectView.xaml
@@ -23,26 +23,18 @@
     <sampleData:ForkRepositorySelectViewModelDesigner IsLoading="True"/>
   </d:DesignProperties.DataContext>
 
-  <Grid Margin="0 8">
-    <Grid.RowDefinitions>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="*"/>
-      <RowDefinition Height="Auto"/>
-    </Grid.RowDefinitions>
-
-    <TextBlock Grid.Row="0" FontSize="16" Margin="8">
+  <DockPanel Margin="0 8">
+    <TextBlock FontSize="16" Margin="8" DockPanel.Dock="Top">
       Where should we fork this repository?
     </TextBlock>
 
-    <ui:GitHubProgressBar Grid.Row="1"
+    <ui:GitHubProgressBar DockPanel.Dock="Top"
                           Foreground="{DynamicResource GitHubAccentBrush}"
                           IsIndeterminate="True"
                           Style="{DynamicResource GitHubProgressBar}"
                           Visibility="{Binding IsLoading, Converter={ui:BooleanToHiddenVisibilityConverter}}"/>
 
     <ListBox Name="accountsListBox"
-             Grid.Row="2"
              BorderThickness="0"
              ItemsSource="{Binding Accounts}"
              VerticalContentAlignment="Top"
@@ -76,8 +68,8 @@
       </ListBox.ItemTemplate>
     </ListBox>
 
-    <DockPanel Grid.Row="3" 
-               Margin="0 16 0 0"
+    <DockPanel Margin="0 16 0 0"
+               DockPanel.Dock="Bottom"
                Visibility="{Binding ExistingForks, Converter={ui:HasItemsVisibilityConverter}}">
       <TextBlock DockPanel.Dock="Top" Margin="8 0">
             <Run FontWeight="SemiBold">Can't find what you're looking for?</Run>
@@ -98,5 +90,5 @@
         </ItemsControl.ItemTemplate>
       </ItemsControl>
     </DockPanel>
-  </Grid>
+  </DockPanel>
 </UserControl>


### PR DESCRIPTION
Using a grid element would cause the listbox selection border to stretch vertically. Using a DockPanel instead fixes this.

<img width="428" alt="screen shot 2018-12-12 at 4 50 06 pm" src="https://user-images.githubusercontent.com/1174461/49908130-00319400-fe2e-11e8-8e5b-35f90c55a6d6.png">

Fixes https://github.com/github/VisualStudio/issues/2103