### PR TITLE
Fix displaying errors in GitHub pane.

### DIFF
--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/GitHubPaneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/GitHubPaneView.xaml
@@ -43,6 +43,7 @@
     <uic:InfoPanel x:Name="infoPanel"
                    DockPanel.Dock="Top"
                    Message="{Binding Message}"
+                   ShowCloseButton="True"
                    VerticalAlignment="Top"/>
     <StackPanel DockPanel.Dock="Top"
                 Margin="6,9,9,5"

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/GitHubPaneView.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/GitHubPaneView.xaml.cs
@@ -27,7 +27,6 @@ namespace GitHub.VisualStudio.Views.GitHubPane
 
             this.WhenActivated(d =>
             {
-                infoPanel.Visibility = Visibility.Collapsed;
                 d(notifications.Listen()
                     .ObserveOnDispatcher(DispatcherPriority.Normal)
                     .Subscribe(n =>


### PR DESCRIPTION
https://github.com/github/VisualStudio/pull/1787 refactored `InfoPanel` but didn't update `GitHubPaneView` with its new behavior. So:

- Don't initially set `infoPanel.Visibility` to `Collapsed`: `InfoPanel` will handle this itself
- Set `ShowCloseButton` to show the `x` button to close the error

Fixes #2172
Related #2058