### PR TITLE
Fix viewing outdated comments in pull request reviews

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewCommentViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewCommentViewModel.cs
@@ -52,9 +52,23 @@ namespace GitHub.ViewModels.GitHubPane
             {
                 if (thread == null)
                 {
-                    var sha = model.Thread.IsOutdated ? model.Thread.OriginalCommitSha : model.Thread.CommitSha;
-                    var file = await session.GetFile(RelativePath, sha);
-                    thread = file.InlineCommentThreads.FirstOrDefault(t => t.Comments.Any(c => c.Comment.Id == model.Id));
+                    if(model.Thread.IsOutdated)
+                    {
+                        var file = await session.GetFile(RelativePath, model.Thread.OriginalCommitSha);
+                        thread = file.InlineCommentThreads.FirstOrDefault(t => t.Comments.Any(c => c.Comment.Id == model.Id));
+                    }
+                    else
+                    {
+                        var file = await session.GetFile(RelativePath, model.Thread.CommitSha);
+                        thread = file.InlineCommentThreads.FirstOrDefault(t => t.Comments.Any(c => c.Comment.Id == model.Id));
+
+                        // Fall back to opening outdated file if we can't find a line number for the comment
+                        if(thread?.LineNumber == -1)
+                        {
+                            file = await session.GetFile(RelativePath, model.Thread.OriginalCommitSha);
+                            thread = file.InlineCommentThreads.FirstOrDefault(t => t.Comments.Any(c => c.Comment.Id == model.Id));
+                        }
+                    }
                 }
 
                 if (thread != null && thread.LineNumber != -1)

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewCommentViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestReviewCommentViewModel.cs
@@ -52,7 +52,8 @@ namespace GitHub.ViewModels.GitHubPane
             {
                 if (thread == null)
                 {
-                    var file = await session.GetFile(RelativePath, model.Thread.CommitSha);
+                    var sha = model.Thread.IsOutdated ? model.Thread.OriginalCommitSha : model.Thread.CommitSha;
+                    var file = await session.GetFile(RelativePath, sha);
                     thread = file.InlineCommentThreads.FirstOrDefault(t => t.Comments.Any(c => c.Comment.Id == model.Id));
                 }
 

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -116,7 +116,7 @@ namespace GitHub.InlineReviews.Services
             relativePath = relativePath.Replace("\\", "/");
 
             var threadsByPosition = pullRequest.Threads
-                .Where(x => x.Path == relativePath && !x.IsOutdated)
+                .Where(x => x.Path == relativePath)
                 .OrderBy(x => x.Id)
                 .GroupBy(x => Tuple.Create(x.OriginalCommitSha, x.OriginalPosition));
             var threads = new List<IInlineCommentThreadModel>();


### PR DESCRIPTION
Navigating to an outdated comment from a pull request review is currently broken. This pull request fixes that and also provides a fallback when our comment matching algorithm diverges from the one on dotcom.

### What this PR does

- Fix navigation to outdated comments
- Open outdated file if we can't find a line number to place comment thread
- Add logging if something goes wrong

### How to test

#### Opening an outdated comment

1. Open `github/VisualStudio` pull request 2241 on GitHub pane
2. Click on `Reviewers > jcansdale`
3. Expand `Outdated comments`
4. Click on one of the outdated comment links
5. File diff should open with file is state where comment was originally made
6. In-line comment should appear

![image](https://user-images.githubusercontent.com/11719160/53498986-5615ef80-3a9f-11e9-9b2c-0c2e042341cd.png)

#### Opening comment where line positioning algorithm doesn't quite match dotcom

This example uses a comment that dotcom doesn't flag as outdated, but current our line positioning algorithm can't find a line number for it. It will fall back to showing the file as it was when the comment was originally made.

1. Open `github/VisualStudio` pull request 2241 on GitHub pane
2. Click on `Reviewers > jcansdale`
3. Click on comment link under `Comments`
4. File diff should open with file is state where comment was originally made
5. In-line comment should appear
![image](https://user-images.githubusercontent.com/11719160/53577432-917eef80-3b6d-11e9-8c28-93c779aa15fa.png)
6. Click on `log.Error(ex, ...` and hit `Enter`
7. Live file should open on same line (notice the lines starting `log` and `operatingSystem` have been swapped)
![image](https://user-images.githubusercontent.com/11719160/53578017-a7d97b00-3b6e-11e9-972d-da7675807a83.png)

### What this PR doesn't do

On github.com, `Outdated` pull requests are clearly marked. I think we should also do this to let users know they're not looking at the latest version of the code. We could also let users know to click on the source and hit `Enter` to navigate to the latest version.

![image](https://user-images.githubusercontent.com/11719160/53581034-bc207680-3b74-11e9-951f-4067bb2a5fef.png)

Fixes #2247