### PR TITLE
Fix keyboard navigation and focus on clone dialog

### DIFF
--- a/src/GitHub.Resources/Resources.Designer.cs
+++ b/src/GitHub.Resources/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GitHub {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -946,7 +946,7 @@ namespace GitHub {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local path.
+        ///   Looks up a localized string similar to Local path:.
         /// </summary>
         public static string localPathText {
             get {

--- a/src/GitHub.Resources/Resources.resx
+++ b/src/GitHub.Resources/Resources.resx
@@ -499,7 +499,7 @@ https://git-scm.com/download/win</value>
     <value>Private Repository</value>
   </data>
   <data name="localPathText" xml:space="preserve">
-    <value>Local path</value>
+    <value>Local path:</value>
   </data>
   <data name="licenseListText" xml:space="preserve">
     <value>License</value>

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -46,7 +46,7 @@
                     VerticalContentAlignment="Center">
                 Browse
             </Button>
-            <TextBox Text="{Binding Path, UpdateSourceTrigger=PropertyChanged}"
+            <TextBox Text="{Binding Path, UpdateSourceTrigger=PropertyChanged}" Margin="6,0"
                      VerticalContentAlignment="Center" />
         </DockPanel>
 

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -20,7 +20,7 @@
     </Control.Resources>
 
     <DockPanel>
-        <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right">
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right" Margin="0,18,0,0">
             <Button
                 HorizontalAlignment="Center"
                 IsDefault="True"
@@ -37,7 +37,7 @@
                 AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.OpenRepositoryButton}"/>
         </StackPanel>
 
-        <DockPanel DockPanel.Dock="Bottom" Margin="0,9">
+        <DockPanel DockPanel.Dock="Bottom" Margin="0,9,0,0">
             <Label DockPanel.Dock="Left" Content="{x:Static ghfvs:Resources.localPathText}" />
             <Button DockPanel.Dock="Right"
                     Command="{Binding Browse}"

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -9,6 +9,7 @@
              xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.14.0"
              Background="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowBackgroundBrushKey}}"
              Foreground="{DynamicResource {x:Static vs:EnvironmentColors.ToolWindowTextBrushKey}}"
+             Margin="12,12"
              mc:Ignorable="d" d:DesignHeight="414" d:DesignWidth="440">
     <d:DesignData.DataContext>
         <ghfvs:RepositoryCloneViewModelDesigner/>

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -42,9 +42,8 @@
             <Label DockPanel.Dock="Left" Content="{x:Static ghfvs:Resources.localPathText}" />
             <Button DockPanel.Dock="Right"
                     Command="{Binding Browse}"
-                    Style="{DynamicResource GitHubLinkButton}"
                     VerticalContentAlignment="Center">
-                Browse
+                Browse...
             </Button>
             <TextBox Text="{Binding Path, UpdateSourceTrigger=PropertyChanged}" Margin="6,0"
                      VerticalContentAlignment="Center" />

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -20,9 +20,8 @@
     </Control.Resources>
 
     <DockPanel>
-        <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Center">
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom" HorizontalAlignment="Right">
             <Button
-                Margin="12"
                 HorizontalAlignment="Center"
                 IsDefault="True"
                 Command="{Binding Clone}"
@@ -30,7 +29,7 @@
                 AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.CloneRepositoryButton}"/>
 
             <Button
-                Margin="12"
+                Margin="6,0,0,0"
                 HorizontalAlignment="Center"
                 IsDefault="True"
                 Command="{Binding Open}"

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -38,9 +38,8 @@
                 AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.OpenRepositoryButton}"/>
         </StackPanel>
 
-        <DockPanel DockPanel.Dock="Bottom"
-                   Margin="16">
-            <Label DockPanel.Dock="Left" Content="{x:Static ghfvs:Resources.localPathText}"/>
+        <DockPanel DockPanel.Dock="Bottom" Margin="0,9">
+            <Label DockPanel.Dock="Left" Content="{x:Static ghfvs:Resources.localPathText}" />
             <Button DockPanel.Dock="Right"
                     Command="{Binding Browse}"
                     Style="{DynamicResource GitHubLinkButton}"

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -26,7 +26,8 @@
                 IsDefault="True"
                 Command="{Binding Clone}"
                 Content="Clone"
-                AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.CloneRepositoryButton}"/>
+                AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.CloneRepositoryButton}"
+                KeyboardNavigation.TabIndex="3" />
 
             <Button
                 Margin="6,0,0,0"
@@ -34,18 +35,21 @@
                 IsDefault="True"
                 Command="{Binding Open}"
                 Content="Open"
-                AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.OpenRepositoryButton}"/>
+                AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.OpenRepositoryButton}"
+                KeyboardNavigation.TabIndex="4 "/>
         </StackPanel>
 
         <DockPanel DockPanel.Dock="Bottom" Margin="0,9,0,0">
             <Label DockPanel.Dock="Left" Content="{x:Static ghfvs:Resources.localPathText}" />
             <Button DockPanel.Dock="Right"
                     Command="{Binding Browse}"
-                    VerticalContentAlignment="Center">
+                    VerticalContentAlignment="Center"
+                    KeyboardNavigation.TabIndex="6">
                 Browse...
             </Button>
             <TextBox Text="{Binding Path, UpdateSourceTrigger=PropertyChanged}" Margin="6,0"
-                     VerticalContentAlignment="Center" />
+                     VerticalContentAlignment="Center"
+                     KeyboardNavigation.TabIndex="5" />
         </DockPanel>
 
         <uic:InfoPanel Message="{Binding PathWarning}"

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -27,7 +27,7 @@
                 Command="{Binding Clone}"
                 Content="Clone"
                 AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.CloneRepositoryButton}"
-                KeyboardNavigation.TabIndex="3" />
+                KeyboardNavigation.TabIndex="5" />
 
             <Button
                 Margin="6,0,0,0"
@@ -36,7 +36,7 @@
                 Command="{Binding Open}"
                 Content="Open"
                 AutomationProperties.AutomationId="{x:Static ghfvs:AutomationIDs.OpenRepositoryButton}"
-                KeyboardNavigation.TabIndex="4 "/>
+                KeyboardNavigation.TabIndex="6"/>
         </StackPanel>
 
         <DockPanel DockPanel.Dock="Bottom" Margin="0,9,0,0">
@@ -44,12 +44,12 @@
             <Button DockPanel.Dock="Right"
                     Command="{Binding Browse}"
                     VerticalContentAlignment="Center"
-                    KeyboardNavigation.TabIndex="6">
+                    KeyboardNavigation.TabIndex="4">
                 Browse...
             </Button>
             <TextBox Text="{Binding Path, UpdateSourceTrigger=PropertyChanged}" Margin="6,0"
                      VerticalContentAlignment="Center"
-                     KeyboardNavigation.TabIndex="5" />
+                     KeyboardNavigation.TabIndex="3" />
         </DockPanel>
 
         <uic:InfoPanel Message="{Binding PathWarning}"

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml
@@ -15,7 +15,7 @@
 
     <DockPanel>
         <ghfvs:PromptTextBox DockPanel.Dock="Top"
-                             Margin="0,4"
+                             Margin="0,0,0,9"
                              PromptText="Search or enter a URL"
                              Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged, Delay=300}"/>
 

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml
@@ -15,7 +15,7 @@
 
     <DockPanel>
         <ghfvs:PromptTextBox DockPanel.Dock="Top"
-                             Margin="0,0,0,9"
+                             Margin="0,9"
                              PromptText="Search or enter a URL"
                              Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged, Delay=300}"/>
 

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml
@@ -14,17 +14,20 @@
     </Control.Resources>
 
     <DockPanel>
-        <ghfvs:PromptTextBox DockPanel.Dock="Top"
+        <ghfvs:PromptTextBox Name="SearchTextBox"
+                             DockPanel.Dock="Top"
                              Margin="0,9"
-                             PromptText="Search or enter a URL"
-                             Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged, Delay=300}"/>
+                             PromptText="Search or enter a URL"                             
+                             Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged, Delay=300}"
+                             KeyboardNavigation.TabIndex="1" />
 
         <Grid>
             <ListView BorderThickness="0"
                       ItemsSource="{Binding ItemsView}"
                       SelectedItem="{Binding SelectedItem}"
                       VirtualizingPanel.IsVirtualizing="True"
-                      VirtualizingPanel.IsVirtualizingWhenGrouping="True">
+                      VirtualizingPanel.IsVirtualizingWhenGrouping="True"
+                      KeyboardNavigation.TabIndex="2">
                 <ListView.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.HeaderTemplate>

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml.cs
@@ -1,6 +1,8 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using GitHub.Exports;
 using GitHub.ViewModels.Dialog.Clone;
 
@@ -13,6 +15,16 @@ namespace GitHub.VisualStudio.Views.Dialog.Clone
         public SelectPageView()
         {
             InitializeComponent();
+
+            // See Douglas Stockwell's suggestion here:
+            // https://social.msdn.microsoft.com/Forums/vstudio/en-US/30ed27ce-f7b7-48ae-8adc-0400b9b9ec78
+            IsVisibleChanged += (sender, e) =>
+            {
+                if (IsVisible)
+                {
+                    Dispatcher.BeginInvoke(DispatcherPriority.Input, (Action)(() => SearchTextBox.Focus()));
+                }
+            };
         }
 
         protected override void OnPreviewMouseDown(MouseButtonEventArgs e)

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/SelectPageView.xaml.cs
@@ -16,7 +16,7 @@ namespace GitHub.VisualStudio.Views.Dialog.Clone
         {
             InitializeComponent();
 
-            // See Douglas Stockwell's suggestion here:
+            // See Douglas Stockwell's suggestion:
             // https://social.msdn.microsoft.com/Forums/vstudio/en-US/30ed27ce-f7b7-48ae-8adc-0400b9b9ec78
             IsVisibleChanged += (sender, e) =>
             {


### PR DESCRIPTION
- [x] Depends on #2331

### What this PR does

- Start with focus on search box
- Set keyboard tab order for controls

![image](https://user-images.githubusercontent.com/11719160/56657218-5ee60480-668f-11e9-86ac-8b5250f55dc5.png)

### How to test

1. Open the open/clone dialig
2. Check that focus is on the `Search or enter a URL` text box
3. Check pressing tab changes focus to repository list
4. Check pressing enter would `Clone` or `Open` (when repository is selected)
5. Check pressing tab changes to path box
6. Check pressing tab changes to `Browse...` button
7. Check pressing tab changes to `Clone` or `Open` button

Fixes #2323