### PR TITLE
Stop A/B testing the clone dialog

### DIFF
--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositoryCloneViewModel.cs
@@ -137,8 +137,8 @@ namespace GitHub.ViewModels.Dialog.Clone
 
             this.WhenAnyValue(x => x.SelectedTabIndex).Subscribe(x => tabs[x].Activate().Forget());
 
-            // When a clipboard URL has been set or a user is in group A, show the URL tab by default
-            if (!string.IsNullOrEmpty(UrlTab.Url) || await IsGroupA().ConfigureAwait(false))
+            // When a clipboard URL has been set, show the URL tab by default
+            if (!string.IsNullOrEmpty(UrlTab.Url))
             {
                 SelectedTabIndex = 2;
             }
@@ -155,14 +155,6 @@ namespace GitHub.ViewModels.Dialog.Clone
                     usageTracker.IncrementCounter(model => model.NumberOfCloneViewUrlTab).Forget();
                     break;
             }
-        }
-
-        // Put 50% of users in group A
-        async Task<bool> IsGroupA()
-        {
-            var userGuid = await usageService.GetUserGuid().ConfigureAwait(false);
-            var lastByte = userGuid.ToByteArray().Last();
-            return lastByte % 2 == 0;
         }
 
         void BrowseForDirectory()

--- a/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
+++ b/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
@@ -37,8 +37,8 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
 
         [TestCase("https://github.com", null, false, 0)]
         [TestCase("https://enterprise.com", null, false, 1)]
-        [TestCase("https://github.com", null, true, 2, Description = "Show URL tab for GitHub connections")]
-        [TestCase("https://enterprise.com", null, true, 2, Description = "Show URL tab for Enterprise connections")]
+        [TestCase("https://github.com", null, true, 0, Description = "Show URL tab for GitHub connections")]
+        [TestCase("https://enterprise.com", null, true, 1, Description = "Show URL tab for Enterprise connections")]
         [TestCase("https://github.com", "https://github.com/github/visualstudio", false, 2)]
         [TestCase("https://enterprise.com", "https://enterprise.com/owner/repo", false, 2)]
         public async Task Default_SelectedTabIndex_For_Group(string address, string clipboardUrl, bool isGroupA, int expectTabIndex)
@@ -56,8 +56,8 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
 
         [TestCase("https://github.com", false, 1, nameof(UsageModel.MeasuresModel.NumberOfCloneViewGitHubTab))]
         [TestCase("https://enterprise.com", false, 1, nameof(UsageModel.MeasuresModel.NumberOfCloneViewEnterpriseTab))]
-        [TestCase("https://github.com", true, 1, nameof(UsageModel.MeasuresModel.NumberOfCloneViewUrlTab))]
-        [TestCase("https://enterprise.com", true, 1, nameof(UsageModel.MeasuresModel.NumberOfCloneViewUrlTab))]
+        [TestCase("https://github.com", true, 1, nameof(UsageModel.MeasuresModel.NumberOfCloneViewGitHubTab))]
+        [TestCase("https://enterprise.com", true, 1, nameof(UsageModel.MeasuresModel.NumberOfCloneViewEnterpriseTab))]
         public async Task IncrementCounter_Showing_Default_Tab(string address, bool isGroupA, int numberOfCalls, string counterName)
         {
             var cm = CreateConnectionManager(address);


### PR DESCRIPTION
## What this PR does

Always show the GitHub/Enterprise pane unless a URL has been specified.

### How to test

1. Change the last digit of `UserGuid` to be either odd or even (found here `\Users\<USER>\AppData\Local\GìtHūbVisualStudio\user.json`)
2. `File > Open > Open from GitHub`
3. The `GitHub` (or `Enterprise`) tab should start off selected

Note, if there is a URL in the clipboard the URL tab will be selected.