### PR TITLE
Ensure that clone from Start Page shows progress status bar

### DIFF
--- a/src/GitHub.App/Services/RepositoryCloneService.cs
+++ b/src/GitHub.App/Services/RepositoryCloneService.cs
@@ -114,7 +114,8 @@ namespace GitHub.Services
         /// <inheritdoc/>
         public async Task CloneOrOpenRepository(
             CloneDialogResult cloneDialogResult,
-            object progress = null)
+            object progress = null,
+            CancellationToken? cancellationToken = null)
         {
             Guard.ArgumentNotNull(cloneDialogResult, nameof(cloneDialogResult));
 
@@ -147,7 +148,7 @@ namespace GitHub.Services
             else
             {
                 var cloneUrl = repositoryUrl.ToString();
-                await CloneRepository(cloneUrl, repositoryPath, progress).ConfigureAwait(true);
+                await CloneRepository(cloneUrl, repositoryPath, progress, cancellationToken).ConfigureAwait(true);
 
                 if (isDotCom)
                 {
@@ -197,7 +198,8 @@ namespace GitHub.Services
         public async Task CloneRepository(
             string cloneUrl,
             string repositoryPath,
-            object progress = null)
+            object progress = null,
+            CancellationToken? cancellationToken = null)
         {
             Guard.ArgumentNotEmptyString(cloneUrl, nameof(cloneUrl));
             Guard.ArgumentNotEmptyString(repositoryPath, nameof(repositoryPath));
@@ -210,7 +212,7 @@ namespace GitHub.Services
 
             try
             {
-                await vsGitServices.Clone(cloneUrl, repositoryPath, true, progress);
+                await vsGitServices.Clone(cloneUrl, repositoryPath, true, progress, cancellationToken);
                 await usageTracker.IncrementCounter(x => x.NumberOfClones);
 
                 if (repositoryPath.StartsWith(DefaultClonePath, StringComparison.OrdinalIgnoreCase))

--- a/src/GitHub.Exports.Reactive/Services/IRepositoryCloneService.cs
+++ b/src/GitHub.Exports.Reactive/Services/IRepositoryCloneService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using GitHub.Models;
 using GitHub.Primitives;
@@ -27,11 +26,13 @@ namespace GitHub.Services
         /// System.IProgress&lt;Microsoft.VisualStudio.Shell.ServiceProgressData&gt;, but
         /// as that type is only available in VS2017+ it is typed as <see cref="object"/> here.
         /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns></returns>
         Task CloneRepository(
             string cloneUrl,
             string repositoryPath,
-            object progress = null);
+            object progress = null,
+            CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// Clones the specified repository into the specified directory or opens it if the directory already exists.
@@ -45,7 +46,8 @@ namespace GitHub.Services
         /// <returns></returns>
         Task CloneOrOpenRepository(
             CloneDialogResult cloneDialogResult,
-            object progress = null);
+            object progress = null,
+            CancellationToken? cancellationToken = null);
 
         /// <summary>
         /// Checks whether the specified destination directory already exists.

--- a/src/GitHub.Exports/Services/IVSGitServices.cs
+++ b/src/GitHub.Exports/Services/IVSGitServices.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using GitHub.Models;
 
@@ -20,13 +21,15 @@ namespace GitHub.Services
         /// System.IProgress&lt;Microsoft.VisualStudio.Shell.ServiceProgressData&gt;, but
         /// as that type is only available in VS2017+ it is typed as <see cref="object"/> here.
         /// </param>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <seealso cref="System.IProgress{T}"/>
         /// <seealso cref="Microsoft.VisualStudio.Shell.ServiceProgressData"/>
         Task Clone(
             string cloneUrl,
             string clonePath,
             bool recurseSubmodules,
-            object progress = null);
+            object progress = null,
+            CancellationToken? cancellationToken = null);
 
         string GetActiveRepoPath();
         LibGit2Sharp.IRepository GetActiveRepo();

--- a/src/GitHub.StartPage/StartPagePackage.cs
+++ b/src/GitHub.StartPage/StartPagePackage.cs
@@ -57,7 +57,7 @@ namespace GitHub.StartPage
             try
             {
                 var uiProvider = await Task.Run(() => Package.GetGlobalService(typeof(IGitHubServiceProvider)) as IGitHubServiceProvider);
-                request = await ShowCloneDialog(uiProvider, downloadProgress, repository);
+                request = await ShowCloneDialog(uiProvider, downloadProgress, cancellationToken, repository);
             }
             catch (Exception e)
             {
@@ -84,6 +84,7 @@ namespace GitHub.StartPage
         async Task<CloneDialogResult> ShowCloneDialog(
             IGitHubServiceProvider gitHubServiceProvider,
             IProgress<ServiceProgressData> progress,
+            CancellationToken cancellationToken,
             RepositoryModel repository = null)
         {
             var dialogService = gitHubServiceProvider.GetService<IDialogService>();
@@ -110,7 +111,7 @@ namespace GitHub.StartPage
             {
                 try
                 {
-                    await cloneService.CloneOrOpenRepository(result, progress);
+                    await cloneService.CloneOrOpenRepository(result, progress, cancellationToken);
                     usageTracker.IncrementCounter(x => x.NumberOfStartPageClones).Forget();
                 }
                 catch

--- a/src/GitHub.StartPage/StartPagePackage.cs
+++ b/src/GitHub.StartPage/StartPagePackage.cs
@@ -81,7 +81,7 @@ namespace GitHub.StartPage
                 lastAccessed: DateTimeOffset.UtcNow);
         }
 
-        async Task<CloneDialogResult> ShowCloneDialog(
+        static async Task<CloneDialogResult> ShowCloneDialog(
             IGitHubServiceProvider gitHubServiceProvider,
             IProgress<ServiceProgressData> progress,
             CancellationToken cancellationToken,

--- a/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.ComponentModel.Composition;
@@ -74,7 +75,8 @@ namespace GitHub.Services
             string cloneUrl,
             string clonePath,
             bool recurseSubmodules,
-            object progress = null)
+            object progress = null,
+            CancellationToken? cancellationToken = null)
         {
             var teamExplorer = serviceProvider.TryGetService<ITeamExplorer>();
             Assumes.Present(teamExplorer);
@@ -84,13 +86,13 @@ namespace GitHub.Services
             NavigateToHomePage(teamExplorer); // Show progress on Team Explorer - Home
             await WaitForCloneOnHomePageAsync(teamExplorer);
 #elif TEAMEXPLORER15 || TEAMEXPLORER16
-            // The ServiceProgressData type is in a Visual Studio 2019 assembly that we don't currently have access to.
-            // Using reflection to call the CloneAsync in order to avoid conflicts with the Visual Studio 2017 version.
-            // Progress won't be displayed on the status bar, but it appears prominently on the Team Explorer Home view.
+            // The progress parameter uses the ServiceProgressData type which is defined in
+            // Microsoft.VisualStudio.Shell.Framework. Referencing this assembly directly
+            // would cause type conflicts, so we're using reflection to call CloneAsync.
             var gitExt = serviceProvider.GetService<IGitActionsExt>();
             var cloneAsyncMethod = typeof(IGitActionsExt).GetMethod(nameof(IGitActionsExt.CloneAsync));
             Assumes.NotNull(cloneAsyncMethod);
-            var cloneParameters = new object[] { cloneUrl, clonePath, recurseSubmodules, null, null };
+            var cloneParameters = new object[] { cloneUrl, clonePath, recurseSubmodules, cancellationToken, progress };
             var cloneTask = (Task)cloneAsyncMethod.Invoke(gitExt, cloneParameters);
 
             NavigateToHomePage(teamExplorer); // Show progress on Team Explorer - Home


### PR DESCRIPTION
You can find a VSIX installer for this PR here:
https://ci.appveyor.com/api/buildjobs/cm5ipkqbus5g6ca0/artifacts/2.8.0.6611%2FGitHub.VisualStudio.vsix

### What this PR does

Ensure that `cancellationToken` and `progress` arguments are propagated to the `CloneAsync`. This will make clone progress appear on the status bar when initiated via the Start Page (or Get to Code).

### How to test

1. Click the `GitHub` button on the Start Page

![image](https://user-images.githubusercontent.com/11719160/51717741-fe1c4100-2039-11e9-9427-dd02c938034a.png)

2. Select a repository and click `Clone`

![image](https://user-images.githubusercontent.com/11719160/51717794-49ceea80-203a-11e9-82c8-5eda559373df.png)

3. Check progress appears on the status bar

![image](https://user-images.githubusercontent.com/11719160/51717700-cdd4a280-2039-11e9-9609-e3270a0605e6.png)

Fixes #2196