### PR TITLE
Add script to help with troubleshooting some dev environment issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ Logs can be viewed at the following location:
 
 `%LOCALAPPDATA%\GitHubVisualStudio\extension.log`
 
+## Troubleshooting
+
+*"The type or namespace name does not exist..." or "Unable to find project... Check that the project reference is valid and that the project file exists."*
+
+If you run into namespace or submodule issues, running the following command might help get your environment in a clean state:
+
+```txt
+clean.cmd
+```
+
 ## More information
 - Andreia Gaita's [presentation](https://www.youtube.com/watch?v=hz2hCO8e_8w) at Codemania 2016 about this extension.
 
@@ -104,4 +114,3 @@ Visit the [Contributor Guidelines](CONTRIBUTING.md) for details on how to contri
 Copyright 2015 - 2018 GitHub, Inc.
 
 Licensed under the [MIT License](LICENSE.md)
-

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ or
 
 > "Unable to find project... Check that the project reference is valid and that the project file exists."*
 
-Running the following command might help:
+Close Visual Studio and run the following command to update submodules and clean your environment.
 
 ```txt
 clean.cmd

--- a/README.md
+++ b/README.md
@@ -94,9 +94,15 @@ Logs can be viewed at the following location:
 
 ## Troubleshooting
 
-*"The type or namespace name does not exist..." or "Unable to find project... Check that the project reference is valid and that the project file exists."*
+If you have issues building with failures similar to:
 
-If you run into namespace or submodule issues, running the following command might help get your environment in a clean state:
+> "The type or namespace name does not exist..."
+
+or
+
+> "Unable to find project... Check that the project reference is valid and that the project file exists."*
+
+Running the following command might help:
 
 ```txt
 clean.cmd

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,1 +1,3 @@
-powershell -ExecutionPolicy Unrestricted scripts\clean.ps1 
+git submodule update --init
+git clean -xdff
+git submodule foreach git clean -xdff

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Unrestricted scripts\clean.ps1 

--- a/scripts/clean.ps1
+++ b/scripts/clean.ps1
@@ -1,0 +1,3 @@
+git submodule update --init
+git clean -xdff
+git submodule foreach git clean -xdff

--- a/scripts/clean.ps1
+++ b/scripts/clean.ps1
@@ -1,3 +1,0 @@
-git submodule update --init
-git clean -xdff
-git submodule foreach git clean -xdff


### PR DESCRIPTION
A common thing that I've been running into often is my development environment not working if I haven't been keeping up to date with changes regularly. When I would pull a branch and try building, I'd often run into errors similar to this:

<img width="1415" alt="screen shot 2018-12-13 at 10 06 56 am" src="https://user-images.githubusercontent.com/1174461/49963133-0413f380-fecc-11e8-81d1-ce3c47e7f2f9.png">

Some of the engineers suggested closing Visual Studio and running the following commands:

```bash
git clean -xdff
git submodule foreach git clean -xdff
```

Which ends up solving most of the issues I've been running into! 🎉 

I've added a script (`scripts/clean.ps1`) and took a crack at [documenting when to use this command](https://github.com/github/VisualStudio/tree/clean-me#troubleshooting) in the README, however there's a chance it could be improved a bit.

I've also added `git submodule update` to the top of the ~`clean.ps1`~ `clean.cmd` script so that submodules such as Octokit are sync'd before running the command.

/cc @grokys @StanleyGoldman since y'all have helped me this week regarding my dev issues.

