### PR TITLE
Fix 2FA when running on Visual Studio 2015

### DIFF
--- a/src/GitHub.InlineReviews/Properties/DesignTimeResources.xaml
+++ b/src/GitHub.InlineReviews/Properties/DesignTimeResources.xaml
@@ -8,6 +8,8 @@
         <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Themes/Dark/ThemedDialogColors.xaml" />
         <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Themes/Dark/EnvironmentColors.xaml" />
         <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Themes/Dark/TreeViewColors.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Themes/FontScalingLabelStyle.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Themes/FontScalingTextBlockStyle.xaml" />
         <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Themes/CommonControlsButtonStyle.xaml" />
         <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Themes/CommonControlsCheckboxStyle.xaml" />
         <ResourceDictionary Source="pack://application:,,,/GitHub.VisualStudio.UI;component/Themes/CommonControlsComboboxStyle.xaml" />

--- a/src/GitHub.UI.Reactive/Assets/Controls/ErrorMessageDisplay.xaml
+++ b/src/GitHub.UI.Reactive/Assets/Controls/ErrorMessageDisplay.xaml
@@ -4,7 +4,6 @@
                     xmlns:uirx="clr-namespace:GitHub.UI">
 
     <Style x:Key="ErrorMessageStyle" TargetType="{x:Type uirx:ErrorMessageDisplay}">
-        <Setter Property="Foreground" Value="{DynamicResource GHTextBrush}" />
         <Setter Property="IconFill" Value="{DynamicResource GitHubErrorBrush}" />
         <Setter Property="KeyboardNavigation.IsTabStop" Value="False" />
         <Setter Property="Template">

--- a/src/GitHub.VisualStudio.UI/Properties/DesignTimeResources.xaml
+++ b/src/GitHub.VisualStudio.UI/Properties/DesignTimeResources.xaml
@@ -8,6 +8,8 @@
         <ResourceDictionary Source="/Themes/Dark/ThemedDialogColors.xaml" />
         <ResourceDictionary Source="/Themes/Dark/EnvironmentColors.xaml" />
         <ResourceDictionary Source="/Themes/Dark/TreeViewColors.xaml" />
+        <ResourceDictionary Source="/Themes/FontScalingLabelStyle.xaml" />
+        <ResourceDictionary Source="/Themes/FontScalingTextBlockStyle.xaml" />
         <ResourceDictionary Source="/Themes/CommonControlsButtonStyle.xaml" />
         <ResourceDictionary Source="/Themes/CommonControlsCheckboxStyle.xaml" />
         <ResourceDictionary Source="/Themes/CommonControlsComboboxStyle.xaml" />

--- a/src/GitHub.VisualStudio.UI/Themes/FontScalingLabelStyle.xaml
+++ b/src/GitHub.VisualStudio.UI/Themes/FontScalingLabelStyle.xaml
@@ -1,0 +1,47 @@
+﻿<ResourceDictionary
+    x:Uid="ResourceDictionary_1" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:vsfx="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0">
+
+    <Style x:Uid="Style_1" TargetType="{x:Type Label}" x:Key="{x:Static vsfx:VsResourceKeys.LabelEnvironment375PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_1"  Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment375PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_2"  Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment375PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_3" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_2" TargetType="{x:Type Label}" x:Key="{x:Static vsfx:VsResourceKeys.LabelEnvironment310PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_4" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment310PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_5" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment310PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_6" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_11" TargetType="{x:Type Label}" x:Key="{x:Static vsfx:VsResourceKeys.LabelEnvironment200PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_30" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment200PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_31" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment200PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_32" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_4" TargetType="{x:Type Label}" x:Key="{x:Static vsfx:VsResourceKeys.LabelEnvironment155PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_10" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment155PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_11" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment155PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_12" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_5" TargetType="{x:Type Label}" x:Key="{x:Static vsfx:VsResourceKeys.LabelEnvironment133PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_13" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment133PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_14" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment133PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_15" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_6" TargetType="{x:Type Label}" x:Key="{x:Static vsfx:VsResourceKeys.LabelEnvironment122PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_16" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment122PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_17" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment122PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_18" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_8" TargetType="{x:Type Label}" x:Key="{x:Static vsfx:VsResourceKeys.LabelEnvironmentBoldStyleKey}">
+        <Setter x:Uid="Setter_22" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.EnvironmentFontSizeKey}}" />
+        <Setter x:Uid="Setter_23" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.EnvironmentBoldFontWeightKey}}" />
+    </Style>
+
+</ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/Themes/FontScalingTextBlockStyle.xaml
+++ b/src/GitHub.VisualStudio.UI/Themes/FontScalingTextBlockStyle.xaml
@@ -1,0 +1,47 @@
+﻿<ResourceDictionary
+    x:Uid="ResourceDictionary_1" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:vsfx="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0">
+
+    <Style x:Uid="Style_1" TargetType="{x:Type TextBlock}" x:Key="{x:Static vsfx:VsResourceKeys.TextBlockEnvironment375PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_1"  Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment375PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_2"  Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment375PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_3" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_2" TargetType="{x:Type TextBlock}" x:Key="{x:Static vsfx:VsResourceKeys.TextBlockEnvironment310PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_4" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment310PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_5" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment310PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_6" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_11" TargetType="{x:Type TextBlock}" x:Key="{x:Static vsfx:VsResourceKeys.TextBlockEnvironment200PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_30" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment200PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_31" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment200PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_32" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_4" TargetType="{x:Type TextBlock}" x:Key="{x:Static vsfx:VsResourceKeys.TextBlockEnvironment155PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_10" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment155PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_11" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment155PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_12" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_5" TargetType="{x:Type TextBlock}" x:Key="{x:Static vsfx:VsResourceKeys.TextBlockEnvironment133PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_13" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment133PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_14" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment133PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_15" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_6" TargetType="{x:Type TextBlock}" x:Key="{x:Static vsfx:VsResourceKeys.TextBlockEnvironment122PercentFontSizeStyleKey}">
+        <Setter x:Uid="Setter_16" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment122PercentFontSizeKey}}" />
+        <Setter x:Uid="Setter_17" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.Environment122PercentFontWeightKey}}" />
+        <Setter x:Uid="Setter_18" Property="TextOptions.TextFormattingMode" Value="Ideal" />
+    </Style>
+
+    <Style x:Uid="Style_8" TargetType="{x:Type TextBlock}" x:Key="{x:Static vsfx:VsResourceKeys.TextBlockEnvironmentBoldStyleKey}">
+        <Setter x:Uid="Setter_22" Property="FontSize" Value="{DynamicResource {x:Static vsfx:VsFonts.EnvironmentFontSizeKey}}" />
+        <Setter x:Uid="Setter_23" Property="FontWeight" Value="{DynamicResource {x:Static vsfx:VsFonts.EnvironmentBoldFontWeightKey}}" />
+    </Style>
+
+</ResourceDictionary>

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/DialogStyles.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/DialogStyles.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:shell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
                     xmlns:ghfvs="https://github.com/github/VisualStudio">
 
     <ResourceDictionary.MergedDictionaries>
@@ -7,6 +8,6 @@
         <ghfvs:SharedDictionaryManager Source="pack://application:,,,/GitHub.VisualStudio.UI;component/SharedDictionary.xaml" />
         <StaticResource ResourceKey="ThemedDialogDefaultStylesKey"/>
     </ResourceDictionary.MergedDictionaries>
-    <Style TargetType="{x:Type TextBlock}" x:Key="GitHubH1TextBlock" BasedOn="{StaticResource TextBlockEnvironment200PercentFontSizeStyleKey}" />
-    <Style TargetType="{x:Type TextBlock}" x:Key="GitHubDescriptionTextBlock" BasedOn="{StaticResource TextBlockEnvironment111PercentFontSizeStyleKey}" />
+    <Style TargetType="{x:Type TextBlock}" x:Key="GitHubH1TextBlock" BasedOn="{StaticResource {x:Static shell:VsResourceKeys.TextBlockEnvironment200PercentFontSizeStyleKey}}" />
+    <Style TargetType="{x:Type TextBlock}" x:Key="GitHubDescriptionTextBlock" BasedOn="{StaticResource {x:Static shell:VsResourceKeys.TextBlockEnvironment122PercentFontSizeStyleKey}}" />
 </ResourceDictionary>


### PR DESCRIPTION
On Visual Studio 2015, authentication was getting stuck on username/password and not showing the 2FA UI.

### What this PR does

- Use strongly typed `VsResourceKeys` rather than referencing style as a string
- Use `TextBlockEnvironment122PercentFontSizeStyleKey` instead of `TextBlockEnvironment1111PercentFontSizeStyleKey` (which doesn't exist in VS 2015)
- Add design time resources for font scaling (so these styles appear correctly in the designer)
- Use default dialog foreground color for `ErrorMessageStyle` instead of `GHTextBrush` (which isn't themed for VS)

### How to test

1. Install extension in Visual Studio 2015
2. Log out and back in using username/password
3. Check that 2FA UI appears
4. Give incorrect code and check error is a readable color

Fixes #2336