### PR TITLE
Hide resolved comments from changes tree and indicate resolved comments on margin

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDetailViewModel.cs
@@ -364,7 +364,8 @@ namespace GitHub.ViewModels.GitHubPane
 
                 Checks = (IReadOnlyList<IPullRequestCheckViewModel>)PullRequestCheckViewModel.Build(viewViewModelFactory, pullRequest)?.ToList() ?? Array.Empty<IPullRequestCheckViewModel>();
 
-                await Files.InitializeAsync(Session);
+                // Only show unresolved comments
+                await Files.InitializeAsync(Session, c => !c.IsResolved);
 
                 var localBranches = await pullRequestsService.GetLocalBranches(LocalRepository, pullRequest).ToList();
 

--- a/src/GitHub.App/ViewModels/PullRequestReviewCommentThreadViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestReviewCommentThreadViewModel.cs
@@ -70,6 +70,9 @@ namespace GitHub.ViewModels
         /// <inheritdoc/>
         public DiffSide Side { get; private set; }
 
+        /// <inheritdoc/>
+        public bool IsResolved { get; private set; }
+
         public bool IsNewThread
         {
             get => isNewThread;
@@ -97,6 +100,7 @@ namespace GitHub.ViewModels
             File = file;
             LineNumber = thread.LineNumber;
             Side = thread.DiffLineType == DiffChangeType.Delete ? DiffSide.Left : DiffSide.Right;
+            IsResolved = thread.IsResolved;
 
             foreach (var comment in thread.Comments)
             {

--- a/src/GitHub.Exports.Reactive/Models/IInlineCommentThreadModel.cs
+++ b/src/GitHub.Exports.Reactive/Models/IInlineCommentThreadModel.cs
@@ -49,5 +49,10 @@ namespace GitHub.Models
         /// Gets the relative path to the file that the thread is on.
         /// </summary>
         string RelativePath { get; }
+
+        /// <summary>
+        /// A value indicating whether the thread is resolved.
+        /// </summary>
+        bool IsResolved { get; }
     }
 }

--- a/src/GitHub.Exports.Reactive/Models/IInlineCommentThreadModel.cs
+++ b/src/GitHub.Exports.Reactive/Models/IInlineCommentThreadModel.cs
@@ -51,7 +51,7 @@ namespace GitHub.Models
         string RelativePath { get; }
 
         /// <summary>
-        /// A value indicating whether the thread is resolved.
+        /// Gets a value indicating whether comment thread has been marked as resolved by a user.
         /// </summary>
         bool IsResolved { get; }
     }

--- a/src/GitHub.Exports.Reactive/ViewModels/IPullRequestReviewCommentThreadViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/IPullRequestReviewCommentThreadViewModel.cs
@@ -37,6 +37,11 @@ namespace GitHub.ViewModels
         DiffSide Side { get; }
 
         /// <summary>
+        /// Gets a value indicating whether comment thread has been marked as resolved by a user.
+        /// </summary>
+        bool IsResolved { get; }
+
+        /// <summary>
         /// Gets a value indicating whether the thread is a new thread being authored, that is not
         /// yet present on the server.
         /// </summary>

--- a/src/GitHub.Exports/Models/PullRequestReviewThreadModel.cs
+++ b/src/GitHub.Exports/Models/PullRequestReviewThreadModel.cs
@@ -34,6 +34,11 @@ namespace GitHub.Models
         public bool IsOutdated { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the thread is resolved.
+        /// </summary>
+        public bool IsResolved { get; set; }
+
+        /// <summary>
         /// Gets or sets the line position in the diff that the thread starts on.
         /// </summary>
         /// <remarks>

--- a/src/GitHub.InlineReviews/Models/InlineCommentThreadModel.cs
+++ b/src/GitHub.InlineReviews/Models/InlineCommentThreadModel.cs
@@ -28,7 +28,8 @@ namespace GitHub.InlineReviews.Models
             string relativePath,
             string commitSha,
             IList<DiffLine> diffMatch,
-            IEnumerable<InlineCommentModel> comments)
+            IEnumerable<InlineCommentModel> comments,
+            bool isResolved)
         {
             Guard.ArgumentNotNull(relativePath, nameof(relativePath));
             Guard.ArgumentNotNull(commitSha, nameof(commitSha));
@@ -39,6 +40,7 @@ namespace GitHub.InlineReviews.Models
             DiffLineType = diffMatch[0].Type;
             CommitSha = commitSha;
             RelativePath = relativePath;
+            IsResolved = isResolved;
 
             foreach (var comment in comments)
             {
@@ -74,5 +76,8 @@ namespace GitHub.InlineReviews.Models
 
         /// <inheritdoc/>
         public string RelativePath { get; }
+
+        /// <inheritdoc/>
+        public bool IsResolved { get; }
     }
 }

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -123,7 +123,8 @@ namespace GitHub.InlineReviews.Services
 
             foreach (var thread in threadsByPosition)
             {
-                var hunk = thread.First().DiffHunk;
+                var reviewThread = thread.First();
+                var hunk = reviewThread.DiffHunk;
                 var chunks = DiffUtilities.ParseFragment(hunk);
                 var chunk = chunks.Last();
                 var diffLines = chunk.Lines.Reverse().Take(5).ToList();
@@ -142,7 +143,8 @@ namespace GitHub.InlineReviews.Services
                     {
                         Comment = c,
                         Review = pullRequest.Reviews.FirstOrDefault(x => x.Comments.Contains(c)),
-                    })));
+                    })),
+                    reviewThread.IsResolved);
                 threads.Add(inlineThread);
             }
 

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -350,7 +350,8 @@ namespace GitHub.InlineReviews.Services
                                 PullRequestReviewId = comment.PullRequestReview != null ? comment.PullRequestReview.Id.Value : null,
                                 CreatedAt = comment.CreatedAt,
                                 Url = comment.Url
-                            }).ToList()
+                            }).ToList(),
+                            IsResolved = thread.IsResolved
                         }).ToList(),
                         Reviews = pr.Reviews(null, null, null, null, null, null).AllPages().Select(review => new PullRequestReviewModel
                         {

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -39,7 +39,8 @@ namespace GitHub.InlineReviews.Services
     public class PullRequestSessionService : IPullRequestSessionService
     {
         static readonly ILogger log = LogManager.ForContext<PullRequestSessionService>();
-        static ICompiledQuery<PullRequestDetailModel> readPullRequest;
+        static ICompiledQuery<PullRequestDetailModel> readPullRequestWithResolved;
+        static ICompiledQuery<PullRequestDetailModel> readPullRequestWithoutResolved;
         static ICompiledQuery<IEnumerable<LastCommitAdapter>> readCommitStatuses;
         static ICompiledQuery<IEnumerable<LastCommitAdapter>> readCommitStatusesEnterprise;
         static ICompiledQuery<ActorModel> readViewer;
@@ -289,11 +290,26 @@ namespace GitHub.InlineReviews.Services
             return null;
         }
 
-        public virtual async Task<PullRequestDetailModel> ReadPullRequestDetail(HostAddress address, string owner, string name, int number)
+        public virtual Task<PullRequestDetailModel> ReadPullRequestDetail(HostAddress address, string owner, string name, int number)
         {
-            if (readPullRequest == null)
+            // The reviewThreads/isResolved field is only guaranteed to be available on github.com
+            if (address.IsGitHubDotCom())
             {
-                readPullRequest = new Query()
+                return ReadPullRequestDetailWithResolved(address, owner, name, number);
+            }
+            else
+            {
+                return ReadPullRequestDetailWithoutResolved(address, owner, name, number);
+            }
+        }
+
+        async Task<PullRequestDetailModel> ReadPullRequestDetailWithResolved(
+            HostAddress address, string owner, string name, int number)
+        {
+
+            if (readPullRequestWithResolved == null)
+            {
+                readPullRequestWithResolved = new Query()
                     .Repository(owner: Var(nameof(owner)), name: Var(nameof(name)))
                     .PullRequest(number: Var(nameof(number)))
                     .Select(pr => new PullRequestDetailModel
@@ -404,7 +420,7 @@ namespace GitHub.InlineReviews.Services
             };
 
             var connection = await graphqlFactory.CreateConnection(address);
-            var result = await connection.Run(readPullRequest, vars);
+            var result = await connection.Run(readPullRequestWithResolved, vars);
 
             var apiClient = await apiClientFactory.Create(address);
 
@@ -436,7 +452,238 @@ namespace GitHub.InlineReviews.Services
                 Status = (PullRequestFileStatus)Enum.Parse(typeof(PullRequestFileStatus), file.Status, true),
             }).ToList();
 
-            BuildPullRequestThreads(result);
+            foreach (var thread in result.Threads)
+            {
+                if (thread.Comments.Count > 0 && thread.Comments[0] is CommentAdapter adapter)
+                {
+                    thread.CommitSha = adapter.CommitSha;
+                    thread.DiffHunk = adapter.DiffHunk;
+                    thread.Id = adapter.Id;
+                    thread.IsOutdated = adapter.Position == null;
+                    thread.OriginalCommitSha = adapter.OriginalCommitId;
+                    thread.OriginalPosition = adapter.OriginalPosition;
+                    thread.Path = adapter.Path;
+                    thread.Position = adapter.Position;
+
+                    foreach (var comment in thread.Comments)
+                    {
+                        comment.Thread = thread;
+                    }
+                }
+            }
+
+            foreach (var review in result.Reviews)
+            {
+                review.Comments = result.Threads
+                    .SelectMany(t => t.Comments)
+                    .Cast<CommentAdapter>()
+                    .Where(c => c.PullRequestReviewId == review.Id)
+                    .ToList();
+            }
+
+            return result;
+        }
+
+        async Task<PullRequestDetailModel> ReadPullRequestDetailWithoutResolved(
+            HostAddress address, string owner, string name, int number)
+        {
+            if (readPullRequestWithoutResolved == null)
+            {
+                readPullRequestWithoutResolved = new Query()
+                    .Repository(owner: Var(nameof(owner)), name: Var(nameof(name)))
+                    .PullRequest(number: Var(nameof(number)))
+                    .Select(pr => new PullRequestDetailModel
+                    {
+                        Id = pr.Id.Value,
+                        Number = pr.Number,
+                        Author = new ActorModel
+                        {
+                            Login = pr.Author.Login,
+                            AvatarUrl = pr.Author.AvatarUrl(null),
+                        },
+                        Title = pr.Title,
+                        Body = pr.Body,
+                        BaseRefSha = pr.BaseRefOid,
+                        BaseRefName = pr.BaseRefName,
+                        BaseRepositoryOwner = pr.Repository.Owner.Login,
+                        HeadRefName = pr.HeadRefName,
+                        HeadRefSha = pr.HeadRefOid,
+                        HeadRepositoryOwner = pr.HeadRepositoryOwner != null ? pr.HeadRepositoryOwner.Login : null,
+                        State = pr.State.FromGraphQl(),
+                        UpdatedAt = pr.UpdatedAt,
+                        CommentCount = pr.Comments(0, null, null, null).TotalCount,
+                        Comments = pr.Comments(null, null, null, null).AllPages().Select(comment => new CommentModel
+                        {
+                            Id = comment.Id.Value,
+                            Author = new ActorModel
+                            {
+                                Login = comment.Author.Login,
+                                AvatarUrl = comment.Author.AvatarUrl(null),
+                            },
+                            Body = comment.Body,
+                            CreatedAt = comment.CreatedAt,
+                            DatabaseId = comment.DatabaseId.Value,
+                            Url = comment.Url,
+                        }).ToList(),
+                        Reviews = pr.Reviews(null, null, null, null, null, null).AllPages().Select(review => new PullRequestReviewModel
+                        {
+                            Id = review.Id.Value,
+                            Body = review.Body,
+                            CommitId = review.Commit.Oid,
+                            State = review.State.FromGraphQl(),
+                            SubmittedAt = review.SubmittedAt,
+                            Author = new ActorModel
+                            {
+                                Login = review.Author.Login,
+                                AvatarUrl = review.Author.AvatarUrl(null),
+                            },
+                            Comments = review.Comments(null, null, null, null).AllPages().Select(comment => new CommentAdapter
+                            {
+                                Id = comment.Id.Value,
+                                PullRequestId = comment.PullRequest.Number,
+                                DatabaseId = comment.DatabaseId.Value,
+                                Author = new ActorModel
+                                {
+                                    Login = comment.Author.Login,
+                                    AvatarUrl = comment.Author.AvatarUrl(null),
+                                },
+                                Body = comment.Body,
+                                Path = comment.Path,
+                                CommitSha = comment.Commit.Oid,
+                                DiffHunk = comment.DiffHunk,
+                                Position = comment.Position,
+                                OriginalPosition = comment.OriginalPosition,
+                                OriginalCommitId = comment.OriginalCommit.Oid,
+                                ReplyTo = comment.ReplyTo != null ? comment.ReplyTo.Id.Value : null,
+                                CreatedAt = comment.CreatedAt,
+                                Url = comment.Url,
+                            }).ToList(),
+                        }).ToList(),
+                        Timeline = pr.Timeline(null, null, null, null, null).AllPages().Select(item => item.Switch<object>(when =>
+                            when.Commit(commit => new CommitModel
+                            {
+                                AbbreviatedOid = commit.AbbreviatedOid,
+                                // TODO: commit.Author.User can be null
+                                Author = new ActorModel
+                                {
+                                    Login = commit.Author.User.Login,
+                                    AvatarUrl = commit.Author.User.AvatarUrl(null),
+                                },
+                                MessageHeadline = commit.MessageHeadline,
+                                Oid = commit.Oid,
+                            }).IssueComment(comment => new CommentModel
+                            {
+                                Author = new ActorModel
+                                {
+                                    Login = comment.Author.Login,
+                                    AvatarUrl = comment.Author.AvatarUrl(null),
+                                },
+                                Body = comment.Body,
+                                CreatedAt = comment.CreatedAt,
+                                DatabaseId = comment.DatabaseId.Value,
+                                Id = comment.Id.Value,
+                                Url = comment.Url,
+                            }))).ToList()
+                    }).Compile();
+            }
+
+            var vars = new Dictionary<string, object>
+            {
+                { nameof(owner), owner },
+                { nameof(name), name },
+                { nameof(number), number },
+            };
+
+            var connection = await graphqlFactory.CreateConnection(address);
+            var result = await connection.Run(readPullRequestWithoutResolved, vars);
+
+            var apiClient = await apiClientFactory.Create(address);
+
+            var files = await log.TimeAsync(nameof(apiClient.GetPullRequestFiles),
+                async () => await apiClient.GetPullRequestFiles(owner, name, number).ToList());
+
+            var lastCommitModel = await log.TimeAsync(nameof(GetPullRequestLastCommitAdapter),
+                () => GetPullRequestLastCommitAdapter(address, owner, name, number));
+
+            result.Statuses = (IReadOnlyList<StatusModel>)lastCommitModel.Statuses ?? Array.Empty<StatusModel>();
+
+            if (lastCommitModel.CheckSuites == null)
+            {
+                result.CheckSuites = Array.Empty<CheckSuiteModel>();
+            }
+            else
+            {
+                result.CheckSuites = lastCommitModel.CheckSuites;
+                foreach (var checkSuite in result.CheckSuites)
+                {
+                    checkSuite.HeadSha = lastCommitModel.HeadSha;
+                }
+            }
+
+            result.ChangedFiles = files.Select(file => new PullRequestFileModel
+            {
+                FileName = file.FileName,
+                Sha = file.Sha,
+                Status = (PullRequestFileStatus)Enum.Parse(typeof(PullRequestFileStatus), file.Status, true),
+            }).ToList();
+
+            // Build pull request threads
+            var commentsByReplyId = new Dictionary<string, List<CommentAdapter>>();
+
+            // Get all comments that are not replies.
+            foreach (CommentAdapter comment in result.Reviews.SelectMany(x => x.Comments))
+            {
+                if (comment.ReplyTo == null)
+                {
+                    commentsByReplyId.Add(comment.Id, new List<CommentAdapter> { comment });
+                }
+            }
+
+            // Get the comments that are replies and place them into the relevant list.
+            foreach (CommentAdapter comment in result.Reviews.SelectMany(x => x.Comments).OrderBy(x => x.CreatedAt))
+            {
+                if (comment.ReplyTo != null)
+                {
+                    List<CommentAdapter> thread = null;
+
+                    if (commentsByReplyId.TryGetValue(comment.ReplyTo, out thread))
+                    {
+                        thread.Add(comment);
+                    }
+                }
+            }
+
+            // Build a collection of threads for the information collected above.
+            var threads = new List<PullRequestReviewThreadModel>();
+
+            foreach (var threadSource in commentsByReplyId)
+            {
+                var adapter = threadSource.Value[0];
+
+                var thread = new PullRequestReviewThreadModel
+                {
+                    Comments = threadSource.Value,
+                    CommitSha = adapter.CommitSha,
+                    DiffHunk = adapter.DiffHunk,
+                    Id = adapter.Id,
+                    IsOutdated = adapter.Position == null,
+                    OriginalCommitSha = adapter.OriginalCommitId,
+                    OriginalPosition = adapter.OriginalPosition,
+                    Path = adapter.Path,
+                    Position = adapter.Position,
+                };
+
+                // Set a reference to the thread in the comment.
+                foreach (var comment in threadSource.Value)
+                {
+                    comment.Thread = thread;
+                }
+
+                threads.Add(thread);
+            }
+
+            result.Threads = threads;
+
             return result;
         }
 
@@ -915,38 +1162,6 @@ namespace GitHub.InlineReviews.Services
             var connection = await graphqlFactory.CreateConnection(address);
             var result = await connection.Run(query, vars);
             return result.First();
-        }
-
-        static void BuildPullRequestThreads(PullRequestDetailModel model)
-        {
-            foreach (var thread in model.Threads)
-            {
-                if (thread.Comments.Count > 0 && thread.Comments[0] is CommentAdapter adapter)
-                {
-                    thread.CommitSha = adapter.CommitSha;
-                    thread.DiffHunk = adapter.DiffHunk;
-                    thread.Id = adapter.Id;
-                    thread.IsOutdated = adapter.Position == null;
-                    thread.OriginalCommitSha = adapter.OriginalCommitId;
-                    thread.OriginalPosition = adapter.OriginalPosition;
-                    thread.Path = adapter.Path;
-                    thread.Position = adapter.Position;
-
-                    foreach (var comment in thread.Comments)
-                    {
-                        comment.Thread = thread;
-                    }
-                }
-            }
-
-            foreach(var review in  model.Reviews)
-            {
-                review.Comments = model.Threads
-                    .SelectMany(t => t.Comments)
-                    .Cast<CommentAdapter>()
-                    .Where(c => c.PullRequestReviewId == review.Id)
-                    .ToList();
-            }
         }
 
         static Octokit.GraphQL.Model.PullRequestReviewEvent ToGraphQl(Octokit.PullRequestReviewEvent e)

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -388,11 +388,15 @@ namespace GitHub.InlineReviews.Services
                             when.Commit(commit => new CommitModel
                             {
                                 AbbreviatedOid = commit.AbbreviatedOid,
-                                // TODO: commit.Author.User can be null
-                                Author = new ActorModel
+                                Author = new CommitActorModel
                                 {
-                                    Login = commit.Author.User.Login,
-                                    AvatarUrl = commit.Author.User.AvatarUrl(null),
+                                    Name = commit.Author.Name,
+                                    Email = commit.Author.Email,
+                                    User = commit.Author.User != null ? new ActorModel
+                                    {
+                                        Login = commit.Author.User.Login,
+                                        AvatarUrl = commit.Author.User.AvatarUrl(null),
+                                    } : null
                                 },
                                 MessageHeadline = commit.MessageHeadline,
                                 Oid = commit.Oid,

--- a/src/GitHub.InlineReviews/Tags/ShowInlineCommentAnnotationGlyph.xaml
+++ b/src/GitHub.InlineReviews/Tags/ShowInlineCommentAnnotationGlyph.xaml
@@ -17,14 +17,27 @@
                         <Setter Property="Stroke" Value="{DynamicResource GitHubDiffGlyphFill.None}" />
                     </Style>
                 </Canvas.Resources>
-
                 <Ellipse Width="9"
                          Height="9" 
                          Canvas.Top="4"
                          Canvas.Left="6"
-                         Fill="#959DA5"
-                         Stroke="White"
-                         StrokeThickness="1" />
+                         StrokeThickness="1">
+                    <Ellipse.Resources>
+                        <Style TargetType="Ellipse">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Thread.IsResolved}" Value="False">
+                                    <Setter Property="Fill" Value="#959DA5" />
+                                    <Setter Property="Stroke" Value="White" />
+                                </DataTrigger>
+
+                                <DataTrigger Binding="{Binding Thread.IsResolved}" Value="True">
+                                    <Setter Property="Fill" Value="Transparent" />
+                                    <Setter Property="Stroke" Value="#959DA5" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Ellipse.Resources>
+                </Ellipse>
 
                 <Rectangle Width="7"
                          Height="7" 

--- a/src/GitHub.InlineReviews/Tags/ShowInlineCommentGlyph.xaml
+++ b/src/GitHub.InlineReviews/Tags/ShowInlineCommentGlyph.xaml
@@ -16,14 +16,27 @@
                         <Setter Property="Stroke" Value="{DynamicResource GitHubDiffGlyphFill.None}" />
                     </Style>
                 </Canvas.Resources>
-
                 <Ellipse Width="9"
                          Height="9" 
                          Canvas.Top="3.5"
                          Canvas.Left="3.5"
-                         Fill="#959DA5"
-                         Stroke="White"
-                         StrokeThickness="1" />
+                         StrokeThickness="1">
+                    <Ellipse.Resources>
+                        <Style TargetType="Ellipse">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Thread.IsResolved}" Value="False">
+                                    <Setter Property="Fill" Value="#959DA5" />
+                                    <Setter Property="Stroke" Value="White" />
+                                </DataTrigger>
+
+                                <DataTrigger Binding="{Binding Thread.IsResolved}" Value="True">
+                                    <Setter Property="Fill" Value="Transparent" />
+                                    <Setter Property="Stroke" Value="#959DA5" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Ellipse.Resources>
+                </Ellipse>
             </Canvas>
         </Viewbox>
     </Grid>

--- a/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml
+++ b/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml
@@ -104,10 +104,9 @@
         </Border>
 
         <Border DockPanel.Dock="Top"
-                Background="{DynamicResource GitHubPeekViewBackground}"
-                BorderBrush="{DynamicResource GitHubButtonBorderBrush}"
-                BorderThickness="0 0 0 1"
-                Padding="8">
+                Background="{DynamicResource VsBrush.InfoBackground}"
+                BorderThickness="1 0 0 1"
+                Padding="4">
             <Border.Style>
                 <Style TargetType="Border">
                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -119,8 +118,8 @@
                 </Style>
             </Border.Style>
             <DockPanel>
-                <imaging:CrispImage  Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.StatusInformation}" Visibility="{Binding Model.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Notice}}"/>
-                <TextBlock TextWrapping="Wrap" Text="{x:Static ghfvs:Resources.ThisConversationWasMarkedAsResolved}"/>
+                <imaging:CrispImage Margin="4 0" Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.StatusInformation}" Visibility="{Binding Model.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Notice}}"/>
+                <TextBlock Foreground="{DynamicResource VsBrush.InfoText}"  TextWrapping="Wrap" Text="{x:Static ghfvs:Resources.ThisConversationWasMarkedAsResolved}"/>
             </DockPanel>
         </Border>
 

--- a/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml
+++ b/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml
@@ -64,6 +64,25 @@
         </Border>
 
         <Border DockPanel.Dock="Top"
+                Background="{DynamicResource {x:Static SystemColors.InfoBrushKey}}"
+                Padding="8">
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Thread.IsResolved}" Value="True">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
+            <DockPanel>
+                <ui:OcticonImage DockPanel.Dock="Left" Icon="info" Margin="0 0 8 0"/>
+                <TextBlock TextWrapping="Wrap" Text="{x:Static ghfvs:Resources.ThisConversationWasMarkedAsResolved}"/>
+            </DockPanel>
+        </Border>
+
+        <Border DockPanel.Dock="Top"
                 BorderThickness="0 0 0 1"
                 Background="{DynamicResource VsBrush.CommandBarOptionsBackground}"
                 BorderBrush="{DynamicResource GitHubVsBrandedUIBorder}">

--- a/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml
+++ b/src/GitHub.InlineReviews/Views/InlineCommentPeekView.xaml
@@ -7,6 +7,8 @@
              xmlns:cache="clr-namespace:GitHub.UI.Helpers;assembly=GitHub.UI"
              xmlns:ui="clr-namespace:GitHub.UI;assembly=GitHub.UI"
              xmlns:ghfvs="https://github.com/github/VisualStudio"
+             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog" 
              mc:Ignorable="d" 
              d:DesignHeight="200" d:DesignWidth="500">
     <UserControl.Resources>
@@ -64,25 +66,6 @@
         </Border>
 
         <Border DockPanel.Dock="Top"
-                Background="{DynamicResource {x:Static SystemColors.InfoBrushKey}}"
-                Padding="8">
-            <Border.Style>
-                <Style TargetType="Border">
-                    <Setter Property="Visibility" Value="Collapsed"/>
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding Thread.IsResolved}" Value="True">
-                            <Setter Property="Visibility" Value="Visible"/>
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </Border.Style>
-            <DockPanel>
-                <ui:OcticonImage DockPanel.Dock="Left" Icon="info" Margin="0 0 8 0"/>
-                <TextBlock TextWrapping="Wrap" Text="{x:Static ghfvs:Resources.ThisConversationWasMarkedAsResolved}"/>
-            </DockPanel>
-        </Border>
-
-        <Border DockPanel.Dock="Top"
                 BorderThickness="0 0 0 1"
                 Background="{DynamicResource VsBrush.CommandBarOptionsBackground}"
                 BorderBrush="{DynamicResource GitHubVsBrandedUIBorder}">
@@ -118,6 +101,27 @@
                 </Button>
                 <Separator Background="{DynamicResource GitHubButtonBorderBrush}" Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" />
             </StackPanel>
+        </Border>
+
+        <Border DockPanel.Dock="Top"
+                Background="{DynamicResource GitHubPeekViewBackground}"
+                BorderBrush="{DynamicResource GitHubButtonBorderBrush}"
+                BorderThickness="0 0 0 1"
+                Padding="8">
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Setter Property="Visibility" Value="Collapsed"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Thread.IsResolved}" Value="True">
+                            <Setter Property="Visibility" Value="Visible"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
+            <DockPanel>
+                <imaging:CrispImage  Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.StatusInformation}" Visibility="{Binding Model.AnnotationLevel, Converter={ghfvs:EqualsToVisibilityConverter Notice}}"/>
+                <TextBlock TextWrapping="Wrap" Text="{x:Static ghfvs:Resources.ThisConversationWasMarkedAsResolved}"/>
+            </DockPanel>
         </Border>
 
         <ScrollViewer Name="threadScroller"

--- a/src/GitHub.Resources/Resources.Designer.cs
+++ b/src/GitHub.Resources/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GitHub {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -2078,6 +2078,15 @@ namespace GitHub {
         public static string ThereArenTAnyOpenPullRequests {
             get {
                 return ResourceManager.GetString("ThereArenTAnyOpenPullRequests", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This conversation was marked as resolved.
+        /// </summary>
+        public static string ThisConversationWasMarkedAsResolved {
+            get {
+                return ResourceManager.GetString("ThisConversationWasMarkedAsResolved", resourceCulture);
             }
         }
         

--- a/src/GitHub.Resources/Resources.cs-CZ.resx
+++ b/src/GitHub.Resources/Resources.cs-CZ.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>a další</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.de-DE.resx
+++ b/src/GitHub.Resources/Resources.de-DE.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>und weitere</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.es-ES.resx
+++ b/src/GitHub.Resources/Resources.es-ES.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>y otros</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.fr-FR.resx
+++ b/src/GitHub.Resources/Resources.fr-FR.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>et autres</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.it-IT.resx
+++ b/src/GitHub.Resources/Resources.it-IT.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>e altri</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.ja-JP.resx
+++ b/src/GitHub.Resources/Resources.ja-JP.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>その他</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.ko-KR.resx
+++ b/src/GitHub.Resources/Resources.ko-KR.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>및 기타</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.pl-PL.resx
+++ b/src/GitHub.Resources/Resources.pl-PL.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>i inni</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.pt-BR.resx
+++ b/src/GitHub.Resources/Resources.pt-BR.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>e outros</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.resx
+++ b/src/GitHub.Resources/Resources.resx
@@ -881,4 +881,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>and others</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.ru-RU.resx
+++ b/src/GitHub.Resources/Resources.ru-RU.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>и др.</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.tr-TR.resx
+++ b/src/GitHub.Resources/Resources.tr-TR.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>ve diğer kişiler</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.zh-CN.resx
+++ b/src/GitHub.Resources/Resources.zh-CN.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>以及其他</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.zh-TW.resx
+++ b/src/GitHub.Resources/Resources.zh-TW.resx
@@ -866,4 +866,7 @@ https://git-scm.com/download/win</value>
   <data name="AndOthers" xml:space="preserve">
     <value>及其他</value>
   </data>
+  <data name="ThisConversationWasMarkedAsResolved" xml:space="preserve">
+    <value>This conversation was marked as resolved</value>
+  </data>
 </root>


### PR DESCRIPTION
Previously pull request comments would be implicitly resolved when when the text near to the comment was changed. GitHub now supports comments being explicitly resolved by a user _and_ comments becoming implicitly outdated when the text near to the comment is changed.

This pull request surfaces the `IsResolved` status of a review comment threads and hides resolved comments from the changes tree (in a similar way to how outdated comments are hidden). This makes it easy to find comments that still need to be addressed when responding to a pull request review.

### What this PR does

- Use `pullRequest/reviewThreads` to populate the `IsResolved` status of a pull request comment threads
- When using GitHub Enterprise fall back to using original model (`reviewThreads` might not be available)
- Hide resolved comments from the changes tree
- Show different in-line comment glyph for resolved comments (an empty circle)
- Show banner to clearly indicate when a thread has been resolved

### To do

- [x] Support fallback for older versions of GitHub Enterprise
- [x] Indicate outdated in-line comments in glyph
![image](https://user-images.githubusercontent.com/11719160/53804701-1e47f580-3f40-11e9-84fa-fb0ea3764dea.png)
- [x] Show banner on resolved comment threads
![image](https://user-images.githubusercontent.com/11719160/53804870-88f93100-3f40-11e9-94cc-2a249839b46a.png)

### What this PR doesn't do

- Probe GitHub Enterprise schema to see if we could fetch resolved comment information
- Surface comments that are outdated but unresolved
- Allow resolving of comments using inline comment view

### How to test

1. Open `https://github.com/grokys/PullRequestSandbox` in Visual Studio
2. Open grokys/PullRequestSandbox#58 in `GitHub` pane
3. Check that only 1 comment appears on `Program.cs`
![image](https://user-images.githubusercontent.com/11719160/53812034-8273b500-3f52-11e9-9024-855349fbe187.png)
4. Click on `💬 1` comment
5. Check `Program.cs` appears in diff view and comment is visible
6. Check that empty circle glyph appears below indicating a resolved comment
7. Click on the resolved comment glyph
8. Check that `The conversation was marked as resolved` banner appears above comment

### Notes

Here is what is looks like in the `Dark` theme

![image](https://user-images.githubusercontent.com/11719160/53812533-9b309a80-3f53-11e9-8064-26bc49685d7b.png)

Related #2245 