### PR TITLE
Fix VSSDK analyzer warnings.

### DIFF
--- a/src/GitHub.InlineReviews/Commands/InlineCommentNavigationCommand.cs
+++ b/src/GitHub.InlineReviews/Commands/InlineCommentNavigationCommand.cs
@@ -9,9 +9,11 @@ using GitHub.Logging;
 using GitHub.Models;
 using GitHub.Services;
 using GitHub.Services.Vssdk.Commands;
+using Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Differencing;
@@ -99,6 +101,8 @@ namespace GitHub.InlineReviews.Commands
         /// </remarks>
         protected IEnumerable<ITextView> GetCurrentTextViews()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var result = new List<ITextView>();
 
             try
@@ -164,6 +168,8 @@ namespace GitHub.InlineReviews.Commands
                     }
 
                     var model = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
+                    Assumes.Present(model);
+
                     var adapterFactory = model.GetService<IVsEditorAdaptersFactoryService>();
                     var wpfTextView = adapterFactory.GetWpfTextView(textView);
                     result.Add(wpfTextView);

--- a/src/GitHub.InlineReviews/Commands/ToggleInlineCommentMarginCommand.cs
+++ b/src/GitHub.InlineReviews/Commands/ToggleInlineCommentMarginCommand.cs
@@ -9,6 +9,7 @@ using GitHub.Services.Vssdk.Commands;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Editor;
+using GitHub.Extensions;
 
 namespace GitHub.InlineReviews.Commands
 {
@@ -42,7 +43,7 @@ namespace GitHub.InlineReviews.Commands
 
         public override Task Execute()
         {
-            usageTracker.Value.IncrementCounter(x => x.ExecuteToggleInlineCommentMarginCommand);
+            usageTracker.Value.IncrementCounter(x => x.ExecuteToggleInlineCommentMarginCommand).Forget();
 
             IVsTextView activeView = null;
             if (textManager.Value.GetActiveView(1, null, out activeView) == VSConstants.S_OK)

--- a/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
+++ b/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
@@ -289,10 +289,10 @@
       <Version>0.2.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers">
-      <Version>15.8.33</Version>
+      <Version>15.8.36</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
-      <Version>15.8.122</Version>
+      <Version>15.8.192</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>15.8.3252</Version>

--- a/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
+++ b/src/GitHub.InlineReviews/GitHub.InlineReviews.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Commands\InlineCommentNavigationCommand.cs" />
     <Compile Include="Commands\PreviousInlineCommentCommand.cs" />
     <Compile Include="Commands\NextInlineCommentCommand.cs" />
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Margins\InlineCommentTextViewOptions.cs" />
     <Compile Include="Margins\PullRequestFileMargin.cs" />
     <Compile Include="Margins\PullRequestFileMarginProvider.cs" />

--- a/src/GitHub.InlineReviews/GlobalSuppressions.cs
+++ b/src/GitHub.InlineReviews/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods")]
+

--- a/src/GitHub.InlineReviews/InlineReviewsPackage.cs
+++ b/src/GitHub.InlineReviews/InlineReviewsPackage.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Serilog;
 using Task = System.Threading.Tasks.Task;
+using Microsoft;
 
 namespace GitHub.InlineReviews
 {
@@ -27,8 +28,9 @@ namespace GitHub.InlineReviews
             CancellationToken cancellationToken,
             IProgress<ServiceProgressData> progress)
         {
-            var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
+            Assumes.Present(componentModel);
+
             var exports = componentModel.DefaultExportProvider;
 
             // Avoid delays when there is ongoing UI activity.
@@ -45,6 +47,8 @@ namespace GitHub.InlineReviews
             }
 
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
+            Assumes.Present(componentModel);
+
             var exports = componentModel.DefaultExportProvider;
             var commands = new IVsCommandBase[]
             {
@@ -55,6 +59,8 @@ namespace GitHub.InlineReviews
 
             await JoinableTaskFactory.SwitchToMainThreadAsync();
             var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
+            Assumes.Present(componentModel);
+
             menuService.AddCommands(commands);
         }
     }

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -770,7 +770,7 @@ namespace GitHub.InlineReviews.Services
 
         Task<IRepository> GetRepository(LocalRepositoryModel repository)
         {
-            return Task.Factory.StartNew(() => gitService.GetRepository(repository.LocalPath));
+            return Task.Run(() => gitService.GetRepository(repository.LocalPath));
         }
 
         async Task<LastCommitAdapter> GetPullRequestLastCommitAdapter(HostAddress address, string owner, string name, int number)

--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
@@ -160,10 +160,10 @@ namespace GitHub.InlineReviews.ViewModels
             }
 
             fileSubscription?.Dispose();
-            fileSubscription = file.LinesChanged.ObserveOn(RxApp.MainThreadScheduler).Subscribe(LinesChanged);
+            fileSubscription = file.LinesChanged.ObserveOn(RxApp.MainThreadScheduler).Subscribe(x => LinesChanged(x).Forget());
         }
 
-        async void LinesChanged(IReadOnlyList<Tuple<int, DiffSide>> lines)
+        async Task LinesChanged(IReadOnlyList<Tuple<int, DiffSide>> lines)
         {
             try
             {

--- a/src/GitHub.StartPage/GitHub.StartPage.csproj
+++ b/src/GitHub.StartPage/GitHub.StartPage.csproj
@@ -55,6 +55,7 @@
     <Compile Include="..\common\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StartPagePackage.cs" />
   </ItemGroup>

--- a/src/GitHub.StartPage/GlobalSuppressions.cs
+++ b/src/GitHub.StartPage/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods")]
+

--- a/src/GitHub.StartPage/StartPagePackage.cs
+++ b/src/GitHub.StartPage/StartPagePackage.cs
@@ -40,17 +40,17 @@ namespace GitHub.StartPage
         public async Task<CodeContainer> AcquireCodeContainerAsync(IProgress<ServiceProgressData> downloadProgress, CancellationToken cancellationToken)
         {
 
-            return await RunAcquisition(downloadProgress, cancellationToken, null);
+            return await RunAcquisition(downloadProgress, null, cancellationToken);
         }
 
         public async Task<CodeContainer> AcquireCodeContainerAsync(RemoteCodeContainer onlineCodeContainer, IProgress<ServiceProgressData> downloadProgress, CancellationToken cancellationToken)
         {
             var repository = new RepositoryModel(onlineCodeContainer.Name, UriString.ToUriString(onlineCodeContainer.DisplayUrl));
-            return await RunAcquisition(downloadProgress, cancellationToken, repository);
+            return await RunAcquisition(downloadProgress, repository, cancellationToken);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "cancellationToken")]
-        async Task<CodeContainer> RunAcquisition(IProgress<ServiceProgressData> downloadProgress, CancellationToken cancellationToken, RepositoryModel repository)
+        async Task<CodeContainer> RunAcquisition(IProgress<ServiceProgressData> downloadProgress, RepositoryModel repository, CancellationToken cancellationToken)
         {
             CloneDialogResult request = null;
 

--- a/src/GitHub.VisualStudio/GitContextPackage.cs
+++ b/src/GitHub.VisualStudio/GitContextPackage.cs
@@ -6,6 +6,7 @@ using GitHub.Services;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
 using static Microsoft.VisualStudio.VSConstants;
+using Microsoft;
 
 namespace GitHub.VisualStudio
 {
@@ -28,6 +29,8 @@ namespace GitHub.VisualStudio
             }
 
             var gitExt = (IVSGitExt)await GetServiceAsync(typeof(IVSGitExt));
+            Assumes.Present(gitExt);
+
             var context = UIContext.FromUIContextGuid(new Guid(Guids.UIContext_Git));
             RefreshContext(context, gitExt);
             gitExt.ActiveRepositoriesChanged += () =>

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -24,6 +24,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Serilog;
 using Task = System.Threading.Tasks.Task;
+using Microsoft;
 
 namespace GitHub.VisualStudio
 {
@@ -80,6 +81,8 @@ namespace GitHub.VisualStudio
             if (ExportForVisualStudioProcessAttribute.IsVisualStudioProcess())
             {
                 var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)));
+                Assumes.Present(componentModel);
+
                 var exports = componentModel.DefaultExportProvider;
                 commands = new IVsCommandBase[]
                 {
@@ -111,11 +114,15 @@ namespace GitHub.VisualStudio
 
             await JoinableTaskFactory.SwitchToMainThreadAsync();
             var menuService = (IMenuCommandService)(await GetServiceAsync(typeof(IMenuCommandService)));
+            Assumes.Present(menuService);
+
             menuService.AddCommands(commands);
         }
 
         async Task EnsurePackageLoaded(Guid packageGuid)
         {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(DisposalToken);
+
             var shell = await GetServiceAsync(typeof(SVsShell)) as IVsShell;
             if (shell != null)
             {
@@ -233,6 +240,8 @@ namespace GitHub.VisualStudio
 
         public async Task<IGitHubPaneViewModel> ShowGitHubPane()
         {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(DisposalToken);
+
             var pane = ShowToolWindow(new Guid(GitHubPane.GitHubPaneGuid));
             if (pane == null)
                 return null;
@@ -248,6 +257,8 @@ namespace GitHub.VisualStudio
 
         static ToolWindowPane ShowToolWindow(Guid windowGuid)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             IVsWindowFrame frame;
             if (ErrorHandler.Failed(Services.UIShell.FindToolWindow((uint)__VSCREATETOOLWIN.CTW_fForceCreate,
                 ref windowGuid, out frame)))
@@ -290,6 +301,8 @@ namespace GitHub.VisualStudio
                 // These services are got through MEF and we will take a performance hit if ILoginManager is requested during 
                 // InitializeAsync. TODO: We can probably make LoginManager a normal MEF component rather than a service.
                 var serviceProvider = await GetServiceAsync(typeof(IGitHubServiceProvider)) as IGitHubServiceProvider;
+                Assumes.Present(serviceProvider);
+
                 var keychain = serviceProvider.GetService<IKeychain>();
                 var oauthListener = serviceProvider.GetService<IOAuthCallbackListener>();
 
@@ -319,6 +332,8 @@ namespace GitHub.VisualStudio
             else if (serviceType == typeof(IUsageService))
             {
                 var sp = await GetServiceAsync(typeof(IGitHubServiceProvider)) as IGitHubServiceProvider;
+                Assumes.Present(sp);
+
                 var environment = new Rothko.Environment();
                 return new UsageService(sp, environment);
             }
@@ -327,6 +342,11 @@ namespace GitHub.VisualStudio
                 var usageService = await GetServiceAsync(typeof(IUsageService)) as IUsageService;
                 var serviceProvider = await GetServiceAsync(typeof(IGitHubServiceProvider)) as IGitHubServiceProvider;
                 var settings = await GetServiceAsync(typeof(IPackageSettings)) as IPackageSettings;
+
+                Assumes.Present(usageService);
+                Assumes.Present(serviceProvider);
+                Assumes.Present(settings);
+
                 return new UsageTracker(serviceProvider, usageService, settings);
             }
             else if (serviceType == typeof(IVSGitExt))
@@ -352,6 +372,8 @@ namespace GitHub.VisualStudio
             else
             {
                 var sp = await GetServiceAsync(typeof(IGitHubServiceProvider)) as IGitHubServiceProvider;
+                Assumes.Present(sp);
+
                 return sp.TryGetService(serviceType);
             }
         }

--- a/src/GitHub.VisualStudio/GlobalSuppressions.cs
+++ b/src/GitHub.VisualStudio/GlobalSuppressions.cs
@@ -9,3 +9,5 @@
 // file manually.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1701:ResourceStringCompoundWordsShouldBeCasedCorrectly", MessageId = "GitHub", Scope = "resource", Target = "VSPackage.resources")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods")]
+

--- a/src/GitHub.VisualStudio/Helpers/ActiveDocumentSnapshot.cs
+++ b/src/GitHub.VisualStudio/Helpers/ActiveDocumentSnapshot.cs
@@ -18,6 +18,8 @@ namespace GitHub.VisualStudio
         [ImportingConstructor]
         public ActiveDocumentSnapshot([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             StartLine = EndLine = -1;
             var document = Services.Dte2?.ActiveDocument;
             Name = document.FullName.Equals(document.ProjectItem.FileNames[1], StringComparison.OrdinalIgnoreCase) ? document.ProjectItem.FileNames[1] : document.FullName;

--- a/src/GitHub.VisualStudio/Helpers/Browser.cs
+++ b/src/GitHub.VisualStudio/Helpers/Browser.cs
@@ -41,7 +41,12 @@ namespace GitHub.VisualStudio.Helpers
             {
                 __VSCREATEWEBBROWSER createFlags = __VSCREATEWEBBROWSER.VSCWB_AutoShow;
                 VSPREVIEWRESOLUTION resolution = VSPREVIEWRESOLUTION.PR_Default;
-                int result = ErrorHandler.CallWithCOMConvention(() => service.CreateExternalWebBrowser((uint)createFlags, resolution, uri.AbsoluteUri));
+                int result = ErrorHandler.CallWithCOMConvention(() =>
+                {
+                    ThreadHelper.ThrowIfNotOnUIThread();
+                    service.CreateExternalWebBrowser((uint)createFlags, resolution, uri.AbsoluteUri);
+                });
+
                 if (ErrorHandler.Succeeded(result))
                     return;
             }

--- a/src/GitHub.VisualStudio/Services/UsageService.cs
+++ b/src/GitHub.VisualStudio/Services/UsageService.cs
@@ -85,11 +85,13 @@ namespace GitHub.Services
         public IDisposable StartTimer(Func<Task> callback, TimeSpan dueTime, TimeSpan period)
         {
             return new Timer(
+#pragma warning disable VSTHRD101 // Avoid unsupported async delegates
                 async _ =>
                 {
                     try { await callback(); }
                     catch (Exception ex) { log.Warning(ex, "Failed submitting usage data"); }
                 },
+#pragma warning restore VSTHRD101 // Avoid unsupported async delegates
                 null,
                 dueTime,
                 period);

--- a/src/GitHub.VisualStudio/UI/GitHubPane.cs
+++ b/src/GitHub.VisualStudio/UI/GitHubPane.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using ReactiveUI;
+using Microsoft;
 
 namespace GitHub.VisualStudio.UI
 {
@@ -94,6 +95,7 @@ namespace GitHub.VisualStudio.UI
 
                 // Allow MEF to initialize its cache asynchronously
                 var provider = (IGitHubServiceProvider)await asyncPackage.GetServiceAsync(typeof(IGitHubServiceProvider));
+                Assumes.Present(provider);
 
                 var teServiceHolder = provider.GetService<ITeamExplorerServiceHolder>();
                 teServiceHolder.ServiceProvider = this;
@@ -139,6 +141,8 @@ namespace GitHub.VisualStudio.UI
 
         public override void OnToolWindowCreated()
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             base.OnToolWindowCreated();
 
             Marshal.ThrowExceptionForHR(((IVsWindowFrame)Frame)?.SetProperty(
@@ -165,6 +169,8 @@ namespace GitHub.VisualStudio.UI
 
         void UpdateSearchHost(bool enabled, string query)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             if (SearchHost != null)
             {
                 SearchHost.IsEnabled = enabled;
@@ -197,6 +203,8 @@ namespace GitHub.VisualStudio.UI
 
             protected override void OnStartSearch()
             {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
                 viewModel.SearchQuery = SearchQuery.SearchString;
                 base.OnStartSearch();
             }

--- a/test/GitHub.VisualStudio.UnitTests/GlobalSuppressions.cs
+++ b/test/GitHub.VisualStudio.UnitTests/GlobalSuppressions.cs
@@ -8,3 +8,6 @@
     Justification = "It's okay for nested unit test types to be visible")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores",
     Justification = "It's okay for unit test names to contain underscores")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "VSSDK006:Check services exist",
+    Justification = "We're mocking the services")]
+

--- a/test/Helpers/GlobalSuppressions.cs
+++ b/test/Helpers/GlobalSuppressions.cs
@@ -6,3 +6,6 @@
 [assembly: SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores")]
 [assembly: SuppressMessage("Performance", "CA1826:Do not use Enumerable methods on indexable collections. Instead use the collection directly")]
 [assembly: SuppressMessage("Reliability", "CA2007:Do not directly await a Task")]
+[assembly: SuppressMessage("Usage", "VSTHRD101:Avoid unsupported async delegates")]
+[assembly: SuppressMessage("Usage", "VSTHRD110:Observe result of async calls")]
+[assembly: SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods")]


### PR DESCRIPTION
This fixes a bunch of `VSSDK` and `VSTHRD` analyzer warnings. A few notes:

- I left intact warnings that are actually warning us that something is a bit iffy, we probably want to see if there's a better way to do some stuff
- ~~We're also hitting Microsoft/VSSDK-Analyzers#95 in a number of places~~
- Suppress `[VSTHRD200](https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD200.md)` for the moment. We don't currently follow the "Async" suffix pattern for async methods. We may want to revisit this later.

~~Depends on #2119~~