### PR TITLE
Remove dependency on TeamExplorer.Extensions 

### DIFF
--- a/src/GitHub.VisualStudio.Vsix/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio.Vsix/source.extension.vsixmanifest
@@ -14,7 +14,6 @@
   </Metadata>
   <Installation AllUsers="true" Experimental="false">
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
-    <InstallationTarget Id="Microsoft.VisualStudio.IntegratedShell" Version="[15.0,17.0)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/GitHub.VisualStudio.Vsix/source.extension.vsixmanifest
+++ b/src/GitHub.VisualStudio.Vsix/source.extension.vsixmanifest
@@ -19,7 +19,6 @@
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0,)" />
-    <Dependency Id="Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions" DisplayName="Team Explorer" d:Source="Installed" Version="[14.0,)" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitHub.Exports" Path="|GitHub.Exports|" />


### PR DESCRIPTION
### What this PR does

Remove dependency on `Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions`. We can't guarantee this will always be there!

- Remove dependency on `Microsoft.VisualStudio.TeamFoundation.TeamExplorer.Extensions`
- Remove support for Visual Studio Team Explorer 2017 (revert #961)

The extension should continue to work with Visual Studio 2015 and above.