### PR TITLE
Point ReleaseNotes URL at GitHub releases page

### DIFF
--- a/src/GitHub.VisualStudio.Vsix/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio.Vsix/source.extension.vsixmanifest
@@ -7,7 +7,7 @@
     <PackageId>GitHub.VisualStudio</PackageId>
     <MoreInfo>https://visualstudio.github.com</MoreInfo>
     <License>LICENSE.txt</License>
-    <ReleaseNotes>https://visualstudio.github.com/release-notes.html</ReleaseNotes>
+    <ReleaseNotes>https://github.com/github/VisualStudio/releases</ReleaseNotes>
     <Icon>Resources\logo_128x128.png</Icon>
     <PreviewImage>Resources\preview_200x200.png</PreviewImage>
     <Tags>GitHub;git;open source;source control;branch;pull request;team explorer;commit;publish</Tags>


### PR DESCRIPTION
The following page is no longer being updated:
https://visualstudio.github.com/release-notes.html

Point `extension.vsixmanifest` at the GitHub releases page instead:
https://github.com/github/VisualStudio/releases

Fixes #2440