### PR TITLE
Enabling VS Installer packages in CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,25 @@
 os: Visual Studio 2017
 version: '2.6.0.{build}'
 skip_tags: true
+
+environment:
+  matrix:
+    - BUILD_TYPE: normal
+
 install:
 - ps: |
     $full_build = Test-Path env:GHFVS_KEY
+    $forVSInstaller = $env:BUILD_TYPE -eq "vsinstaller"
+    $package = $full_build -and ($env:APPVEYOR_PULL_REQUEST_NUMBER -or $env:APPVEYOR_REPO_BRANCH -eq "master" -or $forVSInstaller -or $env:BUILD_TYPE -eq "package")
+
+    $message = "Building "
+    if ($package) { $message += "and packaging "}
+    $message += "version " + $env:APPVEYOR_BUILD_NUMBER + " "
+
+    if ($full_build) { $message += "(full build)" } else { $message += "(partial build)" }
+    if ($forVSInstaller) { $message += " for the VS installer" }
+    Write-Host $message
+
     git submodule init
     git submodule sync
 
@@ -20,17 +36,30 @@ install:
     nuget restore GitHubVS.sln
 - choco install --no-progress BCC-MSBuildLog
 - choco install --no-progress BCC-Submission
+
 build_script:
-- ps: scripts\build.ps1 -AppVeyor -BuildNumber:$env:APPVEYOR_BUILD_NUMBER
+- ps: scripts\build.ps1 -AppVeyor -Package:$package -BuildNumber:$env:APPVEYOR_BUILD_NUMBER -ForVSInstaller:$forVSInstaller
 test:
   categories:
     except:
       - Timings
 on_success:
 - ps: |
-    if ($full_build) {
-      script\Sign-Package -AppVeyor
+    if ($package) {
+      Write-Host "Signing and packaging"
+      script\Sign-Package -AppVeyor -ForVSInstaller:$forVSInstaller
     }
+
 on_finish:
 - IF NOT "%BCC_TOKEN%x"=="x" BCCMSBuildLog --cloneRoot "%APPVEYOR_BUILD_FOLDER%" --input output.binlog --output checkrun.json --ownerRepo %APPVEYOR_REPO_NAME% --hash %APPVEYOR_REPO_COMMIT%
 - IF NOT "%BCC_TOKEN%x"=="x" BCCSubmission -h %APPVEYOR_REPO_COMMIT% -i checkrun.json -t %BCC_TOKEN%
+
+for:
+-
+  branches:
+    only:
+      - /releases/.*-vsinstaller/
+  environment:
+    matrix:
+      - BUILD_TYPE: vsinstaller
+      - BUILD_TYPE: package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ environment:
     - BUILD_TYPE: normal
 
 install:
+- choco install --no-progress BCC-MSBuildLog
+- choco install --no-progress BCC-Submission
 - ps: |
     $full_build = Test-Path env:GHFVS_KEY
     $forVSInstaller = $env:BUILD_TYPE -eq "vsinstaller"
@@ -37,10 +39,12 @@ install:
 
 build_script:
 - ps: scripts\build.ps1 -AppVeyor -Package:$package -BuildNumber:$env:APPVEYOR_BUILD_NUMBER -ForVSInstaller:$forVSInstaller
+
 test:
   categories:
     except:
       - Timings
+
 on_success:
 - ps: |
     if ($package) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,8 +34,6 @@ install:
 
     git submodule update --recursive --force
     nuget restore GitHubVS.sln
-- choco install --no-progress BCC-MSBuildLog
-- choco install --no-progress BCC-Submission
 
 build_script:
 - ps: scripts\build.ps1 -AppVeyor -Package:$package -BuildNumber:$env:APPVEYOR_BUILD_NUMBER -ForVSInstaller:$forVSInstaller
@@ -49,10 +47,6 @@ on_success:
       Write-Host "Signing and packaging"
       script\Sign-Package -AppVeyor -ForVSInstaller:$forVSInstaller
     }
-
-on_finish:
-- IF NOT "%BCC_TOKEN%x"=="x" BCCMSBuildLog --cloneRoot "%APPVEYOR_BUILD_FOLDER%" --input output.binlog --output checkrun.json --ownerRepo %APPVEYOR_REPO_NAME% --hash %APPVEYOR_REPO_COMMIT%
-- IF NOT "%BCC_TOKEN%x"=="x" BCCSubmission -h %APPVEYOR_REPO_COMMIT% -i checkrun.json -t %BCC_TOKEN%
 
 for:
 -

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -38,6 +38,10 @@ Param(
     ,
     [switch]
     $Trace = $false
+    ,
+    [switch]
+    $ForVSInstaller = $false
+
 )
 
 Set-StrictMode -Version Latest
@@ -53,19 +57,16 @@ Vsix | out-null
 
 Push-Location $rootDirectory
 
+if ($Package -and $BuildNumber -gt -1) {
+    $BumpVersion = $true
+}
+
 if ($UpdateSubmodules) {
     Update-Submodules
 }
 
 if ($Clean) {
 	Clean-WorkingTree
-}
-
-$fullBuild = Test-Path env:GHFVS_KEY
-$publishable = $fullBuild -and $AppVeyor -and ($env:APPVEYOR_PULL_REQUEST_NUMBER -or $env:APPVEYOR_REPO_BRANCH -eq "master")
-if ($publishable) { #forcing a deploy flag for CI
-    $Package = $true
-    $BumpVersion = $true
 }
 
 if ($BumpVersion) {
@@ -79,6 +80,6 @@ if ($Package) {
     Write-Output "Building GitHub for Visual Studio"
 }
 
-Build-Solution GitHubVs.sln "Build" $config -Deploy:$Package
+Build-Solution GitHubVs.sln "Build" $config -Deploy:$Package -ForVSInstaller:$ForVSInstaller
 
 Pop-Location

--- a/scripts/modules.ps1
+++ b/scripts/modules.ps1
@@ -114,7 +114,7 @@ New-Module -ScriptBlock {
         $msbuild
     }
 
-    function Build-Solution([string]$solution, [string]$target, [string]$configuration, [switch]$ForVSInstaller, [bool]$Deploy = $false) {
+    function Build-Solution([string]$solution, [string]$target, [string]$configuration, [switch]$ForVSInstaller = $false, [bool]$Deploy = $false) {
         $msbuild = Find-MSBuild
 
         Run-Command -Fatal { & $nuget restore $solution -NonInteractive -Verbosity detailed -MSBuildPath (Split-Path -parent $msbuild) }


### PR DESCRIPTION
This causes AppVeyor to run multiple build jobs on certain commits, creating packages for the marketplace and for the VS installer.

The following conditions apply:

- if the branch is **`master`** or the branch is named **`releases/*-vsinstaller`**:
  - a build job called `vsinstaller` will run, generating a vsix for the *VS Installer*
  - a build job called `package` will run, generating a vsix for the marketplace will be generated
- if CI runs because a PR has been created or updated:
  - a vsix for the marketplace will be generated
