### PR TITLE
Fixing the error with the clone button

### DIFF
--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositoryCloneViewModel.cs
@@ -68,7 +68,7 @@ namespace GitHub.ViewModels.Dialog.Clone
             var canClone = Observable.CombineLatest(
                 repository, this.WhenAnyValue(x => x.Path),
                 (repo, path) => repo != null && !service.DestinationFileExists(path) &&
-                (!service.DestinationDirectoryExists(path)) || service.DestinationDirectoryEmpty(path));
+                (!service.DestinationDirectoryExists(path) || service.DestinationDirectoryEmpty(path)));
 
             var canOpen = Observable.CombineLatest(
                 repository, this.WhenAnyValue(x => x.Path),


### PR DESCRIPTION
In #2316 @ https://github.com/github/VisualStudio/pull/2316/commits/1d8e3e87c81b6ee9ed1b98ddfa3ac9144e1976c5

I made the determination that `DestinationDirectoryEmpty` should be used responsibly and should assume the directory it is checking actually exists. The caller of the function should've done their homework and inspected that the directory exists, before asking if it is empty.

That "fix" exposes the very simple bug of a misplaced parenthesis.

Previously we were checking `!service.DestinationDirectoryExists(path)` and because of the misplaced parenthesis and the unoptimized code, we were calling `!service.DestinationDirectoryExists(path)` a second time. The second time it would have the desired effect.