### PR TITLE
Be consistent about how we use relative paths and Git paths

### DIFF
--- a/src/GitHub.App/SampleData/GitServiceDesigner.cs
+++ b/src/GitHub.App/SampleData/GitServiceDesigner.cs
@@ -15,7 +15,7 @@ namespace GitHub.SampleData
         public IRepository GetRepository(string path) => null;
         public UriString GetUri(string path, string remote = "origin") => null;
         public UriString GetUri(IRepository repository, string remote = "origin") => null;
-        public Task<Patch> Compare(IRepository repository, string sha1, string sha2, string path) => null;
+        public Task<Patch> Compare(IRepository repository, string sha1, string sha2, string relativePath) => null;
         public Task<ContentChanges> CompareWith(IRepository repository, string sha1, string sha2, string path, byte[] contents) => null;
         public Task<TreeChanges> Compare(IRepository repository, string sha1, string sha2, bool detectRenames = false) => null;
     }

--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -265,7 +265,7 @@ namespace GitHub.Services
             Guard.ArgumentNotEmptyString(commitSha, nameof(commitSha));
             Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
-            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var gitPath = Paths.ToGitPath(relativePath);
             return Task.Run(() =>
             {
                 var commit = repository.Lookup<Commit>(commitSha);
@@ -285,7 +285,7 @@ namespace GitHub.Services
             Guard.ArgumentNotEmptyString(commitSha, nameof(commitSha));
             Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
-            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var gitPath = Paths.ToGitPath(relativePath);
             return Task.Run(() =>
             {
                 var commit = repository.Lookup<Commit>(commitSha);
@@ -315,7 +315,7 @@ namespace GitHub.Services
             Guard.ArgumentNotNull(repository, nameof(repository));
             Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
-            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var gitPath = Paths.ToGitPath(relativePath);
             return Task.Run(() =>
             {
                 if (repository.RetrieveStatus(gitPath) == FileStatus.Unaltered)

--- a/src/GitHub.App/Services/GitClient.cs
+++ b/src/GitHub.App/Services/GitClient.cs
@@ -259,40 +259,42 @@ namespace GitHub.Services
             });
         }
 
-        public Task<string> ExtractFile(IRepository repository, string commitSha, string fileName)
+        public Task<string> ExtractFile(IRepository repository, string commitSha, string relativePath)
         {
             Guard.ArgumentNotNull(repository, nameof(repository));
             Guard.ArgumentNotEmptyString(commitSha, nameof(commitSha));
-            Guard.ArgumentIsGitPath(fileName, nameof(fileName));
+            Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
+            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
             return Task.Run(() =>
             {
                 var commit = repository.Lookup<Commit>(commitSha);
                 if (commit == null)
                 {
-                    throw new FileNotFoundException("Couldn't find '" + fileName + "' at commit " + commitSha + ".");
+                    throw new FileNotFoundException("Couldn't find '" + gitPath + "' at commit " + commitSha + ".");
                 }
 
-                var blob = commit[fileName]?.Target as Blob;
+                var blob = commit[gitPath]?.Target as Blob;
                 return blob?.GetContentText();
             });
         }
 
-        public Task<byte[]> ExtractFileBinary(IRepository repository, string commitSha, string fileName)
+        public Task<byte[]> ExtractFileBinary(IRepository repository, string commitSha, string relativePath)
         {
             Guard.ArgumentNotNull(repository, nameof(repository));
             Guard.ArgumentNotEmptyString(commitSha, nameof(commitSha));
-            Guard.ArgumentIsGitPath(fileName, nameof(fileName));
+            Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
+            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
             return Task.Run(() =>
             {
                 var commit = repository.Lookup<Commit>(commitSha);
                 if (commit == null)
                 {
-                    throw new FileNotFoundException("Couldn't find '" + fileName + "' at commit " + commitSha + ".");
+                    throw new FileNotFoundException("Couldn't find '" + gitPath + "' at commit " + commitSha + ".");
                 }
 
-                var blob = commit[fileName]?.Target as Blob;
+                var blob = commit[gitPath]?.Target as Blob;
 
                 if (blob != null)
                 {
@@ -308,16 +310,17 @@ namespace GitHub.Services
             });
         }
 
-        public Task<bool> IsModified(IRepository repository, string path, byte[] contents)
+        public Task<bool> IsModified(IRepository repository, string relativePath, byte[] contents)
         {
             Guard.ArgumentNotNull(repository, nameof(repository));
-            Guard.ArgumentIsGitPath(path, nameof(path));
+            Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
+            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
             return Task.Run(() =>
             {
-                if (repository.RetrieveStatus(path) == FileStatus.Unaltered)
+                if (repository.RetrieveStatus(gitPath) == FileStatus.Unaltered)
                 {
-                    var treeEntry = repository.Head[path];
+                    var treeEntry = repository.Head[gitPath];
                     if (treeEntry?.TargetType != TreeEntryTargetType.Blob)
                     {
                         return false;
@@ -326,7 +329,7 @@ namespace GitHub.Services
                     var blob1 = (Blob)treeEntry.Target;
                     using (var s = contents != null ? new MemoryStream(contents) : new MemoryStream())
                     {
-                        var blob2 = repository.ObjectDatabase.CreateBlob(s, path);
+                        var blob2 = repository.ObjectDatabase.CreateBlob(s, gitPath);
                         var diff = repository.Diff.Compare(blob1, blob2);
                         return diff.LinesAdded != 0 || diff.LinesDeleted != 0;
                     }

--- a/src/GitHub.App/Services/GitHubContextService.cs
+++ b/src/GitHub.App/Services/GitHubContextService.cs
@@ -282,7 +282,8 @@ namespace GitHub.Services
                 return false;
             }
 
-            var fullPath = Path.Combine(repositoryDir, path.Replace('/', '\\'));
+            var relativePath = Paths.ToRelativePath(path);
+            var fullPath = Path.Combine(repositoryDir, relativePath);
             var textView = OpenDocument(fullPath);
             SetSelection(textView, context);
             return true;
@@ -410,7 +411,7 @@ namespace GitHub.Services
             Guard.ArgumentNotNull(commitish, nameof(commitish));
             Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
-            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var gitPath = Paths.ToGitPath(relativePath);
             using (var repo = gitService.GetRepository(repositoryDir))
             {
                 var commit = repo.Lookup<Commit>(commitish);

--- a/src/GitHub.App/Services/GitHubContextService.cs
+++ b/src/GitHub.App/Services/GitHubContextService.cs
@@ -282,7 +282,7 @@ namespace GitHub.Services
                 return false;
             }
 
-            var relativePath = Paths.ToRelativePath(path);
+            var relativePath = Paths.ToWindowsPath(path);
             var fullPath = Path.Combine(repositoryDir, relativePath);
             var textView = OpenDocument(fullPath);
             SetSelection(textView, context);

--- a/src/GitHub.App/Services/GitHubContextService.cs
+++ b/src/GitHub.App/Services/GitHubContextService.cs
@@ -404,16 +404,17 @@ namespace GitHub.Services
         }
 
         /// <inheritdoc/>
-        public bool HasChangesInWorkingDirectory(string repositoryDir, string commitish, string path)
+        public bool HasChangesInWorkingDirectory(string repositoryDir, string commitish, string relativePath)
         {
-            Guard.ArgumentNotNull(path, nameof(repositoryDir));
-            Guard.ArgumentNotNull(path, nameof(commitish));
-            Guard.ArgumentIsGitPath(path, nameof(path));
+            Guard.ArgumentNotNull(repositoryDir, nameof(repositoryDir));
+            Guard.ArgumentNotNull(commitish, nameof(commitish));
+            Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
+            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
             using (var repo = gitService.GetRepository(repositoryDir))
             {
                 var commit = repo.Lookup<Commit>(commitish);
-                var paths = new[] { path };
+                var paths = new[] { gitPath };
 
                 return repo.Diff.Compare<Patch>(commit.Tree, DiffTargets.WorkingDirectory, paths).Count() > 0;
             }

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -638,7 +638,7 @@ namespace GitHub.Services
                 var gitPath = Paths.ToGitPath(file.RelativePath);
                 var fileChange = changes.FirstOrDefault(x => x.Path == gitPath);
                 return fileChange?.Status == LibGit2Sharp.ChangeKind.Renamed ?
-                    Paths.ToRelativePath(fileChange.OldPath) : file.RelativePath;
+                    Paths.ToWindowsPath(fileChange.OldPath) : file.RelativePath;
             }
         }
 

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -119,12 +119,9 @@ namespace GitHub.Services
 
                     if (!workingDirectory)
                     {
-                        var gitPath = FindGitPath(session.LocalRepository, fullPath);
-                        if (gitPath != null)
-                        {
-                            AddBufferTag(wpfTextView.TextBuffer, session, gitPath, commitSha, null);
-                            EnableNavigateToEditor(textView, session);
-                        }
+                        var gitPath = ToGitPath(session.LocalRepository, fullPath);
+                        AddBufferTag(wpfTextView.TextBuffer, session, gitPath, commitSha, null);
+                        EnableNavigateToEditor(textView, session);
                     }
                 }
 
@@ -489,7 +486,7 @@ namespace GitHub.Services
             return Path.Combine(localPath, relativePath);
         }
 
-        static string FindGitPath(LocalRepositoryModel localRepository, string path)
+        static string ToGitPath(LocalRepositoryModel localRepository, string path)
         {
             var basePath = localRepository.LocalPath + Path.DirectorySeparatorChar;
             if (path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
@@ -497,7 +494,7 @@ namespace GitHub.Services
                 return path.Substring(basePath.Length).Replace(Path.DirectorySeparatorChar, '/');
             }
 
-            return null;
+            throw new ArgumentException($"Path '{path}' is not in the working directory '{localRepository.LocalPath}'");
         }
 
         string GetText(IVsTextView textView)

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -7,6 +7,7 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using EnvDTE;
 using GitHub.Commands;
+using GitHub.Primitives;
 using GitHub.Extensions;
 using GitHub.Models;
 using GitHub.Models.Drafts;
@@ -482,7 +483,7 @@ namespace GitHub.Services
         static string GetAbsolutePath(LocalRepositoryModel localRepository, string relativePath)
         {
             var localPath = localRepository.LocalPath;
-            relativePath = relativePath.Replace('/', Path.DirectorySeparatorChar);
+            relativePath = Paths.ToRelativePath(relativePath);
             return Path.Combine(localPath, relativePath);
         }
 
@@ -491,7 +492,7 @@ namespace GitHub.Services
             var basePath = localRepository.LocalPath + Path.DirectorySeparatorChar;
             if (path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
             {
-                return path.Substring(basePath.Length).Replace(Path.DirectorySeparatorChar, '/');
+                return Paths.ToGitPath(path.Substring(basePath.Length));
             }
 
             throw new ArgumentException($"Path '{path}' is not in the working directory '{localRepository.LocalPath}'");
@@ -654,10 +655,10 @@ namespace GitHub.Services
                 session.LocalRepository,
                 session.PullRequest))
             {
-                var gitPath = file.RelativePath.Replace(Path.DirectorySeparatorChar, '/');
+                var gitPath = Paths.ToGitPath(file.RelativePath);
                 var fileChange = changes.FirstOrDefault(x => x.Path == gitPath);
                 return fileChange?.Status == LibGit2Sharp.ChangeKind.Renamed ?
-                    fileChange.OldPath.Replace('/', Path.DirectorySeparatorChar) : file.RelativePath;
+                    Paths.ToRelativePath(fileChange.OldPath) : file.RelativePath;
             }
         }
 

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -90,13 +90,12 @@ namespace GitHub.Services
 
             try
             {
-                var fullPath = GetAbsolutePath(session.LocalRepository, relativePath);
                 string fileName;
                 string commitSha;
 
                 if (workingDirectory)
                 {
-                    fileName = fullPath;
+                    fileName = Path.Combine(session.LocalRepository.LocalPath, relativePath);
                     commitSha = null;
                 }
                 else
@@ -477,13 +476,6 @@ namespace GitHub.Services
             }
 
             return matchingLine;
-        }
-
-        static string GetAbsolutePath(LocalRepositoryModel localRepository, string relativePath)
-        {
-            var localPath = localRepository.LocalPath;
-            relativePath = Paths.ToRelativePath(relativePath);
-            return Path.Combine(localPath, relativePath);
         }
 
         string GetText(IVsTextView textView)

--- a/src/GitHub.App/Services/PullRequestEditorService.cs
+++ b/src/GitHub.App/Services/PullRequestEditorService.cs
@@ -120,8 +120,7 @@ namespace GitHub.Services
 
                     if (!workingDirectory)
                     {
-                        var gitPath = ToGitPath(session.LocalRepository, fullPath);
-                        AddBufferTag(wpfTextView.TextBuffer, session, gitPath, commitSha, null);
+                        AddBufferTag(wpfTextView.TextBuffer, session, relativePath, commitSha, null);
                         EnableNavigateToEditor(textView, session);
                     }
                 }
@@ -485,17 +484,6 @@ namespace GitHub.Services
             var localPath = localRepository.LocalPath;
             relativePath = Paths.ToRelativePath(relativePath);
             return Path.Combine(localPath, relativePath);
-        }
-
-        static string ToGitPath(LocalRepositoryModel localRepository, string path)
-        {
-            var basePath = localRepository.LocalPath + Path.DirectorySeparatorChar;
-            if (path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
-            {
-                return Paths.ToGitPath(path.Substring(basePath.Length));
-            }
-
-            throw new ArgumentException($"Path '{path}' is not in the working directory '{localRepository.LocalPath}'");
         }
 
         string GetText(IVsTextView textView)

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -779,7 +779,7 @@ namespace GitHub.Services
             Encoding encoding)
         {
             var tempFilePath = CalculateTempFileName(relativePath, commitSha, encoding);
-            var gitPath = relativePath.TrimStart('/').Replace('\\', '/');
+            var gitPath = Paths.ToGitPath(relativePath);
 
             if (!File.Exists(tempFilePath))
             {

--- a/src/GitHub.App/Services/PullRequestService.cs
+++ b/src/GitHub.App/Services/PullRequestService.cs
@@ -922,24 +922,22 @@ namespace GitHub.Services
             IRepository repo,
             int pullRequestNumber,
             string commitSha,
-            string path,
+            string relativePath,
             Encoding encoding,
             string tempFilePath)
         {
-            Guard.ArgumentIsGitPath(path, nameof(path));
-
             string contents;
 
             try
             {
-                contents = await gitClient.ExtractFile(repo, commitSha, path) ?? string.Empty;
+                contents = await gitClient.ExtractFile(repo, commitSha, relativePath) ?? string.Empty;
             }
             catch (FileNotFoundException)
             {
                 var pullHeadRef = $"refs/pull/{pullRequestNumber}/head";
                 var remote = await gitClient.GetHttpRemote(repo, "origin");
                 await gitClient.Fetch(repo, remote.Name, commitSha, pullHeadRef);
-                contents = await gitClient.ExtractFile(repo, commitSha, path) ?? string.Empty;
+                contents = await gitClient.ExtractFile(repo, commitSha, relativePath) ?? string.Empty;
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(tempFilePath));

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDirectoryNode.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDirectoryNode.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using GitHub.Primitives;
 
 namespace GitHub.ViewModels.GitHubPane
 {
@@ -12,11 +13,11 @@ namespace GitHub.ViewModels.GitHubPane
         /// <summary>
         /// Initializes a new instance of the <see cref="PullRequestDirectoryNode"/> class.
         /// </summary>
-        /// <param name="relativePath">The path to the directory, relative to the repository.</param>
-        public PullRequestDirectoryNode(string relativePath)
+        /// <param name="relativeOrGitPath">The path to the directory, relative to the repository.</param>
+        public PullRequestDirectoryNode(string relativeOrGitPath)
         {
-            DirectoryName = System.IO.Path.GetFileName(relativePath);
-            RelativePath = relativePath.Replace("/", "\\");
+            DirectoryName = System.IO.Path.GetFileName(relativeOrGitPath);
+            RelativePath = Paths.ToRelativePath(relativeOrGitPath);
             Directories = new List<IPullRequestDirectoryNode>();
             Files = new List<IPullRequestFileNode>();
         }

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestDirectoryNode.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestDirectoryNode.cs
@@ -17,7 +17,7 @@ namespace GitHub.ViewModels.GitHubPane
         public PullRequestDirectoryNode(string relativeOrGitPath)
         {
             DirectoryName = System.IO.Path.GetFileName(relativeOrGitPath);
-            RelativePath = Paths.ToRelativePath(relativeOrGitPath);
+            RelativePath = Paths.ToWindowsPath(relativeOrGitPath);
             Directories = new List<IPullRequestDirectoryNode>();
             Files = new List<IPullRequestFileNode>();
         }

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestFileNode.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestFileNode.cs
@@ -3,6 +3,7 @@ using System.IO;
 using GitHub.App;
 using GitHub.Extensions;
 using GitHub.Models;
+using GitHub.Primitives;
 using ReactiveUI;
 
 namespace GitHub.ViewModels.GitHubPane
@@ -21,7 +22,7 @@ namespace GitHub.ViewModels.GitHubPane
         /// Initializes a new instance of the <see cref="PullRequestFileNode"/> class.
         /// </summary>
         /// <param name="repositoryPath">The absolute path to the repository.</param>
-        /// <param name="relativePath">The path to the file, relative to the repository.</param>
+        /// <param name="relativeOrGitPath">The path to the file, relative to the repository.</param>
         /// <param name="sha">The SHA of the file.</param>
         /// <param name="status">The way the file was changed.</param>
         /// <param name="statusDisplay">The string to display in the [message] box next to the filename.</param>
@@ -31,17 +32,17 @@ namespace GitHub.ViewModels.GitHubPane
         /// </param>
         public PullRequestFileNode(
             string repositoryPath,
-            string relativePath,
+            string relativeOrGitPath,
             string sha,
             PullRequestFileStatus status,
             string oldPath)
         {
             Guard.ArgumentNotEmptyString(repositoryPath, nameof(repositoryPath));
-            Guard.ArgumentNotEmptyString(relativePath, nameof(relativePath));
+            Guard.ArgumentNotEmptyString(relativeOrGitPath, nameof(relativeOrGitPath));
             Guard.ArgumentNotEmptyString(sha, nameof(sha));
 
-            FileName = Path.GetFileName(relativePath);
-            RelativePath = relativePath.Replace("/", "\\");
+            FileName = Path.GetFileName(relativeOrGitPath);
+            RelativePath = Paths.ToRelativePath(relativeOrGitPath);
             Sha = sha;
             Status = status;
             OldPath = oldPath;
@@ -54,7 +55,7 @@ namespace GitHub.ViewModels.GitHubPane
             {
                 if (oldPath != null)
                 {
-                    StatusDisplay = Path.GetDirectoryName(oldPath) == Path.GetDirectoryName(relativePath) ?
+                    StatusDisplay = Path.GetDirectoryName(oldPath) == Path.GetDirectoryName(relativeOrGitPath) ?
                             Path.GetFileName(oldPath) : oldPath;
                 }
                 else

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestFileNode.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestFileNode.cs
@@ -42,7 +42,7 @@ namespace GitHub.ViewModels.GitHubPane
             Guard.ArgumentNotEmptyString(sha, nameof(sha));
 
             FileName = Path.GetFileName(relativeOrGitPath);
-            RelativePath = Paths.ToRelativePath(relativeOrGitPath);
+            RelativePath = Paths.ToWindowsPath(relativeOrGitPath);
             Sha = sha;
             Status = status;
             OldPath = oldPath;

--- a/src/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/PullRequestFilesViewModel.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using GitHub.Extensions;
 using GitHub.Models;
+using GitHub.Primitives;
 using GitHub.Services;
 using LibGit2Sharp;
 using ReactiveUI;
@@ -224,8 +225,8 @@ namespace GitHub.ViewModels.GitHubPane
         {
             if (file.Status == PullRequestFileStatus.Renamed)
             {
-                var fileName = file.FileName.Replace("/", "\\");
-                return changes?.Renamed.FirstOrDefault(x => x.Path == fileName)?.OldPath;
+                var gitPath = Paths.ToGitPath(file.FileName);
+                return changes?.Renamed.FirstOrDefault(x => x.Path == gitPath)?.OldPath;
             }
 
             return null;

--- a/src/GitHub.App/ViewModels/PullRequestReviewCommentThreadViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestReviewCommentThreadViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -197,7 +198,7 @@ namespace GitHub.ViewModels
                     await Session.PostReviewComment(
                         comment.Body,
                         File.CommitSha,
-                        File.RelativePath.Replace("\\", "/"),
+                        File.RelativePath.Replace(Path.DirectorySeparatorChar, '/'),
                         File.Diff,
                         diffPosition.DiffLineNumber).ConfigureAwait(false);
                 }
@@ -234,8 +235,8 @@ namespace GitHub.ViewModels
             string relativePath,
             int lineNumber)
         {
-            relativePath = relativePath.Replace("\\", "/");
-            var key = Invariant($"pr-review-comment|{cloneUri}|{pullRequestNumber}|{relativePath}");
+            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var key = Invariant($"pr-review-comment|{cloneUri}|{pullRequestNumber}|{gitPath}");
             return (key, lineNumber.ToString(CultureInfo.InvariantCulture));
         }
 

--- a/src/GitHub.App/ViewModels/PullRequestReviewCommentThreadViewModel.cs
+++ b/src/GitHub.App/ViewModels/PullRequestReviewCommentThreadViewModel.cs
@@ -198,7 +198,7 @@ namespace GitHub.ViewModels
                     await Session.PostReviewComment(
                         comment.Body,
                         File.CommitSha,
-                        File.RelativePath.Replace(Path.DirectorySeparatorChar, '/'),
+                        Paths.ToGitPath(File.RelativePath),
                         File.Diff,
                         diffPosition.DiffLineNumber).ConfigureAwait(false);
                 }
@@ -235,7 +235,7 @@ namespace GitHub.ViewModels
             string relativePath,
             int lineNumber)
         {
-            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var gitPath = Paths.ToGitPath(relativePath);
             var key = Invariant($"pr-review-comment|{cloneUri}|{pullRequestNumber}|{gitPath}");
             return (key, lineNumber.ToString(CultureInfo.InvariantCulture));
         }

--- a/src/GitHub.Exports/Primitives/Paths.cs
+++ b/src/GitHub.Exports/Primitives/Paths.cs
@@ -21,11 +21,11 @@ namespace GitHub.Primitives
         }
 
         /// <summary>
-        /// Convert from a Git path to a relative path.
+        /// Convert from a Git path to a path that uses the Windows directory separator ('\').
         /// </summary>
-        /// <param name="gitPath">A working directory relative path which uses the '/' directory separator.</param>
-        /// <returns>A relative paht that uses the <see cref="Path.DirectorySeparatorChar"/> directory separator.</returns>
-        public static string ToRelativePath(string gitPath)
+        /// <param name="gitPath">A relative path that uses the '/' directory separator.</param>
+        /// <returns>A relative path that uses the <see cref="Path.DirectorySeparatorChar"/> directory separator ('\' on Windows).</returns>
+        public static string ToWindowsPath(string gitPath)
         {
             return gitPath.Replace(GitDirectorySeparatorChar, Path.DirectorySeparatorChar);
         }

--- a/src/GitHub.Exports/Primitives/Paths.cs
+++ b/src/GitHub.Exports/Primitives/Paths.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.IO;
+
+namespace GitHub.Primitives
+{
+    public static class Paths
+    {
+        public const char GitDirectorySeparatorChar = '/';
+
+        public static string ToGitPath(string relativePath)
+        {
+            return relativePath.Replace(Path.DirectorySeparatorChar, GitDirectorySeparatorChar);
+        }
+
+        public static string ToRelativePath(string relativePath)
+        {
+            return relativePath.Replace(GitDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        }
+    }
+}

--- a/src/GitHub.Exports/Primitives/Paths.cs
+++ b/src/GitHub.Exports/Primitives/Paths.cs
@@ -3,18 +3,31 @@ using System.IO;
 
 namespace GitHub.Primitives
 {
+    /// <summary>
+    /// Convert to and from Git paths.
+    /// </summary>
     public static class Paths
     {
         public const char GitDirectorySeparatorChar = '/';
 
+        /// <summary>
+        /// Convert from a relative path to a Git path.
+        /// </summary>
+        /// <param name="relativePath">A relative path.</param>
+        /// <returns>A working directory relative path which uses the '/' directory separator.</returns>
         public static string ToGitPath(string relativePath)
         {
             return relativePath.Replace(Path.DirectorySeparatorChar, GitDirectorySeparatorChar);
         }
 
-        public static string ToRelativePath(string relativePath)
+        /// <summary>
+        /// Convert from a Git path to a relative path.
+        /// </summary>
+        /// <param name="gitPath">A working directory relative path which uses the '/' directory separator.</param>
+        /// <returns>A relative paht that uses the <see cref="Path.DirectorySeparatorChar"/> directory separator.</returns>
+        public static string ToRelativePath(string gitPath)
         {
-            return relativePath.Replace(GitDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            return gitPath.Replace(GitDirectorySeparatorChar, Path.DirectorySeparatorChar);
         }
     }
 }

--- a/src/GitHub.Exports/Services/GitService.cs
+++ b/src/GitHub.Exports/Services/GitService.cs
@@ -241,7 +241,7 @@ namespace GitHub.Services
             Guard.ArgumentNotEmptyString(sha2, nameof(sha2));
             Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
-            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var gitPath = Paths.ToGitPath(relativePath);
             return Task.Run(() =>
             {
                 var commit1 = repository.Lookup<Commit>(sha1);
@@ -269,7 +269,7 @@ namespace GitHub.Services
             Guard.ArgumentNotEmptyString(sha2, nameof(sha1));
             Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
-            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var gitPath = Paths.ToGitPath(relativePath);
             return Task.Run(() =>
             {
                 var commit1 = repository.Lookup<Commit>(sha1);

--- a/src/GitHub.Exports/Services/GitService.cs
+++ b/src/GitHub.Exports/Services/GitService.cs
@@ -234,13 +234,14 @@ namespace GitHub.Services
             IRepository repository,
             string sha1,
             string sha2,
-            string path)
+            string relativePath)
         {
             Guard.ArgumentNotNull(repository, nameof(repository));
             Guard.ArgumentNotEmptyString(sha1, nameof(sha1));
             Guard.ArgumentNotEmptyString(sha2, nameof(sha2));
-            Guard.ArgumentIsGitPath(path, nameof(path));
+            Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
+            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
             return Task.Run(() =>
             {
                 var commit1 = repository.Lookup<Commit>(sha1);
@@ -251,7 +252,7 @@ namespace GitHub.Services
                     return repository.Diff.Compare<Patch>(
                         commit1.Tree,
                         commit2.Tree,
-                        new[] { path },
+                        new[] { gitPath },
                         defaultCompareOptions);
                 }
                 else
@@ -261,27 +262,28 @@ namespace GitHub.Services
             });
         }
 
-        public Task<ContentChanges> CompareWith(IRepository repository, string sha1, string sha2, string path, byte[] contents)
+        public Task<ContentChanges> CompareWith(IRepository repository, string sha1, string sha2, string relativePath, byte[] contents)
         {
             Guard.ArgumentNotNull(repository, nameof(repository));
             Guard.ArgumentNotEmptyString(sha1, nameof(sha1));
             Guard.ArgumentNotEmptyString(sha2, nameof(sha1));
-            Guard.ArgumentIsGitPath(path, nameof(path));
+            Guard.ArgumentIsRelativePath(relativePath, nameof(relativePath));
 
+            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
             return Task.Run(() =>
             {
                 var commit1 = repository.Lookup<Commit>(sha1);
                 var commit2 = repository.Lookup<Commit>(sha2);
 
                 var treeChanges = repository.Diff.Compare<TreeChanges>(commit1.Tree, commit2.Tree, defaultCompareOptions);
-                var change = treeChanges.FirstOrDefault(x => x.Path == path);
+                var change = treeChanges.FirstOrDefault(x => x.Path == gitPath);
                 var oldPath = change?.OldPath;
 
                 if (commit1 != null && oldPath != null)
                 {
                     var contentStream = contents != null ? new MemoryStream(contents) : new MemoryStream();
                     var blob1 = commit1[oldPath]?.Target as Blob ?? repository.ObjectDatabase.CreateBlob(new MemoryStream());
-                    var blob2 = repository.ObjectDatabase.CreateBlob(contentStream, path);
+                    var blob2 = repository.ObjectDatabase.CreateBlob(contentStream, gitPath);
                     return repository.Diff.Compare(blob1, blob2, defaultCompareOptions);
                 }
 

--- a/src/GitHub.Exports/Services/IGitService.cs
+++ b/src/GitHub.Exports/Services/IGitService.cs
@@ -90,13 +90,13 @@ namespace GitHub.Services
         /// <param name="repository">The repository</param>
         /// <param name="sha1">The SHA of the first commit.</param>
         /// <param name="sha2">The SHA of the second commit.</param>
-        /// <param name="path">The relative path to the file (using '/' directory separator).</param>
+        /// <param name="path">The relative path to the file.</param>
         /// <param name="contents">The contents to compare with the file.</param>
         /// <returns>
         /// A <see cref="Patch"/> object or null if the commit could not be found in the repository.
         /// </returns>
         /// <exception cref="ArgumentException">If <paramref name="path"/> contains a '\'.</exception>
-        Task<ContentChanges> CompareWith(IRepository repository, string sha1, string sha2, string path, byte[] contents);
+        Task<ContentChanges> CompareWith(IRepository repository, string sha1, string sha2, string relativePath, byte[] contents);
 
         /// <summary>
         /// Compares two commits.

--- a/src/GitHub.Extensions/Guard.cs
+++ b/src/GitHub.Extensions/Guard.cs
@@ -7,14 +7,9 @@ namespace GitHub.Extensions
 {
     public static class Guard
     {
-        public static void ArgumentIsGitPath(string value, string name)
+        public static void ArgumentIsRelativePath(string value, string name)
         {
             ArgumentNotNull(value, name);
-
-            if (value.Contains('\\'))
-            {
-                throw new ArgumentException($"The value '{value}' must use '/' not '\\' as directory separator", name);
-            }
 
             if (Path.IsPathRooted(value))
             {

--- a/src/GitHub.InlineReviews/Services/DiffService.cs
+++ b/src/GitHub.InlineReviews/Services/DiffService.cs
@@ -29,9 +29,9 @@ namespace GitHub.InlineReviews.Services
             IRepository repo,
             string baseSha,
             string headSha,
-            string path)
+            string relativePath)
         {
-            var patch = await gitService.Compare(repo, baseSha, headSha, path);
+            var patch = await gitService.Compare(repo, baseSha, headSha, relativePath);
 
             if (patch != null)
             {

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -81,7 +81,7 @@ namespace GitHub.InlineReviews.Services
             try
             {
                 PullRequestSessionFile file;
-                var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+                var gitPath = Paths.ToGitPath(relativePath);
                 var key = gitPath + '@' + commitSha;
 
                 if (!fileIndex.TryGetValue(key, out file))

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -81,12 +81,12 @@ namespace GitHub.InlineReviews.Services
             try
             {
                 PullRequestSessionFile file;
-                var normalizedPath = relativePath.Replace("\\", "/");
-                var key = normalizedPath + '@' + commitSha;
+                var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+                var key = gitPath + '@' + commitSha;
 
                 if (!fileIndex.TryGetValue(key, out file))
                 {
-                    file = new PullRequestSessionFile(normalizedPath, commitSha);
+                    file = new PullRequestSessionFile(relativePath, commitSha);
                     await UpdateFile(file);
                     fileIndex.Add(key, file);
                 }

--- a/src/GitHub.InlineReviews/Services/PullRequestSession.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSession.cs
@@ -111,22 +111,6 @@ namespace GitHub.InlineReviews.Services
         }
 
         /// <inheritdoc/>
-        public string GetRelativePath(string path)
-        {
-            if (Path.IsPathRooted(path))
-            {
-                var basePath = LocalRepository.LocalPath;
-
-                if (path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase) && path.Length > basePath.Length + 1)
-                {
-                    return path.Substring(basePath.Length + 1);
-                }
-            }
-
-            return null;
-        }
-
-        /// <inheritdoc/>
         public async Task PostReviewComment(
             string body,
             string commitId,

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -95,7 +95,7 @@ namespace GitHub.InlineReviews.Services
             PullRequestDetailModel pullRequest,
             string relativePath)
         {
-            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var gitPath = Paths.ToGitPath(relativePath);
 
             return pullRequest.CheckSuites
                 ?.SelectMany(checkSuite => checkSuite.CheckRuns.Select(checkRun => new { checkSuite, checkRun }))
@@ -114,7 +114,7 @@ namespace GitHub.InlineReviews.Services
             IReadOnlyList<DiffChunk> diff,
             string headSha)
         {
-            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            var gitPath = Paths.ToGitPath(relativePath);
 
             var threadsByPosition = pullRequest.Threads
                 .Where(x => x.Path == gitPath)

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -95,13 +95,13 @@ namespace GitHub.InlineReviews.Services
             PullRequestDetailModel pullRequest,
             string relativePath)
         {
-            relativePath = relativePath.Replace("\\", "/");
+            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
 
             return pullRequest.CheckSuites
                 ?.SelectMany(checkSuite => checkSuite.CheckRuns.Select(checkRun => new { checkSuite, checkRun }))
                 .SelectMany(arg =>
                     arg.checkRun.Annotations
-                        .Where(annotation => annotation.Path == relativePath)
+                        .Where(annotation => annotation.Path == gitPath)
                         .Select(annotation => new InlineAnnotationModel(arg.checkSuite, arg.checkRun, annotation)))
                 .OrderBy(tuple => tuple.StartLine)
                 .ToArray();
@@ -114,10 +114,10 @@ namespace GitHub.InlineReviews.Services
             IReadOnlyList<DiffChunk> diff,
             string headSha)
         {
-            relativePath = relativePath.Replace("\\", "/");
+            var gitPath = relativePath.Replace(Path.DirectorySeparatorChar, '/');
 
             var threadsByPosition = pullRequest.Threads
-                .Where(x => x.Path == relativePath)
+                .Where(x => x.Path == gitPath)
                 .OrderBy(x => x.Id)
                 .GroupBy(x => Tuple.Create(x.OriginalCommitSha, x.OriginalPosition));
             var threads = new List<IInlineCommentThreadModel>();


### PR DESCRIPTION
In versions of `LibGit2Sharp` we were using prior to #2142, `LibGit2Sharp` didn't care whether paths passed contained `/` or `\` and could cope with absolute as well as working directory relative paths. In recent versions of `LibGit2Sharp`, Git paths must be working directory relative and use `/` as their directory separator. If they're not in this format the operation will silently fail (as if the file simply doesn't exist).

Because GitHub for Visual Studio was developed when `LibGit2Sharp` didn't care about directory separators, we often mixed up relative paths and Git paths (which use '/'). This has created the potential for a whole category of bugs and has made the code difficult to reason about. This PR is attempt to bring a bit of sanity to the situation.

### What this PR does

- Use `relativePath` when a parameter contains a Windows style relative path
- Use `gitPath` when a parameter contains a Git style relative path
- Use `Guard.ArgumentIsRelativePath` to check we're not passing absolute paths
- Automatically convert Windows paths to Git style relative paths before using them
- Factor out conversions into `Paths.ToGitPath` and `Paths.ToWindowsPath`
- Fix #2380 which was caused by passing `AddBufferTag` an absolute path
- Fix issue where `PullRequestSessionFile` used a Git relative path and `PullRequestSessionLiveFile` a Windows relative path
- Fix issue where `GetOldFileName` was using a Windows style relative path

### How to test

Here is how to test one of the bugs it fixes

1. Open a solution that contains pull requests
2. Open the pull request detail view without checking out the PR
3. Right-click on a PR file that has comments and `View File`
4. Check that comments appear on comment margin

Fixes #2380