### PR TITLE
Be smarter about the repository list we download

### DIFF
--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -95,7 +95,7 @@ namespace GitHub.Services
                     .Select(viewer => new ViewerRepositoriesModel
                     {
                         Owner = viewer.Login,
-                        Repositories = viewer.Repositories(null, null, null, null, null, null, null, order, affiliation, null)
+                        Repositories = viewer.Repositories(null, null, null, null, affiliation, null, null, order, affiliation, null)
                             .AllPages()
                             .Select(repositorySelection).ToList(),
                         ContributedToRepositories = viewer.RepositoriesContributedTo(100, null, null, null, null, null, null, order, null)

--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using GitHub.Api;
 using GitHub.Extensions;
@@ -69,8 +70,8 @@ namespace GitHub.Services
             {
                 var order = new RepositoryOrder
                 {
-                    Field = RepositoryOrderField.Name,
-                    Direction = OrderDirection.Asc
+                    Field = RepositoryOrderField.PushedAt,
+                    Direction = OrderDirection.Desc
                 };
 
                 var affiliation = new RepositoryAffiliation?[]
@@ -100,8 +101,8 @@ namespace GitHub.Services
                         Organizations = viewer.Organizations(null, null, null, null).AllPages().Select(org => new
                         {
                             org.Login,
-                            Repositories = org.Repositories(null, null, null, null, null, null, null, order, null, null)
-                                .AllPages()
+                            Repositories = org.Repositories(100, null, null, null, null, null, null, order, null, null)
+                                .Nodes
                                 .Select(repositorySelection).ToList()
                         }).ToDictionary(x => x.Login, x => (IReadOnlyList<RepositoryListItemModel>)x.Repositories),
                     }).Compile();

--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -98,6 +98,9 @@ namespace GitHub.Services
                         Repositories = viewer.Repositories(null, null, null, null, null, null, null, order, affiliation, null)
                             .AllPages()
                             .Select(repositorySelection).ToList(),
+                        ContributedToRepositories = viewer.RepositoriesContributedTo(100, null, null, null, null, null, null, order, null)
+                            .Nodes
+                            .Select(repositorySelection).ToList(),
                         Organizations = viewer.Organizations(null, null, null, null).AllPages().Select(org => new
                         {
                             org.Login,

--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
@@ -119,10 +119,16 @@ namespace GitHub.ViewModels.Dialog.Clone
                     .Where(r => r.Owner != results.Owner)
                     .OrderBy(r => r.Owner)
                     .Select(x => new RepositoryItemViewModel(x, "Collaborator repositories"));
+                var repositoriesContributedTo = results.ContributedToRepositories
+                    .Select(x => new RepositoryItemViewModel(x, "Contributed to repositories"));
                 var orgRepositories = results.Organizations
                     .OrderBy(x => x.Key)
                     .SelectMany(x => x.Value.Select(y => new RepositoryItemViewModel(y, GroupName(x, 100))));
-                Items = yourRepositories.Concat(collaboratorRepositories).Concat(orgRepositories).ToList();
+                Items = yourRepositories
+                    .Concat(collaboratorRepositories)
+                    .Concat(repositoriesContributedTo)
+                    .Concat(orgRepositories)
+                    .ToList();
                 log.Information("Read {Total} viewer repositories", Items.Count);
                 ItemsView = CollectionViewSource.GetDefaultView(Items);
                 ItemsView.GroupDescriptions.Add(new PropertyGroupDescription(nameof(RepositoryItemViewModel.Group)));

--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -120,7 +121,7 @@ namespace GitHub.ViewModels.Dialog.Clone
                     .Select(x => new RepositoryItemViewModel(x, "Collaborator repositories"));
                 var orgRepositories = results.Organizations
                     .OrderBy(x => x.Key)
-                    .SelectMany(x => x.Value.Select(y => new RepositoryItemViewModel(y, x.Key)));
+                    .SelectMany(x => x.Value.Select(y => new RepositoryItemViewModel(y, GroupName(x, 100))));
                 Items = yourRepositories.Concat(collaboratorRepositories).Concat(orgRepositories).ToList();
                 log.Information("Read {Total} viewer repositories", Items.Count);
                 ItemsView = CollectionViewSource.GetDefaultView(Items);
@@ -142,6 +143,17 @@ namespace GitHub.ViewModels.Dialog.Clone
             {
                 IsLoading = false;
             }
+        }
+
+        static string GroupName(KeyValuePair<string, IReadOnlyList<RepositoryListItemModel>> group, int max)
+        {
+            var name = group.Key;
+            if (group.Value.Count == max)
+            {
+                name += $" ({string.Format(CultureInfo.InvariantCulture, Resources.MostRecentlyPushed, max)})";
+            }
+
+            return name;
         }
 
         bool FilterItem(object obj)

--- a/src/GitHub.Exports/Models/ViewerRepositoriesModel.cs
+++ b/src/GitHub.Exports/Models/ViewerRepositoriesModel.cs
@@ -7,6 +7,7 @@ namespace GitHub.Models
     {
         public string Owner { get; set; }
         public IReadOnlyList<RepositoryListItemModel> Repositories { get; set; }
+        public IReadOnlyList<RepositoryListItemModel> ContributedToRepositories { get; set; }
         public IDictionary<string, IReadOnlyList<RepositoryListItemModel>> Organizations { get; set; }
     }
 }

--- a/src/GitHub.Resources/Resources.Designer.cs
+++ b/src/GitHub.Resources/Resources.Designer.cs
@@ -1027,6 +1027,15 @@ namespace GitHub {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} most recently pushed.
+        /// </summary>
+        public static string MostRecentlyPushed {
+            get {
+                return ResourceManager.GetString("MostRecentlyPushed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You must pull before you can push.
         /// </summary>
         public static string MustPullBeforePush {

--- a/src/GitHub.Resources/Resources.resx
+++ b/src/GitHub.Resources/Resources.resx
@@ -845,4 +845,7 @@ https://git-scm.com/download/win</value>
   <data name="CouldntFindCorrespondingFile" xml:space="preserve">
     <value>Couldn't find file corresponding to '{0}' in the repository. Please do a 'git fetch' or checkout the target pull request.</value>
   </data>
+  <data name="MostRecentlyPushed" xml:space="preserve">
+    <value>{0} most recently pushed</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR is intended as a low impact fix for the `Open from GitHub` dialog when the user belongs to an organization that owns 1000s of repositories.

### What this PR does

- Display at most 100 repositories per organization
- Order the repositories by their most recent commit (freshest first)
- Warn when an organization has hit the 100 repository limit
- Show repositories that the user has contributed to

### Rational

When github.com displays a list of repositories for a user or organization, the repositories are ordered starting with the one with the most recent commit. This ensures that the freshest repositories, which are most likely to be of interest to the user appear at the top of the list.

A user might have worked on a repository that doesn't appear on their organization's list of 100 repositories with recent commits. To ensure that these repositories are also visible, the list of repositories that the user has contributed to has also been included in this list. This includes repositories they created, committed to, opened an issue on or sent a pull request to.

If a user wants to clone a repository that they don't own, isn't on the top 100 active list and they haven't contributed to, they always have the option to open it using the URL tab (like they would for a 3rd party public repository).

### What to expect

- The repository list should appear faster. Here are some before and after timings for a user that has `github` on their organization list (`github` and `Microsoft` both have well over 2000 repositories)

Before:
```
RepositorySelectViewModel ReadViewerRepositories took 39.86 seconds
RepositorySelectViewModel Read 2788 viewer repositories
```

After:
```
RepositorySelectViewModel ReadViewerRepositories took 3.49 seconds
RepositorySelectViewModel Read 309 viewer repositories
```

- Repositories will be displayed in order of when they were last commited to  (the same as the `https://github.com/<owner>` view on github.com)

![image](https://user-images.githubusercontent.com/11719160/50357118-b7c05780-054c-11e9-81fb-2098b6db9547.png)

![image](https://user-images.githubusercontent.com/11719160/50351081-f9df9e00-0538-11e9-86a6-9745dba829ca.png)

- Added new `Contributed to repositories` list

![image](https://user-images.githubusercontent.com/11719160/50350522-5772eb00-0537-11e9-86e6-77603523ca97.png)

- If an organization has over 100 repositories, this will be indicated in the section heading

![image](https://user-images.githubusercontent.com/11719160/50350896-732ac100-0538-11e9-8eb9-282ccca1c40c.png)

- All of a users own repositories and repositories that they're collaborators on will appear (no 100 limit)

### Questions

- Is `100 most recently pushed` too literal? Would `100 most recently updated` be better?

Fixes #2143 
