### PR TITLE
Return a null view for a null view-model

### DIFF
--- a/src/GitHub.VisualStudio.UI/Views/ViewLocator.cs
+++ b/src/GitHub.VisualStudio.UI/Views/ViewLocator.cs
@@ -32,10 +32,16 @@ namespace GitHub.VisualStudio.Views
         /// <param name="culture">Unused.</param>
         /// <returns>
         /// A new instance of a view for the specified view model, or an error string if a view
-        /// could not be located.
+        /// could not be located. A null view model will return null.
         /// </returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
+            if (value == null)
+            {
+                // Return null for a null view model
+                return null;
+            }
+
             var exportViewModelAttribute = value.GetType().GetCustomAttributes(typeof(ExportAttribute), false)
                 .OfType<ExportAttribute>()
                 .Where(x => typeof(IViewModel).IsAssignableFrom(x.ContractType))


### PR DESCRIPTION
For some reason clone/open view-model was starting off null when initialized from the essentials extension. This caused the `ViewLocator` to throw a null reference exception and stopped the clone/open dialog from working.

### What this PR does

- Make `ViewLocator` return a null view when a null view-model is passed in

### How to test

1. Install the essentials extension
2. Uninstall the full extension (if installed)
3. Open the clone/open dialog via `File > Clone or checkout code`
4. Check that dialog appears and repository can be cloned