### PR TITLE
Make the essentials extension a system component

### DIFF
--- a/src/GitHub.VisualStudio.16/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio.16/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="f4fbb70d-dee2-4dee-b322-bd74e3010e8f" Version="2.10.2.0" Language="en-US" Publisher="GitHub, Inc" />
-    <DisplayName>Clone from GitHub</DisplayName>
+    <DisplayName>GitHub Essentials</DisplayName>
     <Description>Clone or checkout code from GitHub</Description>
     <PackageId>GitHub.VisualStudio.16</PackageId>
   </Metadata>

--- a/src/GitHub.VisualStudio.16/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio.16/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description>Clone or checkout code from GitHub</Description>
     <PackageId>GitHub.VisualStudio.16</PackageId>
   </Metadata>
-  <Installation AllUsers="true">
+  <Installation AllUsers="true" SystemComponent="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
   </Installation>
   <Dependencies>


### PR DESCRIPTION
The essentials extension is currently the only extension that is installed as part of the Core Editor that appears on the extension manager. Marking is as a `SystemComponent` will prevent it from appearing on the extension manager.

![image](https://user-images.githubusercontent.com/11719160/58699430-59b65c80-8395-11e9-9d2b-3ea18a7fa567.png)

- Add `SystemComponent=true` setting to `.vsixmanafest`
- Change `DisplayName` to "GitHub Essentials"

### How to test

Testing before insertion

1. Install essentials extension
2. Check that `GitHub` icon appears on `Start Window > Clone or checkout code`
3. Check the essentials extension doesn't appear on `Extensions > Manage Extensions` (it should be empty)

Testing after insertion

1. Install Visual Studio without selecting _any_ workloads (e.g. .NET desktop development)
2. Check that `GitHub` icon appears on `Start Window > Clone or checkout code`
3. Check the essentials extension doesn't appear on `Extensions > Manage Extensions` (it should be empty)