### PR TITLE
Don't send duplicate comment body.

### DIFF
--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -649,7 +649,6 @@ namespace GitHub.InlineReviews.Services
 
             var addReview = new AddPullRequestReviewInput
             {
-                Body = body,
                 CommitOID = commitId,
                 Event = Octokit.GraphQL.Model.PullRequestReviewEvent.Comment,
                 PullRequestId = new ID(pullRequestId),


### PR DESCRIPTION
When adding a PR review comment, don't send the `body` twice, as it causes the body to be repeated in the comment itself and the containing review.

Fixes #2170