### PR TITLE
Make comment margin appear on PR file view

### DIFF
--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -119,12 +119,9 @@ namespace GitHub.Services
 
                     if (!workingDirectory)
                     {
-                        var gitPath = FindGitPath(session.LocalRepository, fullPath);
-                        if (gitPath != null)
-                        {
-                            AddBufferTag(wpfTextView.TextBuffer, session, gitPath, commitSha, null);
-                            EnableNavigateToEditor(textView, session);
-                        }
+                        var gitPath = ToGitPath(session.LocalRepository, fullPath);
+                        AddBufferTag(wpfTextView.TextBuffer, session, gitPath, commitSha, null);
+                        EnableNavigateToEditor(textView, session);
                     }
                 }
 
@@ -489,7 +486,7 @@ namespace GitHub.Services
             return Path.Combine(localPath, relativePath);
         }
 
-        static string FindGitPath(LocalRepositoryModel localRepository, string path)
+        static string ToGitPath(LocalRepositoryModel localRepository, string path)
         {
             var basePath = localRepository.LocalPath + Path.DirectorySeparatorChar;
             if (path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
@@ -497,7 +494,7 @@ namespace GitHub.Services
                 return path.Substring(basePath.Length).Replace(Path.DirectorySeparatorChar, '/');
             }
 
-            return null;
+            throw new ArgumentException($"Path '{path}' is not in the working directory '{localRepository.LocalPath}'");
         }
 
         string GetText(IVsTextView textView)

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -111,22 +111,6 @@ namespace GitHub.InlineReviews.Services
         }
 
         /// <inheritdoc/>
-        public string GetRelativePath(string path)
-        {
-            if (Path.IsPathRooted(path))
-            {
-                var basePath = LocalRepository.LocalPath;
-
-                if (path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase) && path.Length > basePath.Length + 1)
-                {
-                    return path.Substring(basePath.Length + 1);
-                }
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc/>
         public async Task PostReviewComment(
             string body,
             string commitId,


### PR DESCRIPTION
When an individual file is opened from the PR detail view, the comment margin wasn't appearing.

### What this PR does

- Ensure that Git relative path is always used

### How to test

1. Open a solution that contains pull requests
2. Open the pull request detail view without checking out the PR
3. Right-click on a PR file that has comments and `View File`
4. Check that comments appear on comment margin

Fixes #2380