### PR TITLE
Avoid using GraphQL repositories/ownerAffiliations

### DIFF
--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -93,6 +93,7 @@ namespace GitHub.Services
                         // We should pass affiliations and ownerAffiliations the same RepositoryAffiliation?[], but
                         // ownerAffiliations doesn't currently exist on GitHub Enterprise. Luckily the default is
                         // Owner and Collaborator, which is what we need in this case (we can simply pass null).
+                        // See https://platform.github.community/t/unable-to-fetch-users-repositories-by-organization-membership/7557/6
                         Repositories = viewer.Repositories(null, null, null, null, null, null, null, order, null, null)
                             .AllPages()
                             .Select(repositorySelection).ToList(),

--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -90,10 +90,6 @@ namespace GitHub.Services
                     .Select(viewer => new ViewerRepositoriesModel
                     {
                         Owner = viewer.Login,
-                        // We should pass affiliations and ownerAffiliations the same RepositoryAffiliation?[], but
-                        // ownerAffiliations doesn't currently exist on GitHub Enterprise. Luckily the default is
-                        // Owner and Collaborator, which is what we need in this case (we can simply pass null).
-                        // See https://platform.github.community/t/unable-to-fetch-users-repositories-by-organization-membership/7557/6
                         Repositories = viewer.Repositories(null, null, null, null, null, null, null, order, null, null)
                             .AllPages()
                             .Select(repositorySelection).ToList(),

--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -74,11 +74,6 @@ namespace GitHub.Services
                     Direction = OrderDirection.Desc
                 };
 
-                var affiliation = new RepositoryAffiliation?[]
-                {
-                    RepositoryAffiliation.Owner, RepositoryAffiliation.Collaborator
-                };
-
                 var repositorySelection = new Fragment<Repository, RepositoryListItemModel>(
                     "repository",
                     repo => new RepositoryListItemModel
@@ -95,7 +90,10 @@ namespace GitHub.Services
                     .Select(viewer => new ViewerRepositoriesModel
                     {
                         Owner = viewer.Login,
-                        Repositories = viewer.Repositories(null, null, null, null, affiliation, null, null, order, affiliation, null)
+                        // We should pass affiliations and ownerAffiliations the same RepositoryAffiliation?[], but
+                        // ownerAffiliations doesn't currently exist on GitHub Enterprise. Luckily the default is
+                        // Owner and Collaborator, which is what we need in this case (we can simply pass null).
+                        Repositories = viewer.Repositories(null, null, null, null, null, null, null, order, null, null)
                             .AllPages()
                             .Select(repositorySelection).ToList(),
                         ContributedToRepositories = viewer.RepositoriesContributedTo(100, null, null, null, null, null, null, order, null)


### PR DESCRIPTION
### What this PR does

We should pass `affiliations` and `ownerAffiliations` the same `RepositoryAffiliation?[]`, but `ownerAffiliations` doesn't currently exist on GitHub Enterprise. Luckily the default is `Owner` and `Collaborator`, which is what we need in this case (we can simply pass `null`).

### How to test

1. Select `Open > Open from GitHub...`
2. Click on `Enterprise` tab
3. Expect repositories to appear

### Related

- Explanation of `affiliations` and `ownerAffiliations`
 https://platform.github.community/t/unable-to-fetch-users-repositories-by-organization-membership/7557/6

Fixes #2162 
