### PR TITLE
Ensure we only reference System.Net.Http v4.0.0.0

### DIFF
--- a/test/GitHub.VisualStudio.UnitTests/GitHub.VisualStudio.UnitTests.csproj
+++ b/test/GitHub.VisualStudio.UnitTests/GitHub.VisualStudio.UnitTests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Codecov" Version="1.1.0" />
     <PackageReference Include="Madskristensen.VisualStudio.SDK" Version="14.3.75-pre" />
+    <PackageReference Include="NCrunch.Framework" Version="3.17.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="NUnit" version="3.9.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />

--- a/test/GitHub.VisualStudio.UnitTests/GitHubAssemblyTests.cs
+++ b/test/GitHub.VisualStudio.UnitTests/GitHubAssemblyTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Reflection;
 using NUnit.Framework;
 
@@ -12,6 +13,19 @@ public class GitHubAssemblyTests
         {
             Assert.That(referencedAssembly.Name, Does.Not.EndWith(".DesignTime"),
                 "DesignTime assemblies should be embedded not referenced");
+        }
+    }
+
+    [Theory]
+    public void GitHub_Assembly_Should_Not_Reference_System_Net_Http_Above_4_0(string assemblyFile)
+    {
+        var asm = Assembly.LoadFrom(assemblyFile);
+        foreach (var referencedAssembly in asm.GetReferencedAssemblies())
+        {
+            if (referencedAssembly.Name == "System.Net.Http")
+            {
+                Assert.That(referencedAssembly.Version, Is.EqualTo(new Version("4.0.0.0")));
+            }
         }
     }
 

--- a/test/GitHub.VisualStudio.UnitTests/GitHubAssemblyTests.cs
+++ b/test/GitHub.VisualStudio.UnitTests/GitHubAssemblyTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using NCrunch.Framework;
 using NUnit.Framework;
 
 public class GitHubAssemblyTests
@@ -30,7 +32,20 @@ public class GitHubAssemblyTests
     }
 
     [DatapointSource]
-    string[] GitHubAssemblies => Directory.GetFiles(AssemblyDirectory, "GitHub.*.dll");
+    string[] GetGitHubAssemblies()
+    {
+        var prefix = "GitHub.";
+        if (NCrunchEnvironment.NCrunchIsResident())
+        {
+            return NCrunchEnvironment.GetAllAssemblyLocations()
+                .Where(p => Path.GetFileName(p).StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+        else
+        {
+            var dir = Path.GetDirectoryName(GetType().Assembly.Location);
+            return Directory.GetFiles(dir, $"{prefix}*.dll");
+        }
+    }
 
-    string AssemblyDirectory => Path.GetDirectoryName(GetType().Assembly.Location);
 }


### PR DESCRIPTION
NOTE: Can't use extension when only .NET 4.7 or below is installed

### What happended

When we changed to include the `Octokit.GraphQL` repository as a submodule in #2127 and reference its projects (rather than referencing it as a NugGet package), this had the unintended consequence of changing which version of `System.Net.Http` any consuming projects referenced.

For users who have a new version of .NET installed this didn't break anything because there is an automatic binding direct from `System.Net.Http, v4.1.1.0` to `System.Net.Http, v4.0.0.0`. Unfortunately users with an older version of .NET installed would experience the following exception:
```
System.MissingMethodException: Method not found:
'System.Net.Http.HttpMessageHandler Octokit.Internal.HttpMessageHandlerFactory.CreateDefault()'.
at GitHub.Infrastructure.ExportedHttpClient..ctor()
```

### What this PR does

This PR ensures that we reference the `System.Net.Http, v4.0.0.0` assembly by changing the  `Octokit.GraphQL` projects to compile against .NET 4.6 rather than .NET Standard 1.1 as they were before. This is a simple fix that should allow us to get a patch release out ASAP.

- Add test to check that `GitHub.*` assemblies only reference `System.Net.Http, v4.0.0.0`
- Compile against .NET 4.6 version of `Octokit.GraphQL` and `Octokit.GraphQL.Core`

### How to test

- Check that .vsix doesn't contain a `System.Net.Http` assembly.

Here is a screenshot of the .vsix contents from this PR:
![image](https://user-images.githubusercontent.com/11719160/51541100-e5503780-1e4f-11e9-8494-4eb363a89d43.png)

### More detail

On recent versions of .NET there is an automatic redirect from  `System.Net.Http, v4.1.1.0` to `v4.1.1.0`. Here is a binding log generated by `fuslogvw`:

![image](https://user-images.githubusercontent.com/11719160/51557533-168f2e80-1e75-11e9-8b96-37c53536f23a.png)

Attempting to load `System.Net.Http, v4.1.1.0` inside a docker image build from `microsoft/dotnet-framework:4.6.2-runtime` fails.

```
Step 20/23 : FROM microsoft/dotnet-framework:4.6.2-runtime AS runtime
 ---> 91af6975d04b
Step 21/23 : WORKDIR /app
 ---> Using cache
 ---> c3fc388c3cf6
Step 22/23 : COPY --from=publish /app/dotnetapp/out ./
 ---> 405821dc4a0d
Step 23/23 : ENTRYPOINT ["dotnetapp.exe"]
 ---> Running in 00c145e35a59
Removing intermediate container 00c145e35a59
 ---> 9f064e8ae099
Successfully built 9f064e8ae099
Successfully tagged foo3:latest
C:\Source\github.com\Microsoft\dotnet-framework-docker\samples\dotnetapp [master ≡ +0 ~4 -0 !]> docker run foo3
Attempting to load: System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
```

I don't know when exactly this redirect was put in place, but it was somewhere between .NET 4.6.2 and .NET 4.7.2.

Fixes #2190
Fixes #2188
Fixes #2186
Fixes #2185 
Fixes #2195 