### PR TITLE
Only auto-fill clone URL for supported link types

### DIFF
--- a/src/GitHub.App/Services/DialogService.cs
+++ b/src/GitHub.App/Services/DialogService.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using GitHub.Api;
+using GitHub.Exports;
 using GitHub.Extensions;
 using GitHub.Factories;
 using GitHub.Models;
@@ -38,7 +39,13 @@ namespace GitHub.Services
             if (string.IsNullOrEmpty(url))
             {
                 var clipboardContext = gitHubContextService.FindContextFromClipboard();
-                url = clipboardContext?.Url;
+                switch (clipboardContext?.LinkType)
+                {
+                    case LinkType.Blob:
+                    case LinkType.Repository:
+                        url = clipboardContext?.Url;
+                        break;
+                }
             }
 
             var viewModel = factory.CreateViewModel<IRepositoryCloneViewModel>();

--- a/src/GitHub.App/Services/GitHubContextService.cs
+++ b/src/GitHub.App/Services/GitHubContextService.cs
@@ -124,7 +124,15 @@ namespace GitHub.Services
                 Url = uri
             };
 
-            var repositoryPrefix = uri.ToRepositoryUrl().ToString() + "/";
+            var repositoryUrl = uri.ToRepositoryUrl().ToString();
+            if (string.Equals(url, repositoryUrl, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(url, repositoryUrl + ".git", StringComparison.OrdinalIgnoreCase))
+            {
+                context.LinkType = LinkType.Repository;
+                return context;
+            }
+
+            var repositoryPrefix = repositoryUrl + "/";
             if (!url.StartsWith(repositoryPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return context;

--- a/src/GitHub.App/Services/GitHubContextService.cs
+++ b/src/GitHub.App/Services/GitHubContextService.cs
@@ -124,6 +124,18 @@ namespace GitHub.Services
                 Url = uri
             };
 
+            if (uri.Owner == null)
+            {
+                context.LinkType = LinkType.Unknown;
+                return context;
+            }
+
+            if (uri.RepositoryName == null)
+            {
+                context.LinkType = LinkType.Unknown;
+                return context;
+            }
+
             var repositoryUrl = uri.ToRepositoryUrl().ToString();
             if (string.Equals(url, repositoryUrl, StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(url, repositoryUrl + ".git", StringComparison.OrdinalIgnoreCase))

--- a/src/GitHub.Exports/Exports/ExportMetadata.cs
+++ b/src/GitHub.Exports/Exports/ExportMetadata.cs
@@ -21,7 +21,8 @@ namespace GitHub.Exports
     {
         Unknown,
         Blob,
-        Blame
+        Blame,
+        Repository
     }
 
     /// <summary>

--- a/test/GitHub.App.UnitTests/Services/GitHubContextServiceTests.cs
+++ b/test/GitHub.App.UnitTests/Services/GitHubContextServiceTests.cs
@@ -133,6 +133,9 @@ public class GitHubContextServiceTests
             Assert.That(context.Url?.ToString(), Is.EqualTo(expectUrl));
         }
 
+        [TestCase("https://github.com/github/VisualStudio", LinkType.Repository)]
+        [TestCase("https://github.com/github/VisualStudio.git", LinkType.Repository)]
+        [TestCase("https://github.com/github/VisualStudio/unknown/master/README.md", LinkType.Unknown)]
         [TestCase("https://github.com/github/VisualStudio/blob/master/README.md", LinkType.Blob)]
         [TestCase("https://github.com/github/VisualStudio/unknown/master/README.md", LinkType.Unknown)]
         public void LinkType_EqualTo(string url, LinkType expectLinkType)

--- a/test/GitHub.App.UnitTests/Services/GitHubContextServiceTests.cs
+++ b/test/GitHub.App.UnitTests/Services/GitHubContextServiceTests.cs
@@ -137,6 +137,8 @@ public class GitHubContextServiceTests
         [TestCase("https://github.com/github/VisualStudio.git", LinkType.Repository)]
         [TestCase("https://github.com/github/VisualStudio/unknown/master/README.md", LinkType.Unknown)]
         [TestCase("https://github.com/github/VisualStudio/blob/master/README.md", LinkType.Blob)]
+        [TestCase("https://github.com", LinkType.Unknown)]
+        [TestCase("https://github.com/github", LinkType.Unknown)]
         [TestCase("https://github.com/github/VisualStudio/unknown/master/README.md", LinkType.Unknown)]
         public void LinkType_EqualTo(string url, LinkType expectLinkType)
         {


### PR DESCRIPTION
The current implementation of Open from GitHub will automatically select the `URL` tab and fill the text box when the clipboard contains a URL. This is overly eager and will trigger for non-repository URLs

### What this PR does

- Add a `Repository` to `LinkType` enum
- Update `GitHubContextService` to know about `LinkType.Repository` URLs
- Only automatically select `URL` tab for supported link types (currently `Repository` and `Blob`)

### How to test

1. Select `File > Open > Open from GitHub...` with any of the following
```
https://github.com/github/VisualStudio
https://github.com/github/VisualStudio.git
https://github.com/github/VisualStudio/blob/master/src/GitHub.VisualStudio/GitHubPackage.cs
```
2. The `Open from GitHub` dialog should appear with `URL` tab selected and field filled
3. Select `File > Open > Open from GitHub...` with any of the following
```
https://github.com
https://github.com/github
https://github.com/github/VisualStudio/commit/285c6649f319bd822c8d4cc283f869aeac33fd7d
```
4. The `Open from GitHub` dialog should appear with `GitHub` tab selected

Fixes #2176