### PR TITLE
Bumping version to 2.10.6

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Product>GitHub Extension for Visual Studio</Product>
-    <Version>2.10.5.0</Version>
+    <Version>2.10.6.0</Version>
     <Copyright>Copyright © GitHub, Inc. 2014-2018</Copyright>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2019 Preview
-version: '2.10.5.{build}'
+version: '2.10.6.{build}'
 skip_tags: true
 
 install:

--- a/src/GitHub.VisualStudio.16/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio.16/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="f4fbb70d-dee2-4dee-b322-bd74e3010e8f" Version="2.10.5.0" Language="en-US" Publisher="GitHub, Inc" />
+    <Identity Id="f4fbb70d-dee2-4dee-b322-bd74e3010e8f" Version="2.10.6.0" Language="en-US" Publisher="GitHub, Inc" />
     <DisplayName>GitHub Essentials</DisplayName>
     <Description>Clone or checkout code from GitHub</Description>
     <PackageId>GitHub.VisualStudio.16</PackageId>

--- a/src/GitHub.VisualStudio.Vsix/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio.Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="c3d3dc68-c977-411f-b3e8-03b0dccf7dfc" Version="2.10.5.0" Language="en-US" Publisher="GitHub, Inc" />
+    <Identity Id="c3d3dc68-c977-411f-b3e8-03b0dccf7dfc" Version="2.10.6.0" Language="en-US" Publisher="GitHub, Inc" />
     <DisplayName>GitHub Extension for Visual Studio</DisplayName>
     <Description xml:space="preserve">A Visual Studio Extension that brings the GitHub Flow into Visual Studio.</Description>
     <PackageId>GitHub.VisualStudio</PackageId>

--- a/src/common/SolutionInfo.cs
+++ b/src/common/SolutionInfo.cs
@@ -18,6 +18,6 @@ using System.Runtime.InteropServices;
 namespace System
 {
     internal static class AssemblyVersionInformation {
-        internal const string Version = "2.10.5.0";
+        internal const string Version = "2.10.6.0";
     }
 }


### PR DESCRIPTION
The version uploaded to the Visual Studio Marketplace must be higher than the one included with Visual Studio.