### PR TITLE
Replace dormant IRC link with follow on Twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Official builds of this extension are available at [the official website](https:
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/github-visual-studio/localized.svg)](https://crowdin.com/project/github-visual-studio)
 [![codecov](https://codecov.io/gh/GitHub/VisualStudio/branch/master/graph/badge.svg)](https://codecov.io/gh/GitHub/VisualStudio)
 
-[![Join the chat at freenode:github-vs](https://img.shields.io/badge/irc-freenode:%20%23github--vs-blue.svg)](http://webchat.freenode.net/?channels=%23github-vs) [![Join the chat at https://gitter.im/github/VisualStudio](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/github/VisualStudio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Follow GitHub for Visual Studio](https://img.shields.io/twitter/follow/GitHubVS.svg?style=social "Follow GitHubVS")](https://twitter.com/githubvs?ref_src=twsrc%5Etfw) [![Join the chat at https://gitter.im/github/VisualStudio](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/github/VisualStudio?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Documentation
 Visit the [documentation](https://github.com/github/VisualStudio/tree/master/docs) for details on how to use the features in the GitHub Extension for Visual Studio.


### PR DESCRIPTION
Add a link to follow @GitHubVS on Twitter.

_It looks like some cheeky person has taken @GitHubVS on GitHub._

### How to test

1. Click Files changed then `View file`
2. You should see the following in the `README.md`
![image](https://user-images.githubusercontent.com/11719160/51737622-f930af00-2084-11e9-88ac-29935645f2b9.png)
3. Check that Twitter link points to GitHubVS account
4. Ideally use an account that isn't already following `@GitHubVS`

### Questions

- Is the link okay here or should we put it somewhere more prominent?
- AFAIK no one used the Freenode IRC, I'm assuming it's okay to replace?