### PR TITLE
Follow dialog style guidelines for Clone/Open

### DIFF
--- a/src/GitHub.Resources/Resources.Designer.cs
+++ b/src/GitHub.Resources/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GitHub {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -946,7 +946,7 @@ namespace GitHub {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local path.
+        ///   Looks up a localized string similar to Local path:.
         /// </summary>
         public static string localPathText {
             get {

--- a/src/GitHub.Resources/Resources.resx
+++ b/src/GitHub.Resources/Resources.resx
@@ -499,7 +499,7 @@ https://git-scm.com/download/win</value>
     <value>Private Repository</value>
   </data>
   <data name="localPathText" xml:space="preserve">
-    <value>Local path</value>
+    <value>Local path:</value>
   </data>
   <data name="licenseListText" xml:space="preserve">
     <value>License</value>

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -46,7 +46,7 @@
                     VerticalContentAlignment="Center">
                 Browse
             </Button>
-            <TextBox Text="{Binding Path, UpdateSourceTrigger=PropertyChanged}"
+            <TextBox Text="{Binding Path, UpdateSourceTrigger=PropertyChanged}" Margin="6,0"
                      VerticalContentAlignment="Center" />
         </DockPanel>
 

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -20,7 +20,7 @@
     </Control.Resources>
 
     <DockPanel>
-        <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right">
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right" Margin="0,18,0,0">
             <Button
                 HorizontalAlignment="Center"
                 IsDefault="True"
@@ -37,7 +37,7 @@
                 AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.OpenRepositoryButton}"/>
         </StackPanel>
 
-        <DockPanel DockPanel.Dock="Bottom" Margin="0,9">
+        <DockPanel DockPanel.Dock="Bottom" Margin="0,9,0,0">
             <Label DockPanel.Dock="Left" Content="{x:Static ghfvs:Resources.localPathText}" />
             <Button DockPanel.Dock="Right"
                     Command="{Binding Browse}"

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -9,6 +9,7 @@
              xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.14.0"
              Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}"
              Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"
+             Margin="12,12"
              mc:Ignorable="d" d:DesignHeight="414" d:DesignWidth="440">
     <d:DesignData.DataContext>
         <ghfvs:RepositoryCloneViewModelDesigner/>

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -42,9 +42,8 @@
             <Label DockPanel.Dock="Left" Content="{x:Static ghfvs:Resources.localPathText}" />
             <Button DockPanel.Dock="Right"
                     Command="{Binding Browse}"
-                    Style="{DynamicResource GitHubLinkButton}"
                     VerticalContentAlignment="Center">
-                Browse
+                Browse...
             </Button>
             <TextBox Text="{Binding Path, UpdateSourceTrigger=PropertyChanged}" Margin="6,0"
                      VerticalContentAlignment="Center" />

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -20,9 +20,8 @@
     </Control.Resources>
 
     <DockPanel>
-        <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Center">
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right">
             <Button
-                Margin="12"
                 HorizontalAlignment="Center"
                 IsDefault="True"
                 Command="{Binding Clone}"
@@ -30,7 +29,7 @@
                 AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.CloneRepositoryButton}"/>
 
             <Button
-                Margin="12"
+                Margin="6,0,0,0"
                 HorizontalAlignment="Center"
                 IsDefault="True"
                 Command="{Binding Open}"

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -38,9 +38,8 @@
                 AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.OpenRepositoryButton}"/>
         </StackPanel>
 
-        <DockPanel DockPanel.Dock="Bottom"
-                   Margin="16">
-            <Label DockPanel.Dock="Left" Content="{x:Static ghfvs:Resources.localPathText}"/>
+        <DockPanel DockPanel.Dock="Bottom" Margin="0,9">
+            <Label DockPanel.Dock="Left" Content="{x:Static ghfvs:Resources.localPathText}" />
             <Button DockPanel.Dock="Right"
                     Command="{Binding Browse}"
                     Style="{DynamicResource GitHubLinkButton}"

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml
@@ -15,7 +15,7 @@
 
     <DockPanel>
         <ghfvs:PromptTextBox DockPanel.Dock="Top"
-                             Margin="0,4"
+                             Margin="0,0,0,9"
                              PromptText="Search or enter a URL"
                              Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged, Delay=300}"/>
 

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml
@@ -15,7 +15,7 @@
 
     <DockPanel>
         <ghfvs:PromptTextBox DockPanel.Dock="Top"
-                             Margin="0,0,0,9"
+                             Margin="0,9"
                              PromptText="Search or enter a URL"
                              Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged, Delay=300}"/>
 


### PR DESCRIPTION
This PR updates the Clone/Open dialog to follow the dialog style guidelines from here:
https://vsuiguide.azurewebsites.net/topics/08%20Layout/08.01%20Dialog%20layout.html

Here is what the updated dialog looks like:

![image](https://user-images.githubusercontent.com/11719160/56577666-6e981700-65c3-11e9-8bfd-8f3cea27ad78.png)

### What this PR does

- Padding for search
- Centered layout content
- Padding between path and browse link

### What this PR doesn't do

- Link tabs

I haven't changed the `GitHub.com` / `Enterprise` link tabs in this PR. There is no obvious Visual Studio style to use for `TabControl` / `TabItem` components. I didn't want to sink too much time into this when there are other priorities.

Fixes #2324