### PR TITLE
Don't match host name when filtering repositories

### DIFF
--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
@@ -178,14 +178,21 @@ namespace GitHub.ViewModels.Dialog.Clone
         {
             if (obj is IRepositoryItemViewModel item && !string.IsNullOrWhiteSpace(Filter))
             {
-                var urlString = item.Url.ToString();
-                var urlStringWithGit = urlString + ".git";
-                var urlStringWithSlash = urlString + "/";
-                return
-                    item.Caption.Contains(Filter, StringComparison.CurrentCultureIgnoreCase) ||
-                    urlString.Contains(Filter, StringComparison.OrdinalIgnoreCase) ||
-                    urlStringWithGit.Contains(Filter, StringComparison.OrdinalIgnoreCase) ||
-                    urlStringWithSlash.Contains(Filter, StringComparison.OrdinalIgnoreCase);
+                if (new UriString(Filter).IsHypertextTransferProtocol)
+                {
+                    var urlString = item.Url.ToString();
+                    var urlStringWithGit = urlString + ".git";
+                    var urlStringWithSlash = urlString + "/";
+                    return
+                        urlString.Contains(Filter, StringComparison.OrdinalIgnoreCase) ||
+                        urlStringWithGit.Contains(Filter, StringComparison.OrdinalIgnoreCase) ||
+                        urlStringWithSlash.Contains(Filter, StringComparison.OrdinalIgnoreCase);
+                }
+                else
+                {
+                    return
+                        item.Caption.Contains(Filter, StringComparison.CurrentCultureIgnoreCase);
+                }
             }
 
             return true;

--- a/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositorySelectViewModelTests.cs
+++ b/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositorySelectViewModelTests.cs
@@ -26,6 +26,7 @@ public class RepositorySelectViewModelTests
         [TestCase("https://github.com/jcansdale/TestDriven.Net", "owner", "name", "https://github.com/jcansdale/TestDriven.Net-issues", 1)]
         [TestCase("https://github.com/owner/name/", "owner", "name", "https://github.com/owner/name", 1, Description = "Trailing slash")]
         [TestCase("https://github.com/owner/name.git", "owner", "name", "https://github.com/owner/name", 1, Description = "Trailing .git")]
+        [TestCase("github.com", "owner", "name", "https://github.com/owner/name", 0, Description = "Don't include host name in search")]
         public async Task Filter(string filter, string owner, string name, string url, int expectCount)
         {
             var contributedToRepositories = new[]


### PR DESCRIPTION
When `github` is entered into filter, repositories that have a host of `github.com` shouldn't be matched.

### What this PR does

- Test to check that host name isn't included in filter
- Filter repositories either by URL or caption (not both)

### How to test

1. Click `File > Open > Open from GitHub`
2. Enter `github` in the filter
3. Repository list should only show repositories with an owner/repo containing `github`

Fixes #2227