### PR TITLE
Use default refspec when fetching

### DIFF
--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -74,27 +74,6 @@ namespace GitHub.Services
             });
         }
 
-        public Task Fetch(IRepository repository, string remoteName)
-        {
-            Guard.ArgumentNotNull(repository, nameof(repository));
-            Guard.ArgumentNotEmptyString(remoteName, nameof(remoteName));
-
-            return Task.Run(() =>
-            {
-                try
-                {
-                    repository.Network.Fetch(remoteName, new[] { "+refs/heads/*:refs/remotes/origin/*" }, fetchOptions);
-                }
-                catch (Exception ex)
-                {
-                    log.Error(ex, "Failed to fetch");
-#if DEBUG
-                    throw;
-#endif
-                }
-            });
-        }
-
         public Task Fetch(IRepository repo, UriString cloneUrl, params string[] refspecs)
         {
             foreach (var remote in repo.Network.Remotes)

--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -30,7 +30,7 @@ namespace GitHub.Services
         /// </summary>
         /// <param name="repository">The repository to pull</param>
         /// <param name="remoteName">The name of the remote</param>
-        /// <param name="refspecs">The custom refspecs no none to use the default</param>
+        /// <param name="refspecs">The custom refspecs or none to use the default</param>
         /// <returns></returns>
         Task Fetch(IRepository repository, string remoteName, params string[] refspecs);
 

--- a/src/GitHub.Exports.Reactive/Services/IGitClient.cs
+++ b/src/GitHub.Exports.Reactive/Services/IGitClient.cs
@@ -26,19 +26,11 @@ namespace GitHub.Services
         Task Push(IRepository repository, string branchName, string remoteName);
 
         /// <summary>
-        /// Fetches the remote.
-        /// </summary>
-        /// <param name="repository">The repository to pull</param>
-        /// <param name="remoteName">The name of the remote</param>
-        /// <returns></returns>
-        Task Fetch(IRepository repository, string remoteName);
-
-        /// <summary>
         /// Fetches from the remote, using custom refspecs.
         /// </summary>
         /// <param name="repository">The repository to pull</param>
         /// <param name="remoteName">The name of the remote</param>
-        /// <param name="refspecs">The custom refspecs</param>
+        /// <param name="refspecs">The custom refspecs no none to use the default</param>
         /// <returns></returns>
         Task Fetch(IRepository repository, string remoteName, params string[] refspecs);
 


### PR DESCRIPTION
The `Fetch(Remote remote, FetchOptions options)` method was removed in the latest version of `LibGit2Sharp`. We need an alternative way to specify that the default refspec (from `.git\config`) should be used.

### What this PR does

- Pass an empty array of refspecs to `Network.Fetch` instead of defaulting to `+refs/heads/*:refs/remotes/origin/*`

### Diagnosis

The extension was making two calls to the following method, one with `remoteName` set to `origin` and another with the name of the externally contributed pull request owner.
```cs
repository.Network.Fetch(remoteName, new[] { $"+refs/heads/*:refs/remotes/origin/*" }, fetchOptions);
```
This was causing the remote refs to change and the pull request detail pain would get stuck refreshing.

### References

- The obsolete/now removed  `Fetch(Remote remote, FetchOptions options)` method
https://github.com/libgit2/libgit2sharp/commit/825c0e819ea9452423ba02ad8e5e2c964a279bf6#diff-3298eb31ba8ca7b0c3458afc4fb58b6bL161
- The incorrect substitution to use `+refs/heads/*:refs/remotes/origin/*` was made here
https://github.com/github/VisualStudio/pull/2142/files#diff-3a3bdad543586b88e406637687688a85L84

Fixes #2343