### PR TITLE
Consolidating PullRequestStatusCircle change handlers

### DIFF
--- a/src/GitHub.VisualStudio.UI/UI/Controls/PullRequestStatusCircle.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/PullRequestStatusCircle.xaml.cs
@@ -23,50 +23,31 @@ namespace GitHub.VisualStudio.UI.Controls
     {
         public static readonly DependencyProperty ErrorCountProperty = DependencyProperty.Register(
             "ErrorCount", typeof(int), typeof(PullRequestStatusCircle),
-            new PropertyMetadata(0, OnErrorCountChanged));
-
-        private static void OnErrorCountChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
-        {
-            var pullRequestStatusCircle = ((PullRequestStatusCircle)dependencyObject);
-            pullRequestStatusCircle.GeneratePolygons();
-        }
+            new PropertyMetadata(0, GeneratePolygons));
 
         public static readonly DependencyProperty SuccessCountProperty = DependencyProperty.Register(
             "SuccessCount", typeof(int), typeof(PullRequestStatusCircle),
-            new PropertyMetadata(0, OnSuccessCountChanged));
-
-        private static void OnSuccessCountChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
-        {
-            var pullRequestStatusCircle = ((PullRequestStatusCircle)dependencyObject);
-            pullRequestStatusCircle.GeneratePolygons();
-        }
+            new PropertyMetadata(0, GeneratePolygons));
 
         public static readonly DependencyProperty PendingCountProperty = DependencyProperty.Register(
             "PendingCount", typeof(int), typeof(PullRequestStatusCircle),
-            new PropertyMetadata(0, OnPendingCountChanged));
+            new PropertyMetadata(0, GeneratePolygons));
 
-        private static void OnPendingCountChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
+        private static void GeneratePolygons(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
         {
-            var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
+            var pullRequestStatusCircle = ((PullRequestStatusCircle)dependencyObject);
             pullRequestStatusCircle.GeneratePolygons();
         }
 
         public static readonly DependencyProperty RadiusProperty = DependencyProperty.Register(
             "Radius", typeof(double), typeof(PullRequestStatusCircle),
-            new PropertyMetadata((double)250, OnRadiusChanged));
-
-        private static void OnRadiusChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
-        {
-            var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
-            pullRequestStatusCircle.GenerateMask();
-            pullRequestStatusCircle.GeneratePolygons();
-        }
+            new PropertyMetadata((double)250, GenerateMaskAndPolygons));
 
         public static readonly DependencyProperty InnerRadiusProperty = DependencyProperty.Register(
             "InnerRadius", typeof(double), typeof(PullRequestStatusCircle),
-            new PropertyMetadata((double)200, OnInnerRadiusChanged));
+            new PropertyMetadata((double)200, GenerateMaskAndPolygons));
 
-        private static void OnInnerRadiusChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
+        private static void GenerateMaskAndPolygons(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
             pullRequestStatusCircle.GenerateMask();
@@ -80,8 +61,7 @@ namespace GitHub.VisualStudio.UI.Controls
         private static void OnPendingColorChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
-            var brush = (Brush) eventArgs.NewValue;
-            pullRequestStatusCircle.PendingPolygon.Fill = brush;
+            pullRequestStatusCircle.PendingPolygon.Fill = (Brush) eventArgs.NewValue;
         }
 
         public static readonly DependencyProperty ErrorColorProperty = DependencyProperty.Register(
@@ -91,8 +71,7 @@ namespace GitHub.VisualStudio.UI.Controls
         private static void OnErrorColorChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
-            var brush = (Brush) eventArgs.NewValue;
-            pullRequestStatusCircle.ErrorPolygon.Fill = brush;
+            pullRequestStatusCircle.ErrorPolygon.Fill = (Brush) eventArgs.NewValue;
         }
 
         public static readonly DependencyProperty SuccessColorProperty = DependencyProperty.Register(
@@ -102,8 +81,7 @@ namespace GitHub.VisualStudio.UI.Controls
         private static void OnSuccessColorChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
-            var brush = (Brush) eventArgs.NewValue;
-            pullRequestStatusCircle.SuccessPolygon.Fill = brush;
+            pullRequestStatusCircle.SuccessPolygon.Fill = (Brush) eventArgs.NewValue;
         }
 
         public IEnumerable<Point> GeneratePoints(float percentage)

--- a/src/GitHub.VisualStudio.UI/UI/Controls/PullRequestStatusCircle.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/UI/Controls/PullRequestStatusCircle.xaml.cs
@@ -28,7 +28,6 @@ namespace GitHub.VisualStudio.UI.Controls
         private static void OnErrorCountChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle)dependencyObject);
-            pullRequestStatusCircle.ErrorCount = (int)eventArgs.NewValue;
             pullRequestStatusCircle.GeneratePolygons();
         }
 
@@ -39,7 +38,6 @@ namespace GitHub.VisualStudio.UI.Controls
         private static void OnSuccessCountChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle)dependencyObject);
-            pullRequestStatusCircle.SuccessCount = (int)eventArgs.NewValue;
             pullRequestStatusCircle.GeneratePolygons();
         }
 
@@ -50,7 +48,6 @@ namespace GitHub.VisualStudio.UI.Controls
         private static void OnPendingCountChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
-            pullRequestStatusCircle.PendingCount = (int) eventArgs.NewValue;
             pullRequestStatusCircle.GeneratePolygons();
         }
 
@@ -61,7 +58,6 @@ namespace GitHub.VisualStudio.UI.Controls
         private static void OnRadiusChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
-            pullRequestStatusCircle.Radius = (double) eventArgs.NewValue;
             pullRequestStatusCircle.GenerateMask();
             pullRequestStatusCircle.GeneratePolygons();
         }
@@ -73,7 +69,6 @@ namespace GitHub.VisualStudio.UI.Controls
         private static void OnInnerRadiusChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
-            pullRequestStatusCircle.InnerRadius = (double) eventArgs.NewValue;
             pullRequestStatusCircle.GenerateMask();
             pullRequestStatusCircle.GeneratePolygons();
         }
@@ -86,7 +81,6 @@ namespace GitHub.VisualStudio.UI.Controls
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
             var brush = (Brush) eventArgs.NewValue;
-            pullRequestStatusCircle.PendingColor = brush;
             pullRequestStatusCircle.PendingPolygon.Fill = brush;
         }
 
@@ -98,7 +92,6 @@ namespace GitHub.VisualStudio.UI.Controls
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
             var brush = (Brush) eventArgs.NewValue;
-            pullRequestStatusCircle.ErrorColor = brush;
             pullRequestStatusCircle.ErrorPolygon.Fill = brush;
         }
 
@@ -110,7 +103,6 @@ namespace GitHub.VisualStudio.UI.Controls
         {
             var pullRequestStatusCircle = ((PullRequestStatusCircle) dependencyObject);
             var brush = (Brush) eventArgs.NewValue;
-            pullRequestStatusCircle.SuccessColor = brush;
             pullRequestStatusCircle.SuccessPolygon.Fill = brush;
         }
 


### PR DESCRIPTION
After some conversation with @grokys I learned that I was using the change handlers incorrectly. I assumed the handler's purpose was to set the value on the instance, but I realize that the method is called after the value is already set on the instance. That allows the methods to be simpler.

Related to : #2145 