### PR TITLE
Only use Visual Studio Telemetry on VS 2017 and above

### DIFF
--- a/src/GitHub.VisualStudio.16/CompositionServices.cs
+++ b/src/GitHub.VisualStudio.16/CompositionServices.cs
@@ -82,7 +82,7 @@ namespace GitHub.VisualStudio
                 var gitHubServiceProvider = compositionContainer.GetExportedValue<IGitHubServiceProvider>();
                 var usageService = compositionContainer.GetExportedValue<IUsageService>();
                 var joinableTaskContext = compositionContainer.GetExportedValue<JoinableTaskContext>();
-                return new UsageTracker(gitHubServiceProvider, usageService, packageSettings, joinableTaskContext);
+                return new UsageTracker(gitHubServiceProvider, usageService, packageSettings, joinableTaskContext, vsTelemetry: true);
             }
         }
 

--- a/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
+++ b/src/GitHub.VisualStudio/GitHub.VisualStudio.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Services\ShowDialogService.cs" />
     <Compile Include="Services\UsageService.cs" />
     <Compile Include="Services\UsageTracker.cs" />
+    <Compile Include="Services\VisualStudioUsageTracker.cs" />
     <Compile Include="Services\VSGitExtFactory.cs" />
     <Compile Include="Settings\Constants.cs" />
     <Compile Include="Services\ConnectionManager.cs" />

--- a/src/GitHub.VisualStudio/GitHubPackage.cs
+++ b/src/GitHub.VisualStudio/GitHubPackage.cs
@@ -393,7 +393,13 @@ namespace GitHub.VisualStudio
                 Assumes.Present(serviceProvider);
                 Assumes.Present(settings);
 
-                return new UsageTracker(serviceProvider, usageService, settings, ThreadHelper.JoinableTaskContext);
+                // Only use Visual Studio Telemetry on VS 2017 and above
+                await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                var dte = await GetServiceAsync(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
+                Assumes.Present(dte);
+                var vsTelemetry = new Version(dte.Version) >= new Version(15, 0);
+
+                return new UsageTracker(serviceProvider, usageService, settings, ThreadHelper.JoinableTaskContext, vsTelemetry);
             }
             else if (serviceType == typeof(IVSGitExt))
             {

--- a/src/GitHub.VisualStudio/Services/UsageTracker.cs
+++ b/src/GitHub.VisualStudio/Services/UsageTracker.cs
@@ -23,6 +23,7 @@ namespace GitHub.Services
         readonly IUsageService service;
         IConnectionManager connectionManager;
         readonly IPackageSettings userSettings;
+        readonly bool vsTelemetry;
         IVSServices vsservices;
         IUsageTracker visualStudioUsageTracker;
         IDisposable timer;
@@ -32,12 +33,15 @@ namespace GitHub.Services
             IGitHubServiceProvider gitHubServiceProvider,
             IUsageService service,
             IPackageSettings settings,
-            JoinableTaskContext joinableTaskContext)
+            JoinableTaskContext joinableTaskContext,
+            bool vsTelemetry)
         {
             this.gitHubServiceProvider = gitHubServiceProvider;
             this.service = service;
             this.userSettings = settings;
             JoinableTaskContext = joinableTaskContext;
+            this.vsTelemetry = vsTelemetry;
+
             timer = StartTimer();
         }
 
@@ -101,9 +105,7 @@ namespace GitHub.Services
             connectionManager = gitHubServiceProvider.GetService<IConnectionManager>();
             vsservices = gitHubServiceProvider.GetService<IVSServices>();
 
-            // Only create VisualStudioUsageTracker on Visual Studio 2017 and above
-            var dte = gitHubServiceProvider.GetService<EnvDTE.DTE>();
-            if (new Version(dte.Version) >= new Version(15, 0))
+            if (vsTelemetry)
             {
                 log.Verbose("Creating VisualStudioUsageTracker");
                 visualStudioUsageTracker = new VisualStudioUsageTracker(connectionManager);

--- a/src/GitHub.VisualStudio/Services/UsageTracker.cs
+++ b/src/GitHub.VisualStudio/Services/UsageTracker.cs
@@ -7,8 +7,6 @@ using System.Threading.Tasks;
 using GitHub.Logging;
 using GitHub.Models;
 using GitHub.Settings;
-using Microsoft.VisualStudio.Telemetry;
-using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Threading;
 using Serilog;
 using Task = System.Threading.Tasks.Task;
@@ -17,25 +15,6 @@ namespace GitHub.Services
 {
     public sealed class UsageTracker : IUsageTracker, IDisposable
     {
-        private const int TelemetryVersion = 1; // Please update the version every time you want to indicate a change in telemetry logic when the extension itself is updated
-
-        private const string EventNamePrefix = "vs/github/usagetracker/";
-        private const string PropertyPrefix = "vs.github.";
-
-        static class Event
-        {
-            public const string UsageTracker = EventNamePrefix + "increment-counter";
-        }
-
-        static class Property
-        {
-            public const string TelemetryVersion = PropertyPrefix + nameof(TelemetryVersion);
-            public const string CounterName = PropertyPrefix + nameof(CounterName);
-            public const string ExtensionVersion = PropertyPrefix + nameof(ExtensionVersion);
-            public const string IsGitHubUser = PropertyPrefix + nameof(IsGitHubUser);
-            public const string IsEnterpriseUser = PropertyPrefix + nameof(IsEnterpriseUser);
-        }
-
         static readonly ILogger log = LogManager.ForContext<UsageTracker>();
         readonly IGitHubServiceProvider gitHubServiceProvider;
 
@@ -45,6 +24,7 @@ namespace GitHub.Services
         IConnectionManager connectionManager;
         readonly IPackageSettings userSettings;
         IVSServices vsservices;
+        IUsageTracker visualStudioUsageTracker;
         IDisposable timer;
         bool firstTick = true;
 
@@ -77,27 +57,13 @@ namespace GitHub.Services
 
             var updateTask = UpdateUsageMetrics(propertyInfo);
 
-            LogTelemetryEvent(counterName);
-
-            await updateTask;
-        }
-
-        void LogTelemetryEvent(string counterName)
-        {
-            const string numberOfPrefix = "numberof";
-            if (counterName.StartsWith(numberOfPrefix, StringComparison.OrdinalIgnoreCase))
+            if (visualStudioUsageTracker != null)
             {
-                counterName = counterName.Substring(numberOfPrefix.Length);
+                // Not available on Visual Studio 2015
+                await visualStudioUsageTracker.IncrementCounter(counter);
             }
 
-            var operation = new TelemetryEvent(Event.UsageTracker);
-            operation.Properties[Property.TelemetryVersion] = TelemetryVersion;
-            operation.Properties[Property.CounterName] = counterName;
-            operation.Properties[Property.ExtensionVersion] = AssemblyVersionInformation.Version;
-            operation.Properties[Property.IsGitHubUser] = IsGitHubUser;
-            operation.Properties[Property.IsEnterpriseUser] = IsEnterpriseUser;
-
-            TelemetryService.DefaultSession.PostEvent(operation);
+            await updateTask;
         }
 
         bool IsEnterpriseUser =>
@@ -111,7 +77,7 @@ namespace GitHub.Services
             var data = await service.ReadLocalData();
             var usage = await GetCurrentReport(data);
 
-            var value = (int) propertyInfo.GetValue(usage.Measures);
+            var value = (int)propertyInfo.GetValue(usage.Measures);
             propertyInfo.SetValue(usage.Measures, value + 1);
 
             await service.WriteLocalData(data);
@@ -134,6 +100,15 @@ namespace GitHub.Services
             client = gitHubServiceProvider.TryGetService<IMetricsService>();
             connectionManager = gitHubServiceProvider.GetService<IConnectionManager>();
             vsservices = gitHubServiceProvider.GetService<IVSServices>();
+
+            // Only create VisualStudioUsageTracker on Visual Studio 2017 and above
+            var dte = gitHubServiceProvider.GetService<EnvDTE.DTE>();
+            if (new Version(dte.Version) >= new Version(15, 0))
+            {
+                log.Verbose("Creating VisualStudioUsageTracker");
+                visualStudioUsageTracker = new VisualStudioUsageTracker(connectionManager);
+            }
+
             initialized = true;
         }
 

--- a/src/GitHub.VisualStudio/Services/VisualStudioUsageTracker.cs
+++ b/src/GitHub.VisualStudio/Services/VisualStudioUsageTracker.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using GitHub.Models;
+using Microsoft.VisualStudio.Telemetry;
+using Task = System.Threading.Tasks.Task;
+
+namespace GitHub.Services
+{
+    /// <summary>
+    /// Implementation of <see cref="IUsageTracker" /> that uses the built in Visual Studio telemetry.
+    /// </summary>
+    /// <remarks>
+    /// This should only be created on Visual Studio 2017 and above.
+    /// </remarks>
+    public sealed class VisualStudioUsageTracker : IUsageTracker
+    {
+        const int TelemetryVersion = 1; // Please update the version every time you want to indicate a change in telemetry logic when the extension itself is updated
+
+        const string EventNamePrefix = "vs/github/usagetracker/";
+        const string PropertyPrefix = "vs.github.";
+
+        readonly IConnectionManager connectionManager;
+
+        public VisualStudioUsageTracker(IConnectionManager connectionManager)
+        {
+            this.connectionManager = connectionManager;
+        }
+
+        public Task IncrementCounter(Expression<Func<UsageModel.MeasuresModel, int>> counter)
+        {
+            var property = (MemberExpression)counter.Body;
+            var propertyInfo = (PropertyInfo)property.Member;
+            var counterName = propertyInfo.Name;
+            LogTelemetryEvent(counterName);
+
+            return Task.CompletedTask;
+        }
+
+        void LogTelemetryEvent(string counterName)
+        {
+            const string numberOfPrefix = "numberof";
+            if (counterName.StartsWith(numberOfPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                counterName = counterName.Substring(numberOfPrefix.Length);
+            }
+
+            var operation = new TelemetryEvent(Event.UsageTracker);
+            operation.Properties[Property.TelemetryVersion] = TelemetryVersion;
+            operation.Properties[Property.CounterName] = counterName;
+            operation.Properties[Property.ExtensionVersion] = AssemblyVersionInformation.Version;
+            operation.Properties[Property.IsGitHubUser] = IsGitHubUser;
+            operation.Properties[Property.IsEnterpriseUser] = IsEnterpriseUser;
+
+            TelemetryService.DefaultSession.PostEvent(operation);
+        }
+
+        bool IsEnterpriseUser =>
+            connectionManager?.Connections.Any(x => !x.HostAddress.IsGitHubDotCom()) ?? false;
+
+        bool IsGitHubUser =>
+            connectionManager?.Connections.Any(x => x.HostAddress.IsGitHubDotCom()) ?? false;
+
+        static class Event
+        {
+            public const string UsageTracker = EventNamePrefix + "increment-counter";
+        }
+
+        static class Property
+        {
+            public const string TelemetryVersion = PropertyPrefix + nameof(TelemetryVersion);
+            public const string CounterName = PropertyPrefix + nameof(CounterName);
+            public const string ExtensionVersion = PropertyPrefix + nameof(ExtensionVersion);
+            public const string IsGitHubUser = PropertyPrefix + nameof(IsGitHubUser);
+            public const string IsEnterpriseUser = PropertyPrefix + nameof(IsEnterpriseUser);
+        }
+    }
+}

--- a/test/GitHub.VisualStudio.UnitTests/Services/MetricsTests.cs
+++ b/test/GitHub.VisualStudio.UnitTests/Services/MetricsTests.cs
@@ -24,7 +24,7 @@ namespace MetricsTests
         public void ShouldStartTimer()
         {
             var service = Substitute.For<IUsageService>();
-            var target = new UsageTracker(CreateServiceProvider(), service, CreatePackageSettings(), new JoinableTaskContext());
+            var target = new UsageTracker(CreateServiceProvider(), service, CreatePackageSettings(), new JoinableTaskContext(), vsTelemetry: false);
 
             service.Received(1).StartTimer(Arg.Any<Func<Task>>(), TimeSpan.FromMinutes(3), TimeSpan.FromDays(1));
         }
@@ -111,7 +111,8 @@ namespace MetricsTests
                 CreateServiceProvider(),
                 usageService,
                 CreatePackageSettings(),
-                new JoinableTaskContext());
+                new JoinableTaskContext(),
+                vsTelemetry: false);
 
             await target.IncrementCounter(x => x.NumberOfClones);
             UsageData result = usageService.ReceivedCalls().First(x => x.GetMethodInfo().Name == "WriteLocalData").GetArguments()[0] as UsageData;
@@ -128,7 +129,8 @@ namespace MetricsTests
                 CreateServiceProvider(),
                 service,
                 CreatePackageSettings(),
-                new JoinableTaskContext());
+                new JoinableTaskContext(),
+                vsTelemetry: false);
 
             await target.IncrementCounter(x => x.NumberOfClones);
             await service.Received(1).WriteLocalData(Arg.Is<UsageData>(data => 
@@ -155,7 +157,8 @@ namespace MetricsTests
                 CreateServiceProvider(),
                 service,
                 CreatePackageSettings(),
-                new JoinableTaskContext());
+                new JoinableTaskContext(),
+                vsTelemetry: false);
 
             await target.IncrementCounter(x => x.NumberOfClones);
             await service.Received(1).WriteLocalData(Arg.Is<UsageData>(data =>
@@ -177,7 +180,7 @@ namespace MetricsTests
             service.WhenForAnyArgs(x => x.StartTimer(null, new TimeSpan(), new TimeSpan()))
                 .Do(x => tick = x.ArgAt<Func<Task>>(0));
 
-            var target = new UsageTracker(serviceProvider, service, CreatePackageSettings(), new JoinableTaskContext());
+            var target = new UsageTracker(serviceProvider, service, CreatePackageSettings(), new JoinableTaskContext(), vsTelemetry: false);
 
             return Tuple.Create(target, tick);
         }


### PR DESCRIPTION
_GitHub for Visual Studio is currently broken on Visual Studio 2015, so I'd like this get this PR out ASAP!_

Make sure that `Microsoft.VisualStudio.Telemetry` is only used on Visual Studio 2017 and above.

## What this PR does

- Factor out `VisualStudioUsageTracker`, an implementation of `IUsageTracker` that uses VS Telemetry
- Add option to `UsageTracker` to use VS Telemetry
- Only use VS Telemetry when running on Visual Studio 2017 and above

## Reviewers

The aim of this PR was to factor out `VisualStudioUsageTracker` which can be selectively disabled in Visual Studio 2015. If we deprecate the GitHub telemetry in a future version, we can simply replace `UsageTracker` with `VisualStudioUsageTracker`. I've deliberately touched `UsageTracker` as little as possible because it's complex and I don't want to break anything!

I've tested this on Visual Studio 2015, 2017 and 2019 using the steps below.

## How to test

### Repro

1. Open Visual Studio 2015
2. Install GitHub for Visual Studio `2.10.6` from the Visual Studio Marketplace and Restart
![image](https://user-images.githubusercontent.com/11719160/65883063-2c52dd00-e38e-11e9-8e0c-5a5319346001.png)
3. Open `Team Explorer - Connect`
4. Click on `Manage Connections > Connect to GitHub`
5. Click on the `GitHub` tab (if `GitHub Enterprise` is selected)
6. Click `Sign in with your browser`
7. After authenticating return to Visual Studio
8. Click on the `GitHub` tab (if `GitHub Enterprise` is selected)
9. Expect the following error
![image](https://user-images.githubusercontent.com/11719160/65883717-7daf9c00-e38f-11e9-8c05-af80b3f8c751.png)

### Fix

1. Close all instances of Visual Studio and open `GitHub.VisualStudio.vsix` from this PR
https://ci.appveyor.com/project/github-windows/visualstudio/builds/27765286/artifacts
2. Install for and open Visual Studio 2015
3. Open `Team Explorer - Connect`
4. Click on `Manage Connections > Connect to GitHub`
5. Click on the `GitHub` tab (if `GitHub Enterprise` is selected)
6. Click `Sign in with your browser`
7. Expect `Connect to GitHub` dialog to close

Fixes #2423