### PR TITLE
Fix AvailableForComment calculation.

### DIFF
--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
@@ -197,7 +197,7 @@ namespace GitHub.InlineReviews.ViewModels
             AvailableForComment =
                 file.Diff.Any(chunk => chunk.Lines
                     .Any(line => leftBuffer ?
-                        line.OldLineNumber -1 == lineNumber :
+                        line.OldLineNumber - 1 == lineNumber :
                         line.NewLineNumber - 1 == lineNumber));
 
             var thread = file.InlineCommentThreads?.FirstOrDefault(x =>

--- a/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/InlineCommentPeekViewModel.cs
@@ -196,7 +196,9 @@ namespace GitHub.InlineReviews.ViewModels
 
             AvailableForComment =
                 file.Diff.Any(chunk => chunk.Lines
-                    .Any(line => line.NewLineNumber - 1 == lineNumber));
+                    .Any(line => leftBuffer ?
+                        line.OldLineNumber -1 == lineNumber :
+                        line.NewLineNumber - 1 == lineNumber));
 
             var thread = file.InlineCommentThreads?.FirstOrDefault(x =>
                 x.LineNumber == lineNumber &&


### PR DESCRIPTION
When showing a comment peek view on the LHS of the diff view, we need to look at `OldLineNumber` instead of `NewLineNumber` to calculate `AvailableForComment`.

Fixes #2166