### PR TITLE
Fix any issues flagged by PoliCheck

### DIFF
--- a/src/GitHub.VisualStudio.UI/Views/Dialog/GistCreationView.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/GistCreationView.xaml.cs
@@ -15,8 +15,6 @@ namespace GitHub.VisualStudio.Views.Dialog
     public class GenericGistCreationView : ViewBase<IGistCreationViewModel, GistCreationView>
     { }
 
-    public class FooBar { }
-
     [ExportViewFor(typeof(IGistCreationViewModel))]
     [PartCreationPolicy(CreationPolicy.NonShared)] 
     public partial class GistCreationView : GenericGistCreationView


### PR DESCRIPTION
I ran PoliCheck on our code-base which flagged the following potential issues.

```xml
<Object URL="C:\Source\github.com\github\VisualStudio\build\Debug\GitHub.VisualStudio.UI.dll" No.="1">
<Term>foobar</Term>
```
A class called `FooBar` has erroneously been committed. This can simply be removed.

```xml
<Object URL="C:\Source\github.com\github\VisualStudio\build\Debug\Octokit.dll" No.="3">
<Term>Ceylon</Term>
```
`Octokit.dll` has an enum that references the Ceylon [programming language](https://en.wikipedia.org/wiki/Ceylon_(programming_language)). This _isn't_ a reference to Ceylon the historic [British Crown colony](https://en.wikipedia.org/wiki/British_Ceylon).

### What this PR does

- Remove `FooBar` class from `GenericGistCreationView`

### How to test

Re-run PoliCheck. 🙂 