### PR TITLE
Use only VS Telemetry in Essentials extension

### DIFF
--- a/src/GitHub.VisualStudio.16/CompositionServices.cs
+++ b/src/GitHub.VisualStudio.16/CompositionServices.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Primitives;
@@ -9,8 +8,6 @@ using System.Linq;
 using System.Reflection;
 using GitHub.Api;
 using GitHub.Services;
-using GitHub.Settings;
-using GitHub.VisualStudio.Settings;
 using GitHub.VisualStudio.Views.Dialog.Clone;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
@@ -55,10 +52,7 @@ namespace GitHub.VisualStudio
         static CompositionContainer CreateVisualStudioCompositionContainer(ExportProvider defaultExportProvider)
         {
             var compositionContainer = CreateCompositionContainer(defaultExportProvider);
-
-            var gitHubServiceProvider = compositionContainer.GetExportedValue<IGitHubServiceProvider>();
-            var packageSettings = new PackageSettings(gitHubServiceProvider);
-            var usageTracker = UsageTrackerFactory.CreateUsageTracker(compositionContainer, packageSettings);
+            var usageTracker = CreateUsageTracker(compositionContainer);
             compositionContainer.ComposeExportedValue(usageTracker);
 
             return compositionContainer;
@@ -67,23 +61,16 @@ namespace GitHub.VisualStudio
         static CompositionContainer CreateOutOfProcCompositionContainer()
         {
             var compositionContainer = CreateCompositionContainer(CreateOutOfProcExports());
-
-            var packageSettings = new OutOfProcPackageSettings();
-            var usageTracker = UsageTrackerFactory.CreateUsageTracker(compositionContainer, packageSettings);
+            var usageTracker = CreateUsageTracker(compositionContainer);
             compositionContainer.ComposeExportedValue(usageTracker);
 
             return compositionContainer;
         }
 
-        class UsageTrackerFactory
+        static IUsageTracker CreateUsageTracker(CompositionContainer compositionContainer)
         {
-            internal static IUsageTracker CreateUsageTracker(CompositionContainer compositionContainer, IPackageSettings packageSettings)
-            {
-                var gitHubServiceProvider = compositionContainer.GetExportedValue<IGitHubServiceProvider>();
-                var usageService = compositionContainer.GetExportedValue<IUsageService>();
-                var joinableTaskContext = compositionContainer.GetExportedValue<JoinableTaskContext>();
-                return new UsageTracker(gitHubServiceProvider, usageService, packageSettings, joinableTaskContext, vsTelemetry: true);
-            }
+            var connectionManager = compositionContainer.GetExport<IConnectionManager>();
+            return new VisualStudioUsageTracker(connectionManager);
         }
 
         static CompositionContainer CreateOutOfProcExports()
@@ -268,22 +255,6 @@ namespace GitHub.VisualStudio
         #endregion
 
         public ExportProvider ExportProvider { get; }
-    }
-
-    public class OutOfProcPackageSettings : IPackageSettings
-    {
-        public bool CollectMetrics { get; set; } = true;
-        public bool EnableTraceLogging { get; set; } = true;
-        public bool EditorComments { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public UIState UIState { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public bool HideTeamExplorerWelcomeMessage { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        public void Save()
-        {
-            throw new NotImplementedException();
-        }
     }
 
     class OutOfProcSVsServiceProvider : SVsServiceProvider

--- a/src/GitHub.VisualStudio/Services/UsageTracker.cs
+++ b/src/GitHub.VisualStudio/Services/UsageTracker.cs
@@ -21,7 +21,7 @@ namespace GitHub.Services
         bool initialized;
         IMetricsService client;
         readonly IUsageService service;
-        IConnectionManager connectionManager;
+        Lazy<IConnectionManager> connectionManager;
         readonly IPackageSettings userSettings;
         readonly bool vsTelemetry;
         IVSServices vsservices;
@@ -71,10 +71,10 @@ namespace GitHub.Services
         }
 
         bool IsEnterpriseUser =>
-            this.connectionManager?.Connections.Any(x => !x.HostAddress.IsGitHubDotCom()) ?? false;
+            connectionManager.Value?.Connections.Any(x => !x.HostAddress.IsGitHubDotCom()) ?? false;
 
         bool IsGitHubUser =>
-            this.connectionManager?.Connections.Any(x => x.HostAddress.IsGitHubDotCom()) ?? false;
+            connectionManager.Value?.Connections.Any(x => x.HostAddress.IsGitHubDotCom()) ?? false;
 
         async Task UpdateUsageMetrics(PropertyInfo propertyInfo)
         {
@@ -102,7 +102,7 @@ namespace GitHub.Services
             await JoinableTaskContext.Factory.SwitchToMainThreadAsync();
 
             client = gitHubServiceProvider.TryGetService<IMetricsService>();
-            connectionManager = gitHubServiceProvider.GetService<IConnectionManager>();
+            connectionManager = new Lazy<IConnectionManager>(() => gitHubServiceProvider.GetService<IConnectionManager>());
             vsservices = gitHubServiceProvider.GetService<IVSServices>();
 
             if (vsTelemetry)

--- a/src/GitHub.VisualStudio/Services/VisualStudioUsageTracker.cs
+++ b/src/GitHub.VisualStudio/Services/VisualStudioUsageTracker.cs
@@ -21,9 +21,9 @@ namespace GitHub.Services
         const string EventNamePrefix = "vs/github/usagetracker/";
         const string PropertyPrefix = "vs.github.";
 
-        readonly IConnectionManager connectionManager;
+        readonly Lazy<IConnectionManager> connectionManager;
 
-        public VisualStudioUsageTracker(IConnectionManager connectionManager)
+        public VisualStudioUsageTracker(Lazy<IConnectionManager> connectionManager)
         {
             this.connectionManager = connectionManager;
         }
@@ -57,10 +57,10 @@ namespace GitHub.Services
         }
 
         bool IsEnterpriseUser =>
-            connectionManager?.Connections.Any(x => !x.HostAddress.IsGitHubDotCom()) ?? false;
+            connectionManager.Value?.Connections.Any(x => !x.HostAddress.IsGitHubDotCom()) ?? false;
 
         bool IsGitHubUser =>
-            connectionManager?.Connections.Any(x => x.HostAddress.IsGitHubDotCom()) ?? false;
+            connectionManager.Value?.Connections.Any(x => x.HostAddress.IsGitHubDotCom()) ?? false;
 
         static class Event
         {


### PR DESCRIPTION
The Essentials extension doesn't include an options pane, so there is no way to opt out of GitHub telemetry. Change to use only the built in VS Telemetry which has a global opt out via `Help > Send Feedback >  Settings...`.

### What this PR does

- Use `VisualStudioUsageTracker` instead of `UsageTracker` for telemetry
- Pass a `Lazy<IConnectionManager>` to `VisualStudioUsageTracker` so we don't need to create a live object when initializing MEF

### Testing

I've checked that the `Open from GitHub` and `Publish to GitHub` functionality still works.