### PR TITLE
Redirecting to the profile page after OAuth login

### DIFF
--- a/src/GitHub.Api/IOAuthCallbackListener.cs
+++ b/src/GitHub.Api/IOAuthCallbackListener.cs
@@ -16,5 +16,7 @@ namespace GitHub.Api
         /// <param name="cancel">A cancellation token.</param>
         /// <returns>The temporary code included in the callback.</returns>
         Task<string> Listen(string id, CancellationToken cancel);
+
+        void RedirectCloseStop(Uri url);
     }
 }

--- a/src/GitHub.Api/IOAuthCallbackListener.cs
+++ b/src/GitHub.Api/IOAuthCallbackListener.cs
@@ -17,6 +17,10 @@ namespace GitHub.Api
         /// <returns>The temporary code included in the callback.</returns>
         Task<string> Listen(string id, CancellationToken cancel);
 
-        void RedirectCloseStop(Uri url);
+        /// <summary>
+        /// Redirects the last context to respond with listen and stops the underlying http listener
+        /// </summary>
+        /// <param name="url">Url to redirect to.</param>
+        void RedirectLastContext(Uri url);
     }
 }

--- a/src/GitHub.Api/LoginManager.cs
+++ b/src/GitHub.Api/LoginManager.cs
@@ -157,7 +157,7 @@ namespace GitHub.Api
             await keychain.Save("[oauth]", token.AccessToken, hostAddress).ConfigureAwait(false);
             var result = await ReadUserWithRetry(client).ConfigureAwait(false);
             await keychain.Save(result.User.Login, token.AccessToken, hostAddress).ConfigureAwait(false);
-            oauthListener.RedirectCloseStop(hostAddress.WebUri.Append(result.User.Login));
+            oauthListener.RedirectLastContext(hostAddress.WebUri.Append(result.User.Login));
 
             return result;
         }

--- a/src/GitHub.Api/LoginManager.cs
+++ b/src/GitHub.Api/LoginManager.cs
@@ -157,6 +157,8 @@ namespace GitHub.Api
             await keychain.Save("[oauth]", token.AccessToken, hostAddress).ConfigureAwait(false);
             var result = await ReadUserWithRetry(client).ConfigureAwait(false);
             await keychain.Save(result.User.Login, token.AccessToken, hostAddress).ConfigureAwait(false);
+            oauthListener.RedirectCloseStop(hostAddress.WebUri.Append(result.User.Login));
+
             return result;
         }
 

--- a/src/GitHub.App/Services/OAuthCallbackListener.cs
+++ b/src/GitHub.App/Services/OAuthCallbackListener.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.Composition;
+﻿using System;
+using System.ComponentModel.Composition;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,6 +40,7 @@ namespace GitHub.Services
         }
 
         public readonly static string CallbackUrl = Invariant($"http://localhost:{CallbackPort}/");
+        private IHttpListenerContext lastContext;
 
         public async Task<string> Listen(string id, CancellationToken cancel)
         {
@@ -51,22 +53,29 @@ namespace GitHub.Services
                 {
                     while (true)
                     {
-                        var context = await httpListener.GetContextAsync().ConfigureAwait(false);
-                        var foo = context.Request;
-                        var queryParts = HttpUtility.ParseQueryString(context.Request.Url.Query);
+                        lastContext = await httpListener.GetContextAsync().ConfigureAwait(false);
+                        var queryParts = HttpUtility.ParseQueryString(lastContext.Request.Url.Query);
 
                         if (queryParts["state"] == id)
                         {
-                            context.Response.Close();
                             return queryParts["code"];
                         }
                     }
                 }
             }
-            finally
+            catch(Exception)
             {
                 httpListener.Stop();
+                throw;
             }
+        }
+
+        public void RedirectCloseStop(Uri url)
+        {
+            lastContext.Response.Redirect(url);
+            lastContext.Response.Close();
+
+            httpListener.Stop();
         }
     }
 }

--- a/src/GitHub.App/Services/OAuthCallbackListener.cs
+++ b/src/GitHub.App/Services/OAuthCallbackListener.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -70,7 +71,7 @@ namespace GitHub.Services
             }
         }
 
-        public void RedirectCloseStop(Uri url)
+        public void RedirectLastContext(Uri url)
         {
             lastContext.Response.Redirect(url);
             lastContext.Response.Close();

--- a/test/GitHub.App.UnitTests/Services/OAuthCallbackListenerTests.cs
+++ b/test/GitHub.App.UnitTests/Services/OAuthCallbackListenerTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GitHub.Extensions;
 using GitHub.Services;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Rothko;
 using NUnit.Framework;
 
@@ -31,6 +32,8 @@ namespace UnitTests.GitHub.App.Services
             var target = new OAuthCallbackListener(httpListener);
 
             await target.Listen("id1", CancellationToken.None);
+
+            target.RedirectLastContext(new Uri("http://github.com"));
 
             httpListener.Received(1).Stop();
         }
@@ -70,7 +73,37 @@ namespace UnitTests.GitHub.App.Services
 
             await target.Listen("id1", CancellationToken.None);
 
+            target.RedirectLastContext(new Uri("http://github.com"));
+
             context.Response.Received(1).Close();
+        }
+
+        [Test]
+        public async Task ContextFailureStopsListener()
+        {
+            var httpListener = Substitute.For<IHttpListener>();
+            httpListener
+                .When(x => x.Start())
+                .Do(_ => httpListener.IsListening.Returns(true));
+
+            var context = Substitute.For<IHttpListenerContext>();
+            context.Request.Url.Returns(new Uri($"https://localhost:42549?code=1234&state={"id1"}"));
+            httpListener.GetContext().Returns(context);
+            httpListener.GetContextAsync().Returns(context);
+
+            httpListener.GetContextAsync().Throws(new Exception());
+            var target = new OAuthCallbackListener(httpListener);
+
+            try
+            {
+                await target.Listen("id1", CancellationToken.None);
+            }
+            catch (Exception e)
+            {
+                
+            }
+
+            httpListener.Received(1).Stop();
         }
 
         static IHttpListener CreateHttpListener(string id)


### PR DESCRIPTION
Users are sometimes confused after Web OAuth as they are left with a blank browser tab. This change redirects the blank to to their profile page, which should now be authenticated. This should reinforce the idea that they are now authenticated on the web.