### PR TITLE
Add timer extension methods for ILogger

### DIFF
--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
@@ -108,7 +108,8 @@ namespace GitHub.ViewModels.Dialog.Clone
 
             try
             {
-                var results = await service.ReadViewerRepositories(connection.HostAddress).ConfigureAwait(true);
+                var results = await log.TimeAsync(nameof(service.ReadViewerRepositories),
+                    () => service.ReadViewerRepositories(connection.HostAddress));
 
                 var yourRepositories = results.Repositories
                     .Where(r => r.Owner == results.Owner)
@@ -121,6 +122,7 @@ namespace GitHub.ViewModels.Dialog.Clone
                     .OrderBy(x => x.Key)
                     .SelectMany(x => x.Value.Select(y => new RepositoryItemViewModel(y, x.Key)));
                 Items = yourRepositories.Concat(collaboratorRepositories).Concat(orgRepositories).ToList();
+                log.Information("Read {Total} viewer repositories", Items.Count);
                 ItemsView = CollectionViewSource.GetDefaultView(Items);
                 ItemsView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(RepositoryItemViewModel.Group)));
                 ItemsView.Filter = FilterItem;

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -97,7 +97,7 @@ namespace GitHub.InlineReviews.Services
             relativePath = relativePath.Replace("\\", "/");
 
             return pullRequest.CheckSuites
-                ?.SelectMany(checkSuite => checkSuite.CheckRuns.Select(checkRun => new { checkSuite, checkRun}))
+                ?.SelectMany(checkSuite => checkSuite.CheckRuns.Select(checkRun => new { checkSuite, checkRun }))
                 .SelectMany(arg =>
                     arg.checkRun.Annotations
                         .Where(annotation => annotation.Path == relativePath)
@@ -361,17 +361,21 @@ namespace GitHub.InlineReviews.Services
             var result = await connection.Run(readPullRequest, vars);
 
             var apiClient = await apiClientFactory.Create(address);
-            var files = await apiClient.GetPullRequestFiles(owner, name, number).ToList();
-            var lastCommitModel = await GetPullRequestLastCommitAdapter(address, owner, name, number);
 
-            result.Statuses = (IReadOnlyList<StatusModel>) lastCommitModel.Statuses ?? Array.Empty<StatusModel>();
+            var files = await log.TimeAsync(nameof(apiClient.GetPullRequestFiles),
+                async () => await apiClient.GetPullRequestFiles(owner, name, number).ToList());
+
+            var lastCommitModel = await log.TimeAsync(nameof(GetPullRequestLastCommitAdapter),
+                () => GetPullRequestLastCommitAdapter(address, owner, name, number));
+
+            result.Statuses = (IReadOnlyList<StatusModel>)lastCommitModel.Statuses ?? Array.Empty<StatusModel>();
 
             if (lastCommitModel.CheckSuites == null)
             {
                 result.CheckSuites = Array.Empty<CheckSuiteModel>();
             }
             else
-            { 
+            {
                 result.CheckSuites = lastCommitModel.CheckSuites;
                 foreach (var checkSuite in result.CheckSuites)
                 {
@@ -838,8 +842,8 @@ namespace GitHub.InlineReviews.Services
                          commit => new LastCommitAdapter
                          {
                              Statuses = commit.Commit.Status == null ? null : commit.Commit.Status
-                                 .Select(context => context == null 
-                                     ? null 
+                                 .Select(context => context == null
+                                     ? null
                                      : context.Contexts
                                          .Select(statusContext => new StatusModel
                                          {
@@ -871,7 +875,7 @@ namespace GitHub.InlineReviews.Services
         static void BuildPullRequestThreads(PullRequestDetailModel model)
         {
             var commentsByReplyId = new Dictionary<string, List<CommentAdapter>>();
-           
+
             // Get all comments that are not replies.
             foreach (CommentAdapter comment in model.Reviews.SelectMany(x => x.Comments))
             {
@@ -961,5 +965,5 @@ namespace GitHub.InlineReviews.Services
 
             public string HeadSha { get; set; }
         }
-    }   
+    }
 }

--- a/src/GitHub.Logging/Logging/ILoggerExtensions.cs
+++ b/src/GitHub.Logging/Logging/ILoggerExtensions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
 using Serilog;
 
 namespace GitHub.Logging
@@ -25,5 +28,37 @@ namespace GitHub.Logging
 #pragma warning restore Serilog004
             }
         }
+
+        public static void Time(this ILogger logger, string name, Action method)
+        {
+            var startTime = DateTime.Now;
+            method();
+            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+        }
+
+        public static T Time<T>(this ILogger logger, string name, Func<T> method)
+        {
+            var startTime = DateTime.Now;
+            var value = method();
+            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+            return value;
+        }
+
+        public static async Task TimeAsync(this ILogger logger, string name, Func<Task> methodAsync)
+        {
+            var startTime = DateTime.Now;
+            await methodAsync().ConfigureAwait(false);
+            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+        }
+
+        public static async Task<T> TimeAsync<T>(this ILogger logger, string name, Func<Task<T>> methodAsync)
+        {
+            var startTime = DateTime.Now;
+            var value = await methodAsync().ConfigureAwait(false);
+            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+            return value;
+        }
+
+        static string FormatSeconds(TimeSpan timeSpan) => timeSpan.TotalSeconds.ToString("0.##", CultureInfo.InvariantCulture);
     }
 }

--- a/src/GitHub.Logging/Logging/ILoggerExtensions.cs
+++ b/src/GitHub.Logging/Logging/ILoggerExtensions.cs
@@ -33,14 +33,14 @@ namespace GitHub.Logging
         {
             var startTime = DateTime.Now;
             method();
-            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+            logger.Verbose("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
         }
 
         public static T Time<T>(this ILogger logger, string name, Func<T> method)
         {
             var startTime = DateTime.Now;
             var value = method();
-            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+            logger.Verbose("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
             return value;
         }
 
@@ -48,14 +48,14 @@ namespace GitHub.Logging
         {
             var startTime = DateTime.Now;
             await methodAsync().ConfigureAwait(false);
-            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+            logger.Verbose("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
         }
 
         public static async Task<T> TimeAsync<T>(this ILogger logger, string name, Func<Task<T>> methodAsync)
         {
             var startTime = DateTime.Now;
             var value = await methodAsync().ConfigureAwait(false);
-            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+            logger.Verbose("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
             return value;
         }
 


### PR DESCRIPTION
The `Time` extension method for `ILogger` allows logging of method that might or might not return an object. This allows timings to be added with minimal code disruption.

For example:
```cs
log.Time("Call", () => Call(args)));
```

```cs
var result = log.Time("Create", () => Create(args)));
```

```cs
var result = await log.TimeAsync("CreateAsync", () => CreateAsync(args)));
```


Here is some example output when the `PullRequestSandbox` project opens:
```
2018-12-13 11:17:04.547 [18064] INFO [30] PullRequestSessionService Run took 1.3259995999999998 seconds
2018-12-13 11:17:05.723 [18064] INFO [01] PullRequestSessionService Create took 0.1729973 seconds
2018-12-13 11:17:06.875 [18064] INFO [05] PullRequestSessionService GetPullRequestFiles took 1.1515254 seconds
2018-12-13 11:17:09.578 [18064] INFO [19] PullRequestSessionService GetPullRequestLastCommitAdapter took 2.69079 seconds
```

Here is when explicitly opening a PR:
```
2018-12-13 11:21:08.529 [18064] INFO [27] PullRequestSessionService Run took 1.0999919999999999 seconds
2018-12-13 11:21:08.540 [18064] INFO [01] PullRequestSessionService Create took 0 seconds
2018-12-13 11:21:09.351 [18064] INFO [43] PullRequestSessionService GetPullRequestFiles took 0.811066 seconds
2018-12-13 11:21:10.228 [18064] INFO [21] PullRequestSessionService GetPullRequestLastCommitAdapter took 0.87658189999999991 seconds
```

Here is from the `github/VisualStudio` project opening:
```
2018-12-13 11:23:06.638 [18064] INFO [29] PullRequestSessionService Run took 1.0580602 seconds
2018-12-13 11:23:06.672 [18064] INFO [01] PullRequestSessionService Create took 0 seconds
2018-12-13 11:23:07.584 [18064] INFO [21] PullRequestSessionService GetPullRequestFiles took 0.9115224 seconds
2018-12-13 11:23:07.987 [18064] DBUG [01] GitHubPaneViewModel       Found a GitHub repository: https://github.com/github/VisualStudio
2018-12-13 11:23:08.946 [18064] DBUG [01] SequentialListSource`2    Loading page 0 of GitHub.Models.PullRequestListItemModel
2018-12-13 11:23:18.343 [18064] INFO [46] PullRequestSessionService GetPullRequestLastCommitAdapter took 10.7592488 seconds
```

Here is from opening #2119:
```
2018-12-13 11:24:25.437 [18064] INFO [15] PullRequestSessionService Run took 0.9559979999999999 seconds
2018-12-13 11:24:25.437 [18064] INFO [01] PullRequestSessionService Create took 0 seconds
2018-12-13 11:24:28.141 [18064] INFO [48] PullRequestSessionService GetPullRequestFiles took 2.7020030999999998 seconds
2018-12-13 11:24:29.180 [18064] INFO [49] PullRequestSessionService GetPullRequestLastCommitAdapter took 1.0390017 seconds
```

Here is from opening this PR:
```
2018-12-13 11:26:40.080 [18064] INFO [01] PullRequestSessionService CreateConnection took 0 seconds
2018-12-13 11:26:41.082 [18064] INFO [59] PullRequestSessionService Run took 1.0015732 seconds
2018-12-13 11:26:41.082 [18064] INFO [01] PullRequestSessionService Create took 0 seconds
2018-12-13 11:26:41.908 [18064] INFO [47] PullRequestSessionService GetPullRequestFiles took 0.82566129999999993 seconds
2018-12-13 11:26:58.586 [18064] INFO [06] PullRequestSessionService GetPullRequestLastCommitAdapter took 16.677088899999998 seconds
```