### PR TITLE
[wip] Find a way to improve the organization list load time

### DIFF
--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -73,6 +73,8 @@ namespace GitHub.Services
                     Direction = OrderDirection.Asc
                 };
 
+                // Pass this for affiliations and ownerAffiliations. See:
+                // https://platform.github.community/t/unable-to-fetch-users-repositories-by-organization-membership/7557/6
                 var affiliation = new RepositoryAffiliation?[]
                 {
                     RepositoryAffiliation.Owner, RepositoryAffiliation.Collaborator, RepositoryAffiliation.OrganizationMember
@@ -94,7 +96,7 @@ namespace GitHub.Services
                     .Select(viewer => new ViewerRepositoriesModel
                     {
                         Owner = viewer.Login,
-                        Repositories = viewer.Repositories(null, null, null, null, null, null, null, order, affiliation, null)
+                        Repositories = viewer.Repositories(null, null, null, null, affiliation, null, null, order, affiliation, RepositoryPrivacy.Private)
                             .AllPages()
                             .Select(repositorySelection).ToList(),
                     }).Compile();

--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -75,7 +75,7 @@ namespace GitHub.Services
 
                 var affiliation = new RepositoryAffiliation?[]
                 {
-                    RepositoryAffiliation.Owner, RepositoryAffiliation.Collaborator
+                    RepositoryAffiliation.Owner, RepositoryAffiliation.Collaborator, RepositoryAffiliation.OrganizationMember
                 };
 
                 var repositorySelection = new Fragment<Repository, RepositoryListItemModel>(
@@ -97,13 +97,6 @@ namespace GitHub.Services
                         Repositories = viewer.Repositories(null, null, null, null, null, null, null, order, affiliation, null)
                             .AllPages()
                             .Select(repositorySelection).ToList(),
-                        Organizations = viewer.Organizations(null, null, null, null).AllPages().Select(org => new
-                        {
-                            org.Login,
-                            Repositories = org.Repositories(null, null, null, null, null, null, null, order, null, null)
-                                .AllPages()
-                                .Select(repositorySelection).ToList()
-                        }).ToDictionary(x => x.Login, x => (IReadOnlyList<RepositoryListItemModel>)x.Repositories),
                     }).Compile();
             }
 

--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
@@ -114,14 +114,13 @@ namespace GitHub.ViewModels.Dialog.Clone
                 var yourRepositories = results.Repositories
                     .Where(r => r.Owner == results.Owner)
                     .Select(x => new RepositoryItemViewModel(x, "Your repositories"));
-                var collaboratorRepositories = results.Repositories
+
+                var orgRepositories = results.Repositories
                     .Where(r => r.Owner != results.Owner)
                     .OrderBy(r => r.Owner)
-                    .Select(x => new RepositoryItemViewModel(x, "Collaborator repositories"));
-                var orgRepositories = results.Organizations
-                    .OrderBy(x => x.Key)
-                    .SelectMany(x => x.Value.Select(y => new RepositoryItemViewModel(y, x.Key)));
-                Items = yourRepositories.Concat(collaboratorRepositories).Concat(orgRepositories).ToList();
+                    .Select(r => new RepositoryItemViewModel(r, r.Owner));
+
+                Items = yourRepositories.Concat(orgRepositories).ToList();
                 log.Information("Read {Total} viewer repositories", Items.Count);
                 ItemsView = CollectionViewSource.GetDefaultView(Items);
                 ItemsView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(RepositoryItemViewModel.Group)));

--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
@@ -108,7 +108,8 @@ namespace GitHub.ViewModels.Dialog.Clone
 
             try
             {
-                var results = await service.ReadViewerRepositories(connection.HostAddress).ConfigureAwait(true);
+                var results = await log.TimeAsync(nameof(service.ReadViewerRepositories),
+                    () => service.ReadViewerRepositories(connection.HostAddress));
 
                 var yourRepositories = results.Repositories
                     .Where(r => r.Owner == results.Owner)
@@ -121,6 +122,7 @@ namespace GitHub.ViewModels.Dialog.Clone
                     .OrderBy(x => x.Key)
                     .SelectMany(x => x.Value.Select(y => new RepositoryItemViewModel(y, x.Key)));
                 Items = yourRepositories.Concat(collaboratorRepositories).Concat(orgRepositories).ToList();
+                log.Information("Read {Total} viewer repositories", Items.Count);
                 ItemsView = CollectionViewSource.GetDefaultView(Items);
                 ItemsView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(RepositoryItemViewModel.Group)));
                 ItemsView.Filter = FilterItem;

--- a/src/GitHub.Exports/Models/ViewerRepositoriesModel.cs
+++ b/src/GitHub.Exports/Models/ViewerRepositoriesModel.cs
@@ -7,6 +7,5 @@ namespace GitHub.Models
     {
         public string Owner { get; set; }
         public IReadOnlyList<RepositoryListItemModel> Repositories { get; set; }
-        public IDictionary<string, IReadOnlyList<RepositoryListItemModel>> Organizations { get; set; }
     }
 }

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -97,7 +97,7 @@ namespace GitHub.InlineReviews.Services
             relativePath = relativePath.Replace("\\", "/");
 
             return pullRequest.CheckSuites
-                ?.SelectMany(checkSuite => checkSuite.CheckRuns.Select(checkRun => new { checkSuite, checkRun}))
+                ?.SelectMany(checkSuite => checkSuite.CheckRuns.Select(checkRun => new { checkSuite, checkRun }))
                 .SelectMany(arg =>
                     arg.checkRun.Annotations
                         .Where(annotation => annotation.Path == relativePath)
@@ -361,17 +361,21 @@ namespace GitHub.InlineReviews.Services
             var result = await connection.Run(readPullRequest, vars);
 
             var apiClient = await apiClientFactory.Create(address);
-            var files = await apiClient.GetPullRequestFiles(owner, name, number).ToList();
-            var lastCommitModel = await GetPullRequestLastCommitAdapter(address, owner, name, number);
 
-            result.Statuses = (IReadOnlyList<StatusModel>) lastCommitModel.Statuses ?? Array.Empty<StatusModel>();
+            var files = await log.TimeAsync(nameof(apiClient.GetPullRequestFiles),
+                async () => await apiClient.GetPullRequestFiles(owner, name, number).ToList());
+
+            var lastCommitModel = await log.TimeAsync(nameof(GetPullRequestLastCommitAdapter),
+                () => GetPullRequestLastCommitAdapter(address, owner, name, number));
+
+            result.Statuses = (IReadOnlyList<StatusModel>)lastCommitModel.Statuses ?? Array.Empty<StatusModel>();
 
             if (lastCommitModel.CheckSuites == null)
             {
                 result.CheckSuites = Array.Empty<CheckSuiteModel>();
             }
             else
-            { 
+            {
                 result.CheckSuites = lastCommitModel.CheckSuites;
                 foreach (var checkSuite in result.CheckSuites)
                 {
@@ -838,8 +842,8 @@ namespace GitHub.InlineReviews.Services
                          commit => new LastCommitAdapter
                          {
                              Statuses = commit.Commit.Status == null ? null : commit.Commit.Status
-                                 .Select(context => context == null 
-                                     ? null 
+                                 .Select(context => context == null
+                                     ? null
                                      : context.Contexts
                                          .Select(statusContext => new StatusModel
                                          {
@@ -871,7 +875,7 @@ namespace GitHub.InlineReviews.Services
         static void BuildPullRequestThreads(PullRequestDetailModel model)
         {
             var commentsByReplyId = new Dictionary<string, List<CommentAdapter>>();
-           
+
             // Get all comments that are not replies.
             foreach (CommentAdapter comment in model.Reviews.SelectMany(x => x.Comments))
             {
@@ -961,5 +965,5 @@ namespace GitHub.InlineReviews.Services
 
             public string HeadSha { get; set; }
         }
-    }   
+    }
 }

--- a/src/GitHub.Logging/Logging/ILoggerExtensions.cs
+++ b/src/GitHub.Logging/Logging/ILoggerExtensions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
 using Serilog;
 
 namespace GitHub.Logging
@@ -25,5 +28,37 @@ namespace GitHub.Logging
 #pragma warning restore Serilog004
             }
         }
+
+        public static void Time(this ILogger logger, string name, Action method)
+        {
+            var startTime = DateTime.Now;
+            method();
+            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+        }
+
+        public static T Time<T>(this ILogger logger, string name, Func<T> method)
+        {
+            var startTime = DateTime.Now;
+            var value = method();
+            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+            return value;
+        }
+
+        public static async Task TimeAsync(this ILogger logger, string name, Func<Task> methodAsync)
+        {
+            var startTime = DateTime.Now;
+            await methodAsync().ConfigureAwait(false);
+            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+        }
+
+        public static async Task<T> TimeAsync<T>(this ILogger logger, string name, Func<Task<T>> methodAsync)
+        {
+            var startTime = DateTime.Now;
+            var value = await methodAsync().ConfigureAwait(false);
+            logger.Information("{Name} took {Seconds} seconds", name, FormatSeconds(DateTime.Now - startTime));
+            return value;
+        }
+
+        static string FormatSeconds(TimeSpan timeSpan) => timeSpan.TotalSeconds.ToString("0.##", CultureInfo.InvariantCulture);
     }
 }


### PR DESCRIPTION
### What this PR does

Load organization repositories by including `OrganizationMember` in `ownerAffiliations` rather than iterating over Repositories for each of the viewer's `Organizations`.

### Related

- List org repos ordered by STARGAZERS not working
https://github.com/github/github/issues/100120

- Unable to fetch user’s repositories by organization membership
https://platform.github.community/t/unable-to-fetch-users-repositories-by-organization-membership/7557/6

Fixes #2143