### PR TITLE
Add pull request comment count link and add back in description section

### DIFF
--- a/src/GitHub.App/ViewModels/Documents/PullRequestPageViewModel.cs
+++ b/src/GitHub.App/ViewModels/Documents/PullRequestPageViewModel.cs
@@ -23,6 +23,7 @@ namespace GitHub.ViewModels.Documents
         readonly IPullRequestService service;
         readonly IPullRequestSessionManager sessionManager;
         readonly ITeamExplorerServices teServices;
+        readonly IVisualStudioBrowser visualStudioBrowser;
         readonly IUsageTracker usageTracker;
         ActorModel currentUserModel;
         ReactiveList<IViewModel> timeline = new ReactiveList<IViewModel>();
@@ -37,22 +38,26 @@ namespace GitHub.ViewModels.Documents
             IPullRequestService service,
             IPullRequestSessionManager sessionManager,
             ITeamExplorerServices teServices,
+            IVisualStudioBrowser visualStudioBrowser,
             IUsageTracker usageTracker)
         {
             Guard.ArgumentNotNull(factory, nameof(factory));
             Guard.ArgumentNotNull(service, nameof(service));
             Guard.ArgumentNotNull(sessionManager, nameof(sessionManager));
+            Guard.ArgumentNotNull(visualStudioBrowser, nameof(visualStudioBrowser));
             Guard.ArgumentNotNull(teServices, nameof(teServices));
 
             this.factory = factory;
             this.service = service;
             this.sessionManager = sessionManager;
             this.teServices = teServices;
+            this.visualStudioBrowser = visualStudioBrowser;
             this.usageTracker = usageTracker;
 
             timeline.ItemsRemoved.Subscribe(TimelineItemRemoved);
 
             ShowCommit = ReactiveCommand.CreateFromTask<string>(DoShowCommit);
+            OpenOnGitHub = ReactiveCommand.Create(DoOpenOnGitHub);
         }
 
         /// <inheritdoc/>
@@ -196,6 +201,11 @@ namespace GitHub.ViewModels.Documents
         {
             await service.FetchCommit(LocalRepository, Repository, oid).ConfigureAwait(true);
             teServices.ShowCommitDetails(oid);
+        }
+
+        void DoOpenOnGitHub()
+        {
+            visualStudioBrowser.OpenUrl(WebUrl);
         }
 
         void TimelineItemRemoved(IViewModel item)

--- a/src/GitHub.App/ViewModels/IssueishViewModel.cs
+++ b/src/GitHub.App/ViewModels/IssueishViewModel.cs
@@ -63,11 +63,11 @@ namespace GitHub.ViewModels
         public Uri WebUrl
         {
             get { return webUrl; }
-            private set { this.RaiseAndSetIfChanged(ref webUrl, value); }
+            protected set { this.RaiseAndSetIfChanged(ref webUrl, value); }
         }
 
         /// <inheritdoc/>
-        public ReactiveCommand<Unit, Unit> OpenOnGitHub { get; }
+        public ReactiveCommand<Unit, Unit> OpenOnGitHub { get; protected set; }
 
         protected Task InitializeAsync(
             RemoteRepositoryModel repository,

--- a/src/GitHub.App/ViewModels/PullRequestViewModelBase.cs
+++ b/src/GitHub.App/ViewModels/PullRequestViewModelBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using GitHub.Extensions;
 using GitHub.Logging;
 using GitHub.Models;
 using ReactiveUI;
@@ -59,6 +60,7 @@ namespace GitHub.ViewModels
             State = model.State;
             SourceBranchDisplayName = GetBranchDisplayName(fork, model.HeadRepositoryOwner, model.HeadRefName);
             TargetBranchDisplayName = GetBranchDisplayName(fork, model.BaseRepositoryOwner, model.BaseRefName);
+            WebUrl = localRepository.CloneUrl.ToRepositoryUrl().Append("pull/" + Number);
         }
 
         static string GetBranchDisplayName(bool isFromFork, string owner, string label)

--- a/src/GitHub.Exports/Models/IssueishDetailModel.cs
+++ b/src/GitHub.Exports/Models/IssueishDetailModel.cs
@@ -37,10 +37,15 @@ namespace GitHub.Models
         /// Gets or sets the date/time at which the issue or pull request was last updated.
         /// </summary>
         public DateTimeOffset UpdatedAt { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the comments on the issue or pull request.
         /// </summary>
         public IReadOnlyList<CommentModel> Comments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of comments on the issue or pull request.
+        /// </summary>
+        public int CommentCount { get; set; }
     }
 }

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -313,6 +313,7 @@ namespace GitHub.InlineReviews.Services
                         HeadRepositoryOwner = pr.HeadRepositoryOwner != null ? pr.HeadRepositoryOwner.Login : null,
                         State = pr.State.FromGraphQl(),
                         UpdatedAt = pr.UpdatedAt,
+                        CommentCount = pr.Comments(0, null, null, null).TotalCount,
                         Comments = pr.Comments(null, null, null, null).AllPages().Select(comment => new CommentModel
                         {
                             Id = comment.Id.Value,

--- a/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Documents/PullRequestPageView.xaml
@@ -14,7 +14,7 @@
     <d:DesignData.DataContext>
         <ghfvs:PullRequestPageViewModelDesigner/>
     </d:DesignData.DataContext>
-    
+
     <Control.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -42,6 +42,7 @@
 
             <TextBlock Margin="0 8"
                        Foreground="{DynamicResource VsBrush.WindowText}"
+                       TextWrapping="Wrap"
                        Style="{DynamicResource {x:Static vsui:VsResourceKeys.TextBlockEnvironment200PercentFontSizeStyleKey}}">
                 <Run Text="{Binding Title, Mode=OneWay}"/>
                 <Hyperlink Command="{Binding OpenOnGitHub}">
@@ -113,7 +114,7 @@
                                     CornerRadius="3"
                                     Padding="2 1"
                                     Visibility="{Binding IsPending, Converter={ui:BooleanToVisibilityConverter}, FallbackValue=Collapsed}">
-                              <TextBlock FontSize="10" Text="{x:Static ghfvs:Resources.Pending}" />
+                                <TextBlock FontSize="10" Text="{x:Static ghfvs:Resources.Pending}" />
                             </Border>
                         </StackPanel>
                     </Border>

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
@@ -66,7 +66,7 @@
         <StackPanel DockPanel.Dock="Top"
                     Orientation="Vertical"
                     Margin="8 0 0 0">
-            
+
             <!-- Title -->
             <TextBlock Style="{DynamicResource {x:Static vsui:VsResourceKeys.TextBlockEnvironment122PercentFontSizeStyleKey}}"
                        TextWrapping="Wrap"
@@ -99,8 +99,7 @@
             <StackPanel Orientation="Horizontal" 
                         Margin="0 0 0 -4"
                         ghfvs:ScrollingVerticalStackPanel.IsFixed="true">
-                <!-- TODO: Needs to be re-hooked up :grimacing: -->
-                <ghfvs:GitHubActionLink Margin="0 6" Command="{Binding OpenConversation}">
+                <ghfvs:GitHubActionLink Margin="0 6" Command="{Binding OpenOnGitHub}">
                     View on GitHub
                 </ghfvs:GitHubActionLink>
 
@@ -259,7 +258,7 @@
                                       HeaderText="{Binding Files.ChangedFilesCount, StringFormat={x:Static ghfvs:Resources.ChangesCountFormat}}"
                                       Margin="0 8 10 0"
                                       ghfvs:ScrollingVerticalStackPanel.IsFixed="true"/>
-                
+
                 <!-- Put the changes tree outside its expander, so it can scroll horizontally 
                      while the header remains fixed -->
                 <local:PullRequestFilesView DataContext="{Binding Files}"

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
@@ -99,17 +99,20 @@
             <StackPanel Orientation="Horizontal" 
                         Margin="0 0 0 -4"
                         ghfvs:ScrollingVerticalStackPanel.IsFixed="true">
-                <!-- TODO: Needs hook up -->
+                <!-- TODO: Needs to be re-hooked up :grimacing: -->
                 <ghfvs:GitHubActionLink Margin="0 6" Command="{Binding OpenConversation}">
                     View on GitHub
                 </ghfvs:GitHubActionLink>
 
                 <Rectangle Margin="5 0" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />
 
-                <!-- TODO: Needs hook up -->
-                <ghfvs:GitHubActionLink Margin="0 6" Command="{Binding OpenConversation}">
-                    42
-                </ghfvs:GitHubActionLink>
+                <StackPanel Orientation="Horizontal">
+                    <ghfvs:OcticonImage Margin="0 2 4 0" Foreground="{DynamicResource VsBrush.GrayText}" Width="12" Height="12" Icon="comment"/>
+                    <ghfvs:GitHubActionLink Margin="0 6" Command="{Binding OpenConversation}">
+                        <!-- TODO: Needs hook up -->
+                        42
+                    </ghfvs:GitHubActionLink>
+                </StackPanel>
 
                 <Rectangle Margin="5 0" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />
 

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
@@ -197,6 +197,31 @@
                       HorizontalScrollBarVisibility="Auto"
                       VerticalScrollBarVisibility="Auto">
             <ghfvs:ScrollingVerticalStackPanel>
+                <!-- Author and open time -->
+                <ghfvs:SectionControl Name="descriptionSection"
+                                      HeaderText="{x:Static ghfvs:Resources.Description}"
+                                      IsExpanded="True"
+                                      ghfvs:ScrollingVerticalStackPanel.IsFixed="true">
+                    <StackPanel Orientation="Vertical">
+                        <!-- View conversation on GitHub -->
+                        <StackPanel Orientation="Horizontal" Margin="0 4 0 0">
+                            <v:ActorAvatarView ViewModel="{Binding Author}"
+                                               VerticalAlignment="Bottom"
+                                               Width="16"
+                                               Height="16"
+                                               Margin="0,0,0,1"/>
+
+                            <TextBlock VerticalAlignment="Center" Margin="4 0" TextWrapping="Wrap">
+                                <Run FontWeight="SemiBold" Text="{Binding Model.Author.Login, Mode=OneWay}" />
+                                <Run Text="{x:Static ghfvs:Resources.Wrote}" />
+                            </TextBlock>
+                        </StackPanel>
+                        <!-- PR Body -->
+                        <markdig:MarkdownViewer Name="bodyMarkdown"
+                                                Margin="2 4 10 6"
+                                                Markdown="{Binding Body}"/>
+                    </StackPanel>
+                </ghfvs:SectionControl>
 
                 <ghfvs:SectionControl Name="reviewsSection"
                                       HeaderText="{x:Static ghfvs:Resources.Reviewers}"

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
@@ -221,7 +221,7 @@
 
                 <ghfvs:SectionControl Name="reviewsSection"
                                       HeaderText="{x:Static ghfvs:Resources.Reviewers}"
-                                      IsExpanded="False"
+                                      IsExpanded="True"
                                       Margin="0 8 0 0"
                                       ghfvs:ScrollingVerticalStackPanel.IsFixed="true">
                     <ItemsControl ItemsSource="{Binding Reviews}" Margin="0 4 12 4">
@@ -235,7 +235,7 @@
 
                 <ghfvs:SectionControl Name="checksSection"
                                       HeaderText="Checks"
-                                      IsExpanded="False"
+                                      IsExpanded="True"
                                       Margin="0 8 0 0"
                                       ghfvs:ScrollingVerticalStackPanel.IsFixed="true"
                                       Visibility="{Binding Checks.Count, Converter={ghfvs:CountToVisibilityConverter}}">

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
@@ -107,10 +107,7 @@
 
                 <StackPanel Orientation="Horizontal">
                     <ghfvs:OcticonImage Margin="0 2 4 0" Foreground="{DynamicResource VsBrush.GrayText}" Width="12" Height="12" Icon="comment"/>
-                    <ghfvs:GitHubActionLink Margin="0 6" Command="{Binding OpenConversation}">
-                        <!-- TODO: Needs hook up -->
-                        42
-                    </ghfvs:GitHubActionLink>
+                    <ghfvs:GitHubActionLink Margin="0 6" Command="{Binding OpenConversation}" Content="{Binding Model.CommentCount}" />
                 </StackPanel>
 
                 <Rectangle Margin="5 0" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
@@ -201,7 +201,7 @@
                 <ghfvs:SectionControl Name="descriptionSection"
                                       HeaderText="{x:Static ghfvs:Resources.Description}"
                                       Margin="0 4 0 0"
-                                      IsExpanded="True"
+                                      IsExpanded="False"
                                       ghfvs:ScrollingVerticalStackPanel.IsFixed="true">
                     <StackPanel Orientation="Vertical">
                         <StackPanel Orientation="Horizontal" Margin="0 4 0 0">
@@ -225,7 +225,7 @@
 
                 <ghfvs:SectionControl Name="reviewsSection"
                                       HeaderText="{x:Static ghfvs:Resources.Reviewers}"
-                                      IsExpanded="True"
+                                      IsExpanded="False"
                                       Margin="0 8 0 0"
                                       ghfvs:ScrollingVerticalStackPanel.IsFixed="true">
                     <ItemsControl ItemsSource="{Binding Reviews}" Margin="0 4 12 4">
@@ -239,7 +239,7 @@
 
                 <ghfvs:SectionControl Name="checksSection"
                                       HeaderText="Checks"
-                                      IsExpanded="True"
+                                      IsExpanded="False"
                                       Margin="0 8 0 0"
                                       ghfvs:ScrollingVerticalStackPanel.IsFixed="true"
                                       Visibility="{Binding Checks.Count, Converter={ghfvs:CountToVisibilityConverter}}">

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
@@ -99,8 +99,16 @@
             <StackPanel Orientation="Horizontal" 
                         Margin="0 0 0 -4"
                         ghfvs:ScrollingVerticalStackPanel.IsFixed="true">
+                <!-- TODO: Needs hook up -->
                 <ghfvs:GitHubActionLink Margin="0 6" Command="{Binding OpenConversation}">
-                    View Conversation
+                    View on GitHub
+                </ghfvs:GitHubActionLink>
+
+                <Rectangle Margin="5 0" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />
+
+                <!-- TODO: Needs hook up -->
+                <ghfvs:GitHubActionLink Margin="0 6" Command="{Binding OpenConversation}">
+                    42
                 </ghfvs:GitHubActionLink>
 
                 <Rectangle Margin="5 0" Width="1" Height="12" VerticalAlignment="Center" Style="{DynamicResource Separator}" />

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/PullRequestDetailView.xaml
@@ -200,10 +200,10 @@
                 <!-- Author and open time -->
                 <ghfvs:SectionControl Name="descriptionSection"
                                       HeaderText="{x:Static ghfvs:Resources.Description}"
+                                      Margin="0 4 0 0"
                                       IsExpanded="True"
                                       ghfvs:ScrollingVerticalStackPanel.IsFixed="true">
                     <StackPanel Orientation="Vertical">
-                        <!-- View conversation on GitHub -->
                         <StackPanel Orientation="Horizontal" Margin="0 4 0 0">
                             <v:ActorAvatarView ViewModel="{Binding Author}"
                                                VerticalAlignment="Bottom"


### PR DESCRIPTION
_**Note:** This pull request targets @grokys's_ `feature/pr-conversation` _branch_ 

---

<img width="1207" alt="screen shot 2019-02-13 at 2 05 08 pm" src="https://user-images.githubusercontent.com/1174461/52747506-da914a00-2f98-11e9-8be5-b7959662393e.png">

@jcansdale and I had a chat in Slack about implementing a few changes:

- Bring back the "View on GitHub" link
- adding a link with the comment count of the pull request
- Add back in the pull request description
- Collapsing the description ~~reviewers, and checks~~ section so that the changed files are quickly accessible
- Make hash-link at top of pull request page navigate to dotcom
- Allow pull request title to wrap

There are still a few things that need to be hooked up such as:

- [x] Re-implementing the ["View on GitHub" link](https://user-images.githubusercontent.com/1174461/52747909-d4e83400-2f99-11e9-82d9-2813c62c86b2.png)
- [x] Returning the correct [comment count](https://user-images.githubusercontent.com/1174461/52747902-cc8ff900-2f99-11e9-926c-97bb18445837.png)

@jcansdale or @grokys, would one of you be able to check this branch out and hook up the last remaining items?