### PR TITLE
Add a login option to Open from GitHub

### DIFF
--- a/src/GitHub.App/SampleData/Dialog/Clone/RepositoryCloneViewModelDesigner.cs
+++ b/src/GitHub.App/SampleData/Dialog/Clone/RepositoryCloneViewModelDesigner.cs
@@ -27,6 +27,7 @@ namespace GitHub.SampleData.Dialog.Clone
         public IRepositorySelectViewModel EnterpriseTab { get; }
         public ReactiveCommand<Unit, Unit> Browse { get; }
         public ReactiveCommand<Unit, CloneDialogResult> Clone { get; }
+        public ReactiveCommand<Unit, Unit> LoginAsDifferentUser { get; }
 
         public Task InitializeAsync(IConnection connection)
         {

--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositoryCloneViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositoryCloneViewModel.cs
@@ -26,6 +26,7 @@ namespace GitHub.ViewModels.Dialog.Clone
         readonly IRepositoryCloneService service;
         readonly IGitService gitService;
         readonly IUsageTracker usageTracker;
+        readonly IDialogService dialogService;
         readonly IReadOnlyList<IRepositoryCloneTabViewModel> tabs;
         string path;
         UriString url;
@@ -40,6 +41,7 @@ namespace GitHub.ViewModels.Dialog.Clone
             IRepositoryCloneService service,
             IGitService gitService,
             IUsageTracker usageTracker,
+            IDialogService dialogService,
             IRepositorySelectViewModel gitHubTab,
             IRepositorySelectViewModel enterpriseTab)
         {
@@ -48,6 +50,7 @@ namespace GitHub.ViewModels.Dialog.Clone
             this.service = service;
             this.gitService = gitService;
             this.usageTracker = usageTracker;
+            this.dialogService = dialogService;
 
             GitHubTab = gitHubTab;
             EnterpriseTab = enterpriseTab;
@@ -82,6 +85,8 @@ namespace GitHub.ViewModels.Dialog.Clone
             Open = ReactiveCommand.CreateFromObservable(
                 () => repository.Select(x => new CloneDialogResult(Path, x?.CloneUrl)),
                 canOpen);
+
+            LoginAsDifferentUser = ReactiveCommand.CreateFromTask(LoginAsDifferentUserAsync);
         }
 
         public IRepositorySelectViewModel GitHubTab { get; }
@@ -111,6 +116,8 @@ namespace GitHub.ViewModels.Dialog.Clone
 
         public IObservable<object> Done => Observable.Merge(Clone, Open);
 
+        public ReactiveCommand<Unit, Unit> LoginAsDifferentUser { get; }
+
         public ReactiveCommand<Unit, Unit> Browse { get; }
 
         public ReactiveCommand<Unit, CloneDialogResult> Clone { get; }
@@ -133,7 +140,11 @@ namespace GitHub.ViewModels.Dialog.Clone
                 EnterpriseTab.Initialize(enterpriseConnection);
             }
 
-            if (connection == enterpriseConnection)
+            if (connection == gitHubConnection)
+            {
+                SelectedTabIndex = 0;
+            }
+            else if (connection == enterpriseConnection)
             {
                 SelectedTabIndex = 1;
             }
@@ -153,6 +164,28 @@ namespace GitHub.ViewModels.Dialog.Clone
             }
 
             this.WhenAnyValue(x => x.SelectedTabIndex).Subscribe(x => tabs[x].Activate().Forget());
+        }
+
+        async Task LoginAsDifferentUserAsync()
+        {
+            if (await dialogService.ShowLoginDialog() is IConnection connection)
+            {
+                var connections = await connectionManager.GetLoadedConnections();
+                var gitHubConnection = connections.FirstOrDefault(x => x.HostAddress.IsGitHubDotCom());
+
+                if (connection == gitHubConnection)
+                {
+                    SelectedTabIndex = 0;
+                    GitHubTab.Initialize(connection);
+                    GitHubTab.Activate().Forget();
+                }
+                else
+                {
+                    SelectedTabIndex = 1;
+                    EnterpriseTab.Initialize(connection);
+                    EnterpriseTab.Activate().Forget();
+                }
+            }
         }
 
         void BrowseForDirectory()

--- a/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/Clone/RepositorySelectViewModel.cs
@@ -129,7 +129,7 @@ namespace GitHub.ViewModels.Dialog.Clone
 
         async Task LoadItems(bool refresh)
         {
-            if (connection == null && !IsLoading) return;
+            if (connection == null || IsLoading) return;
 
             Error = null;
             IsLoading = true;

--- a/src/GitHub.Exports.Reactive/ViewModels/Dialog/Clone/IRepositoryCloneViewModel.cs
+++ b/src/GitHub.Exports.Reactive/ViewModels/Dialog/Clone/IRepositoryCloneViewModel.cs
@@ -53,5 +53,7 @@ namespace GitHub.ViewModels.Dialog.Clone
         /// Gets the command executed when the user clicks "Clone".
         /// </summary>
         ReactiveCommand<Unit, CloneDialogResult> Clone { get; }
+
+        ReactiveCommand<Unit, Unit> LoginAsDifferentUser { get; }
     }
 }

--- a/src/GitHub.Resources/Resources.Designer.cs
+++ b/src/GitHub.Resources/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GitHub {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -57,6 +57,15 @@ namespace GitHub {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add/Change Accounts.
+        /// </summary>
+        public static string AddChangeAccounts {
+            get {
+                return ResourceManager.GetString("AddChangeAccounts", resourceCulture);
             }
         }
         

--- a/src/GitHub.Resources/Resources.cs-CZ.resx
+++ b/src/GitHub.Resources/Resources.cs-CZ.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>Klon</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.de-DE.resx
+++ b/src/GitHub.Resources/Resources.de-DE.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>Klonen</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.es-ES.resx
+++ b/src/GitHub.Resources/Resources.es-ES.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>Clonar</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.fr-FR.resx
+++ b/src/GitHub.Resources/Resources.fr-FR.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>Cloner</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.it-IT.resx
+++ b/src/GitHub.Resources/Resources.it-IT.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>Clona</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.ja-JP.resx
+++ b/src/GitHub.Resources/Resources.ja-JP.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>複製</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.ko-KR.resx
+++ b/src/GitHub.Resources/Resources.ko-KR.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>복제</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.pl-PL.resx
+++ b/src/GitHub.Resources/Resources.pl-PL.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>Klonuj</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.pt-BR.resx
+++ b/src/GitHub.Resources/Resources.pt-BR.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>Clonar</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.resx
+++ b/src/GitHub.Resources/Resources.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>Clone</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.ru-RU.resx
+++ b/src/GitHub.Resources/Resources.ru-RU.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>Клонировать</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.tr-TR.resx
+++ b/src/GitHub.Resources/Resources.tr-TR.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>Kopyalama</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.zh-CN.resx
+++ b/src/GitHub.Resources/Resources.zh-CN.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>克隆</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.Resources/Resources.zh-TW.resx
+++ b/src/GitHub.Resources/Resources.zh-TW.resx
@@ -888,4 +888,7 @@ https://git-scm.com/download/win</value>
   <data name="OpenFromGitHubClone" xml:space="preserve">
     <value>複製</value>
   </data>
+  <data name="AddChangeAccounts" xml:space="preserve">
+    <value>Add/Change Accounts</value>
+  </data>
 </root>

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/Clone/RepositoryCloneView.xaml
@@ -39,6 +39,12 @@
                 KeyboardNavigation.TabIndex="6"/>
         </StackPanel>
 
+        <TextBlock DockPanel.Dock="Top" TextAlignment="Right">
+            <Hyperlink Command="{Binding LoginAsDifferentUser}">
+                <Run Text="{x:Static ghfvs:Resources.LoginLink}" />
+            </Hyperlink>
+        </TextBlock>
+            
         <DockPanel DockPanel.Dock="Bottom" Margin="0,9,0,0">
             <Label DockPanel.Dock="Left" Content="{x:Static ghfvs:Resources.localPathText}" />
             <Button DockPanel.Dock="Right"

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/LoginCredentialsView.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/LoginCredentialsView.xaml.cs
@@ -32,7 +32,7 @@ namespace GitHub.VisualStudio.Views.Dialog
             {
                 SetupDotComBindings(d);
                 SetupEnterpriseBindings(d);
-                SetupSelectedAndVisibleTabBindings(d);
+                SetupSelectedTabBindings(d);
                 d(Disposable.Create(Deactivate));
             });
 
@@ -110,16 +110,8 @@ namespace GitHub.VisualStudio.Views.Dialog
             d(this.OneWayBind(ViewModel, vm => vm.EnterpriseLogin.Error, v => v.enterpriseErrorMessage.UserError));
         }
 
-        void SetupSelectedAndVisibleTabBindings(Action<IDisposable> d)
+        void SetupSelectedTabBindings(Action<IDisposable> d)
         {
-            d(this.WhenAny(x => x.ViewModel.LoginMode, x => x.Value)
-                .Select(x => x == LoginMode.DotComOrEnterprise || x == LoginMode.DotComOnly)
-                .BindTo(this, v => v.dotComTab.IsEnabled));
-
-            d(this.WhenAny(x => x.ViewModel.LoginMode, x => x.Value)
-                .Select(x => x == LoginMode.DotComOrEnterprise || x == LoginMode.EnterpriseOnly)
-                .BindTo(this, v => v.enterpriseTab.IsEnabled));
-
             d(this.WhenAny(x => x.ViewModel.LoginMode, x => x.Value)
                 .Select(x => x == LoginMode.DotComOrEnterprise || x == LoginMode.DotComOnly)
                 .Where(x => x == true)

--- a/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
+++ b/test/GitHub.App.UnitTests/ViewModels/Dialog/Clone/RepositoryCloneViewModelTests.cs
@@ -424,6 +424,7 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
             IConnectionManager connectionManager = null,
             IRepositoryCloneService service = null,
             IUsageTracker usageTracker = null,
+            IDialogService dialogService = null,
             IRepositorySelectViewModel gitHubTab = null,
             IRepositorySelectViewModel enterpriseTab = null,
             IGitService gitService = null,
@@ -433,6 +434,7 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
             connectionManager = connectionManager ?? CreateConnectionManager("https://github.com");
             service = service ?? CreateRepositoryCloneService(defaultClonePath);
             usageTracker = usageTracker ?? Substitute.For<IUsageTracker>();
+            dialogService = dialogService ?? Substitute.For<IDialogService>();
             gitHubTab = gitHubTab ?? CreateSelectViewModel();
             enterpriseTab = enterpriseTab ?? CreateSelectViewModel();
             gitService = gitService ?? CreateGitService(true, "https://github.com/owner/repo");
@@ -443,6 +445,7 @@ namespace GitHub.App.UnitTests.ViewModels.Dialog.Clone
                 service,
                 gitService,
                 usageTracker,
+                dialogService,
                 gitHubTab,
                 enterpriseTab);
         }


### PR DESCRIPTION
We need a way to allow users to log into a different GitHub or GitHub Enterprise from the Open from GitHub dialog. This PR adds a `Login` button so that a user can list and clone repositories from a different account.

### What this PR does

- Add a `Sign in` button to `Open from GitHub` dialog
- Don't disable tabs on the `Connect to GitHub` dialog when already logged in

### How it works

Click on the ~~`Login`~~ `Sign in` button.

![image](https://user-images.githubusercontent.com/11719160/57860128-2d72db80-77ec-11e9-9018-a4f606ce4988.png)

The `Connect to GitHub` dialog appears. If the user is already logged into GitHub, the `GitHub Enterprise` tab will be selected by default. If the user wants to log in using a different GitHub account, they can select the `GitHub` tab and log in. Previously this tab would have been disabled and the user would only have been able to log into a GitHub Enterprise server.

![image](https://user-images.githubusercontent.com/11719160/57701198-6297f600-7653-11e9-9e88-f743a5c842b4.png)

When the user logs in successfully, the appropriate `GitHub.com` or `Enterprise` tab will be selected and the repository list will be refreshed. If the user closes the `Connect to GitHub` dialog, the previous `Open from GitHub` tab will remain active.

### Reviewers

I've used a simple button for the `Login` action so as not to immediately violate the Visual Studio UI guidelines. Is there a more appropriate placement or control that I should use?

### What we also tried

Put `Sign in` as button next to `Clone` and `Open`.

![image](https://user-images.githubusercontent.com/11719160/57770391-1ce93500-7708-11e9-9904-b78b9bb425a1.png)

I found the `Sign in` button felt out of place next to `Clone` and `Open`.

`Sign in` has been moved to a link at the top right which is a convention on websites.

Fixes #2352