### PR TITLE
Fix switching back to Start Window after browser login

### DIFF
--- a/src/GitHub.VisualStudio.UI/Views/Dialog/LoginCredentialsView.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/LoginCredentialsView.xaml.cs
@@ -48,7 +48,7 @@ namespace GitHub.VisualStudio.Views.Dialog
             this.WhenAnyObservable(
                 x => x.ViewModel.GitHubLogin.LoginViaOAuth,
                 x => x.ViewModel.EnterpriseLogin.LoginViaOAuth)
-                .Subscribe(_ => SwitchToThisWindow());
+                .Subscribe(_ => SetForegroundWindow());
 
             hostTabControl.SelectionChanged += (s, e) =>
             {
@@ -125,19 +125,22 @@ namespace GitHub.VisualStudio.Views.Dialog
                 .BindTo(this, v => v.enterpriseTab.IsSelected));
         }
 
-        static void SwitchToThisWindow()
+        static bool SetForegroundWindow()
         {
             var hWnd = Process.GetCurrentProcess().MainWindowHandle;
             if (hWnd != IntPtr.Zero)
             {
-                NativeMethods.SwitchToThisWindow(hWnd, true);
+                return NativeMethods.SetForegroundWindow(hWnd);
             }
+
+            return false;
         }
 
         class NativeMethods
         {
             [DllImport("user32.dll")]
-            internal static extern void SwitchToThisWindow(IntPtr hWnd, bool fAltTab);
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool SetForegroundWindow(IntPtr hWnd);
         }
     }
 }

--- a/src/GitHub.VisualStudio.UI/Views/Dialog/LoginCredentialsView.xaml.cs
+++ b/src/GitHub.VisualStudio.UI/Views/Dialog/LoginCredentialsView.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Input;
 using GitHub.Controls;
@@ -46,7 +48,7 @@ namespace GitHub.VisualStudio.Views.Dialog
             this.WhenAnyObservable(
                 x => x.ViewModel.GitHubLogin.LoginViaOAuth,
                 x => x.ViewModel.EnterpriseLogin.LoginViaOAuth)
-                .Subscribe(_ => Application.Current.MainWindow?.Activate());
+                .Subscribe(_ => SwitchToThisWindow());
 
             hostTabControl.SelectionChanged += (s, e) =>
             {
@@ -121,6 +123,21 @@ namespace GitHub.VisualStudio.Views.Dialog
                 .Select(x => x == LoginMode.EnterpriseOnly)
                 .Where(x => x == true)
                 .BindTo(this, v => v.enterpriseTab.IsSelected));
+        }
+
+        static void SwitchToThisWindow()
+        {
+            var hWnd = Process.GetCurrentProcess().MainWindowHandle;
+            if (hWnd != IntPtr.Zero)
+            {
+                NativeMethods.SwitchToThisWindow(hWnd, true);
+            }
+        }
+
+        class NativeMethods
+        {
+            [DllImport("user32.dll")]
+            internal static extern void SwitchToThisWindow(IntPtr hWnd, bool fAltTab);
         }
     }
 }


### PR DESCRIPTION
Switching back to Visual Studio wasn't working when logging in using browser from the Start Window. This PR uses the `SetForegroundWindow` native method instead of calling `Activate()` on Visual Studio's main window (which was hidden).

### What this PR does

- Use `SetForegroundWindow` native method to re-activate Visual Studio's window
- Stop possible `InvalidOperationException` when hidden Visual Studio window was activated

### How to test

1. Open Visual Studio 2019
2. Select `Clone or checkout code`
3. Select `GitHub` icon
4. Select `Sign in`
5. Ensure than any browser windows are using the same monitor as Visual Studio
6. Select `GitHub` tab and then `Sign in with your browser`
7. Web browser should open (complete sign in if necessary)
8. The Start Window and `Open from GitHub` should appear on top of the browser (if it doesn't appear on top, its task bar icon should flash)

### Notes

This PR uses `SetForegroundWindow` instead of `SwitchToThisWindow`. `SwitchToThisWindow` is [marked](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-switchtothiswindow) with the following:
> [This function is not intended for general use. It may be altered or unavailable in subsequent versions of Windows.]

`SetForegroundWindow` is also used internally by the WPF `Window.Activate()` method.

The previous implementation that used `Window.Activate()` would sometimes crash with the following:

```
Application: devenv.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.InvalidOperationException
   at System.Windows.Window.VerifyHwndCreateShowState()
   at System.Windows.Window.Activate()
   at GitHub.VisualStudio.Views.Dialog.LoginCredentialsView+<>c.<.ctor>b__0_4(GitHub.Models.IConnection)
```

Fixes #2364 