### PR TITLE
Ensure that clone works when Visual Studio is first launched

### DIFF
--- a/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
@@ -88,24 +88,20 @@ namespace GitHub.Services
 #elif TEAMEXPLORER15 || TEAMEXPLORER16
             // IGitActionsExt is proffered by SccProviderPackage, but isn't advertised.
             // To ensure that getting IGitActionsExt doesn't return null, we first request the
-            // SccService which is advertised. This forces SccProviderPackage to load
+            // IGitExt service which is advertised. This forces SccProviderPackage to load
             // and proffer IGitActionsExt.
-            var gitSccServiceGuid = new Guid("28C35EB2-67EA-4C5F-B49D-DACF73A66989");
-            var gitSccServiceType = Type.GetTypeFromCLSID(gitSccServiceGuid);
-            var gitSccService = serviceProvider.GetService(gitSccServiceType);
-            if (gitSccService is null)
-            {
-                log.Warning("Couldn't find Git SccService with Guid {Guid}", gitSccServiceGuid);
-            }
+            var gitExt = serviceProvider.GetService(typeof(IGitExt));
+            Assumes.NotNull(gitExt);
+            var gitActionsExt = serviceProvider.GetService<IGitActionsExt>();
+            Assumes.NotNull(gitActionsExt);
 
             // The progress parameter uses the ServiceProgressData type which is defined in
             // Microsoft.VisualStudio.Shell.Framework. Referencing this assembly directly
             // would cause type conflicts, so we're using reflection to call CloneAsync.
-            var gitExt = serviceProvider.GetService<IGitActionsExt>();
             var cloneAsyncMethod = typeof(IGitActionsExt).GetMethod(nameof(IGitActionsExt.CloneAsync));
             Assumes.NotNull(cloneAsyncMethod);
             var cloneParameters = new object[] { cloneUrl, clonePath, recurseSubmodules, cancellationToken, progress };
-            var cloneTask = (Task)cloneAsyncMethod.Invoke(gitExt, cloneParameters);
+            var cloneTask = (Task)cloneAsyncMethod.Invoke(gitActionsExt, cloneParameters);
 
             NavigateToHomePage(teamExplorer); // Show progress on Team Explorer - Home
             await cloneTask;

--- a/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
+++ b/src/GitHub.TeamFoundation.14/Services/VSGitServices.cs
@@ -86,6 +86,18 @@ namespace GitHub.Services
             NavigateToHomePage(teamExplorer); // Show progress on Team Explorer - Home
             await WaitForCloneOnHomePageAsync(teamExplorer);
 #elif TEAMEXPLORER15 || TEAMEXPLORER16
+            // IGitActionsExt is proffered by SccProviderPackage, but isn't advertised.
+            // To ensure that getting IGitActionsExt doesn't return null, we first request the
+            // SccService which is advertised. This forces SccProviderPackage to load
+            // and proffer IGitActionsExt.
+            var gitSccServiceGuid = new Guid("28C35EB2-67EA-4C5F-B49D-DACF73A66989");
+            var gitSccServiceType = Type.GetTypeFromCLSID(gitSccServiceGuid);
+            var gitSccService = serviceProvider.GetService(gitSccServiceType);
+            if (gitSccService is null)
+            {
+                log.Warning("Couldn't find Git SccService with Guid {Guid}", gitSccServiceGuid);
+            }
+
             // The progress parameter uses the ServiceProgressData type which is defined in
             // Microsoft.VisualStudio.Shell.Framework. Referencing this assembly directly
             // would cause type conflicts, so we're using reflection to call CloneAsync.


### PR DESCRIPTION
### What this PR does

`IGitActionsExt` is proffered by `SccProviderPackage`, but isn't advertised. To ensure that getting `IGitActionsExt` doesn't return null, we first request the `IGitExt` which is advertised. This forces `SccProviderPackage` to load and proffer `IGitActionsExt`.

### How to test

Due to issues installing MEF components when testing using F5, I'd recomend installing [this](https://ci.appveyor.com/api/buildjobs/ob7b7uxgtgfgbakj/artifacts/2.8.0.6774%2FGitHub.VisualStudio.vsix) VSIX using [DogfoodVsix](https://marketplace.visualstudio.com/items?itemName=JamieCansdale.DogfoodVsix).

1. Open Visual Studio 2019 Preview 3
2. Select `Tools > Options...` and set `Current source control plug-in` to `None`.
![image](https://user-images.githubusercontent.com/11719160/52339253-84eef780-2a04-11e9-8268-e9acfd2c812a.png)
3. Close and relaunch Visual Studio
4. `Clone or check out code > GitHub`
5. Select and `Clone` a repository
6. The repository should clone

### To do

Unfortunately Team Explorer / GitHub for Visual Studio doesn't notice that a GitHub repository has been loaded and the `GitHub` section doesn't appear on the `Team Explorer - Home` page.

![image](https://user-images.githubusercontent.com/11719160/52340226-1cede080-2a07-11e9-82af-11518b3e7714.png)

At least the clone works and the banner will appear next time the solution is loaded or the current branch changes. I don't think this is a ship blocker. I'll work on a fix in another PR.

Fixes #2218 