### PR TITLE
[spike] Automatically detect the PR branch the user is on

### DIFF
--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -56,6 +56,9 @@ namespace GitHub.Services
         /// <returns></returns>
         Task Fetch(IRepository repository, UriString remoteUri, params string[] refspecs);
 
+        // blar!
+        Task<IDictionary<string, string>> ListReferences(IRepository repo, string remoteName);
+
         /// <summary>
         /// Checks out a branch.
         /// </summary>


### PR DESCRIPTION
The PR associated with the current branch is only highlighted when the user created or opened the PR using GitHub for Visual Studio. This isn't very helpful for users who are new to the extension.

### What this PR does

This spike attempts to look up the PR associated with the current branch if the branch hasn't already been tagged. It uses the simple approach of matching `refs/heads/<name>` references with `refs/pull/xxx/head` references. This approach has worked well for https://github.com/jcansdale/GitPullRequest.

### Challenges

There are issues with spam PRs, where an external user creates a PR from an existing branch in the target repository. For example, a user might create a PR from the `master` branch in a repository. The owner of the repository is likely to close the spam PR, but won't delete the `master` branch! Unfortunately the above approach can detect deleted branches but no closed PRs.

### Todo

Implement this using the GraphQL API so we can detect and ignore closed PRs.
