### PR TITLE
Fix opening a /blob/ URL using combined repository list/URL clone dialog

### DIFF
--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
@@ -50,8 +50,7 @@ namespace GitHub.ViewModels.Dialog.Clone
 
             var filterRepository = this.WhenAnyValue(x => x.Filter)
                 .Select(f => gitHubContextService.FindContextFromUrl(f))
-                .Where(c => c?.LinkType == LinkType.Repository)
-                .Select(c => new RepositoryModel(c.RepositoryName, c.Url));
+                .Select(CreateRepository);
 
             repository = selectedRepository
                 .Merge(filterRepository)
@@ -197,6 +196,18 @@ namespace GitHub.ViewModels.Dialog.Clone
             return item != null ?
                 new RepositoryModel(item.Name, UriString.ToUriString(item.Url)) :
                 null;
+        }
+
+        RepositoryModel CreateRepository(GitHubContext context)
+        {
+            switch (context?.LinkType)
+            {
+                case LinkType.Repository:
+                case LinkType.Blob:
+                    return new RepositoryModel(context.RepositoryName, context.Url);
+            }
+
+            return null;
         }
     }
 }

--- a/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositorySelectViewModelTests.cs
+++ b/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositorySelectViewModelTests.cs
@@ -57,6 +57,8 @@ public class RepositorySelectViewModelTests
         [TestCase("filter", null)]
         [TestCase("https://github.com", null)]
         [TestCase("https://github.com/github/VisualStudio", "https://github.com/github/VisualStudio")]
+        [TestCase("https://github.com/github/VisualStudio/blob/master/README.md", "https://github.com/github/VisualStudio/blob/master/README.md")]
+        [TestCase("https://github.com/github/VisualStudio/pull/2208", null)]
         public void Set_Repository_When_Filter_Is_Url(string url, string expectUrl)
         {
             var expectCloneUrl = expectUrl != null ? new UriString(expectUrl) : null;
@@ -66,6 +68,24 @@ public class RepositorySelectViewModelTests
             var target = new RepositorySelectViewModel(repositoryCloneService, gitHubContextService);
 
             target.Filter = url;
+
+            Assert.That(target.Repository?.CloneUrl, Is.EqualTo(expectCloneUrl));
+        }
+
+        [TestCase("filter;https://github.com/github/VisualStudio", "https://github.com/github/VisualStudio")]
+        [TestCase("https://github.com/github/VisualStudio;filter", null)]
+        public void Change_Filters(string filters, string expectUrl)
+        {
+            var expectCloneUrl = expectUrl != null ? new UriString(expectUrl) : null;
+            var repositoryCloneService = CreateRepositoryCloneService();
+            var gitHubContextService = new GitHubContextService(Substitute.For<IGitHubServiceProvider>(),
+                Substitute.For<IGitService>(), Substitute.For<IVSServices>());
+            var target = new RepositorySelectViewModel(repositoryCloneService, gitHubContextService);
+
+            foreach (var filter in filters.Split(';'))
+            {
+                target.Filter = filter;
+            }
 
             Assert.That(target.Repository?.CloneUrl, Is.EqualTo(expectCloneUrl));
         }


### PR DESCRIPTION
### What this PR does

Entering a repository or /blob/ URL into the filter box should allow the repository to be cloned or opened.

- Light up `Clone` or `Open` button when a valid URL is entered into filter box
- Deactivate `Clone` and `Open` buttons when URL is no longer valid

### How to test

#### Allow /blob/ URLs

1. Open `Open from GitHub` dialog
2. Paste a blob URL into filter (e.g `https://github.com/github/VisualStudio/blob/master/README.md`)
3. `Clone` or `Open` button should activate

#### Deactivate buttons when URL is invalid

1. Open `Open from GitHub` dialog
2. Paste a repository URL into filter (e.g `https://github.com/foo/bar`)
3. `Clone` or `Open` button should activate
4. Delete the end of URL until it's no longer valid (e.g `https://github.com/foo/`)
5. `Clone` or `Open` button should become inactive
