### PR TITLE
Make GitHub.OpenFromUrl command use active repository when possible

### DIFF
--- a/src/GitHub.VisualStudio/Commands/OpenFromUrlCommand.cs
+++ b/src/GitHub.VisualStudio/Commands/OpenFromUrlCommand.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using GitHub.Commands;
+using GitHub.Models;
+using GitHub.Primitives;
 using GitHub.Services;
 using GitHub.Services.Vssdk.Commands;
 using Task = System.Threading.Tasks.Task;
@@ -12,6 +14,8 @@ namespace GitHub.VisualStudio.Commands
     {
         readonly Lazy<IDialogService> dialogService;
         readonly Lazy<IRepositoryCloneService> repositoryCloneService;
+        readonly Lazy<ITeamExplorerContext> teamExplorerContext;
+        readonly Lazy<IGitHubContextService> gitHubContextService;
 
         /// <summary>
         /// Gets the GUID of the group the command belongs to.
@@ -26,23 +30,57 @@ namespace GitHub.VisualStudio.Commands
         [ImportingConstructor]
         public OpenFromUrlCommand(
             Lazy<IDialogService> dialogService,
-            Lazy<IRepositoryCloneService> repositoryCloneService) :
+            Lazy<IRepositoryCloneService> repositoryCloneService,
+            Lazy<ITeamExplorerContext> teamExplorerContext,
+            Lazy<IGitHubContextService> gitHubContextService) :
             base(CommandSet, CommandId)
         {
             this.dialogService = dialogService;
             this.repositoryCloneService = repositoryCloneService;
+            this.teamExplorerContext = teamExplorerContext;
+            this.gitHubContextService = gitHubContextService;
 
             // See https://code.msdn.microsoft.com/windowsdesktop/AllowParams-2005-9442298f
             ParametersDescription = "u";    // accept a single url
         }
 
-        public override async Task Execute(string url)
+        public override async Task Execute(string targetUrl)
         {
-            var cloneDialogResult = await dialogService.Value.ShowCloneDialog(null, url);
+            if (targetUrl != null)
+            {
+                // Navigate to  to active repository when same as target
+                if (FindActiveRepositoryDir(targetUrl) is string repositoryDir)
+                {
+                    // Navigate to context for supported URL types (e.g. /blob/ URLs)
+                    if (gitHubContextService.Value.FindContextFromUrl(targetUrl) is GitHubContext context)
+                    {
+                        gitHubContextService.Value.TryNavigateToContext(repositoryDir, context);
+                        return;
+                    }
+                }
+            }
+
+            var cloneDialogResult = await dialogService.Value.ShowCloneDialog(null, targetUrl);
             if (cloneDialogResult != null)
             {
                 await repositoryCloneService.Value.CloneOrOpenRepository(cloneDialogResult);
             }
+        }
+
+        string FindActiveRepositoryDir(UriString targetUrl)
+        {
+            if (teamExplorerContext.Value.ActiveRepository is LocalRepositoryModel activeRepository)
+            {
+                if (activeRepository.CloneUrl is UriString activeUrl)
+                {
+                    if (UriString.RepositoryUrlsAreEqual(activeUrl, targetUrl))
+                    {
+                        return activeRepository.LocalPath;
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/test/GitHub.VisualStudio.UnitTests/Commands/OpenFromUrlCommandTests.cs
+++ b/test/GitHub.VisualStudio.UnitTests/Commands/OpenFromUrlCommandTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Threading.Tasks;
+using GitHub.Models;
+using GitHub.Services;
+using GitHub.VisualStudio.Commands;
+using NSubstitute;
+using NUnit.Framework;
+
+public static class OpenFromUrlCommandTests
+{
+    public class TheExecuteMethod
+    {
+        [Test]
+        public async Task Executed_From_Menu()
+        {
+            var target = CreateOpenFromUrlCommand();
+
+            await target.Execute(null);
+        }
+
+        [Test]
+        public async Task Executed_From_Command_Window()
+        {
+            var target = CreateOpenFromUrlCommand();
+
+            await target.Execute("");
+        }
+
+        [TestCase("https://github.com/github/visualstudio", null, null, 0, 1, Description = "No active repository")]
+        [TestCase("https://github.com/github/visualstudio", null, @"c:\source\visualstudio", 0, 1, Description = "Active repository with no remote")]
+        [TestCase("https://github.com/github/visualstudio", "https://github.com/github/visualstudio", @"c:\source\visualstudio", 1, 0, Description = "Matching active repository")]
+        [TestCase("HTTPS://GITHUB.COM/GITHUB/VISUALSTUDIO", "https://github.com/github/visualstudio", @"c:\source\visualstudio", 1, 0, Description = "Matching active repository with different case")]
+        [TestCase("https://github.com/jcansdale/visualstudio", "https://github.com/github/visualstudio", @"c:\source\visualstudio", 0, 1, Description = "Fork of target repository")]
+        [TestCase("https://github.com/owner1/repo1", "https://github.com/owner2/repo2", @"c:\source", 0, 1, Description = "Different repository")]
+        public async Task Execute(string url, string activeUrl, string activePath, int tryNavigateToContextCalls, int showCloneDialogCalls)
+        {
+            var dialogService = Substitute.For<IDialogService>();
+            var teamExplorerContext = Substitute.For<ITeamExplorerContext>();
+            var activeRepository = new LocalRepositoryModel { CloneUrl = activeUrl, LocalPath = activePath };
+            teamExplorerContext.ActiveRepository.Returns(activeRepository);
+            var gitHubContextService = Substitute.For<IGitHubContextService>();
+            gitHubContextService.FindContextFromUrl(url).Returns(new GitHubContext());
+            dialogService.ShowCloneDialog(null, url).Returns(new CloneDialogResult(@"c:\source", url));
+            var target = CreateOpenFromUrlCommand(dialogService: dialogService,
+                teamExplorerContext: teamExplorerContext, gitHubContextService: gitHubContextService);
+
+            await target.Execute(url);
+
+            gitHubContextService.ReceivedWithAnyArgs(tryNavigateToContextCalls).TryNavigateToContext(null, null);
+            await dialogService.ReceivedWithAnyArgs(showCloneDialogCalls).ShowCloneDialog(null, null);
+        }
+    }
+
+    static OpenFromUrlCommand CreateOpenFromUrlCommand(
+        IDialogService dialogService = null,
+        IRepositoryCloneService repositoryCloneService = null,
+        ITeamExplorerContext teamExplorerContext = null,
+        IGitHubContextService gitHubContextService = null)
+    {
+        dialogService = dialogService ?? Substitute.For<IDialogService>();
+        repositoryCloneService = repositoryCloneService ?? Substitute.For<IRepositoryCloneService>();
+        teamExplorerContext = teamExplorerContext ?? Substitute.For<ITeamExplorerContext>();
+        gitHubContextService = gitHubContextService ?? Substitute.For<IGitHubContextService>();
+
+        return new OpenFromUrlCommand(
+            new Lazy<IDialogService>(() => dialogService),
+            new Lazy<IRepositoryCloneService>(() => repositoryCloneService),
+            new Lazy<ITeamExplorerContext>(() => teamExplorerContext),
+            new Lazy<IGitHubContextService>(() => gitHubContextService));
+    }
+}


### PR DESCRIPTION
At the moment `GitHub.OpenFromUrl` always shows the open/clone dialog, even when the target repository is already active. This disrupts the workflow when opening a file in the active workspace.

## What this PR does

- Check if the target repository host/owner/repositoryName matches the active repository
- Attempt to navigate inside the active workspace when the repositories match
- Only show the open/clone when the active repository is different to the target repository

## How to test

1. Open the command window
2. Enter
```
> GitHub.OpenFromUrl https://github.com/grokys/PullRequestSandbox
```
3. Open/clone dialog should appear
4. Clone the repository
5. Enter
```
> GitHub.OpenFromUrl https://github.com/grokys/PullRequestSandbox/blob/master/PullRequestSandbox/Program.cs#L11-L14
```
6. The `Program.cs` file should open (without showing the Open/Clone dialog)
7. Enter
```
> GitHub.OpenFromUrl https://github.com/github/VisualStudio
```
8. The Open/Clone dialog should appear
