### PR TITLE
Fix broken Browser service.

### DIFF
--- a/src/GitHub.VisualStudio/Helpers/Browser.cs
+++ b/src/GitHub.VisualStudio/Helpers/Browser.cs
@@ -44,7 +44,7 @@ namespace GitHub.VisualStudio.Helpers
                 int result = ErrorHandler.CallWithCOMConvention(() =>
                 {
                     ThreadHelper.ThrowIfNotOnUIThread();
-                    service.CreateExternalWebBrowser((uint)createFlags, resolution, uri.AbsoluteUri);
+                    return service.CreateExternalWebBrowser((uint)createFlags, resolution, uri.AbsoluteUri);
                 });
 
                 if (ErrorHandler.Succeeded(result))


### PR DESCRIPTION
[`ba8382400c4eb50039e12abf39550b23fe6e0233`](https://github.com/github/VisualStudio/commit/ba8382400c4eb50039e12abf39550b23fe6e0233#diff-9a66fa71ef943ce3fa2c93bd35840156R44) changed `Browser.cs` to add a call to `ThreadHelper.ThrowIfNotOnUIThread();`. However it _also_ erroneously changed the code to not return the result of `service.CreateExternalWebBrowser` to the caller, breaking the browser on VS2015.