### PR TITLE
Update GraphQL schema and add CheckConclusionState.(Skipped / Stale)

### DIFF
--- a/src/GitHub.App/Services/FromGraphQlExtensions.cs
+++ b/src/GitHub.App/Services/FromGraphQlExtensions.cs
@@ -29,6 +29,10 @@ namespace GitHub.Services
                     return CheckConclusionState.Success;
                 case Octokit.GraphQL.Model.CheckConclusionState.Neutral:
                     return CheckConclusionState.Neutral;
+                case Octokit.GraphQL.Model.CheckConclusionState.Skipped:
+                    return CheckConclusionState.Skipped;
+                case Octokit.GraphQL.Model.CheckConclusionState.Stale:
+                    return CheckConclusionState.Stale;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(value), value, null);
             }

--- a/src/GitHub.App/Services/MentionsAutoCompleteSource.cs
+++ b/src/GitHub.App/Services/MentionsAutoCompleteSource.cs
@@ -54,7 +54,7 @@ namespace GitHub.Services
             {
                 query = new Query().Repository(owner: Var(nameof(owner)), name: Var(nameof(name)))
                 .Select(repository =>
-                    repository.MentionableUsers(null, null, null, null)
+                    repository.MentionableUsers(null, null, null, null, null)
                         .AllPages()
                         .Select(sourceItem => 
                             new SuggestionItem(sourceItem.Login, 

--- a/src/GitHub.Exports/Models/CheckConclusionState.cs
+++ b/src/GitHub.Exports/Models/CheckConclusionState.cs
@@ -8,5 +8,7 @@
         Failure,
         Success,
         Neutral,
+        Skipped,
+        Stale
     }
 }

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -347,7 +347,7 @@ namespace GitHub.InlineReviews.Services
                         }).ToList(),
                         Threads = pr.ReviewThreads(null, null, null, null).AllPages().Select(thread => new PullRequestReviewThreadModel
                         {
-                            Comments = thread.Comments(null, null, null, null).AllPages().Select(comment => new CommentAdapter
+                            Comments = thread.Comments(null, null, null, null, null).AllPages().Select(comment => new CommentAdapter
                             {
                                 Id = comment.Id.Value,
                                 PullRequestId = comment.PullRequest.Number,


### PR DESCRIPTION
The PR list was failing because new check conclusion states have been added. This updates the GraphQL schema and adds these new states.

### What this PR does

- Update to the latest GraphQL schema
- Fix `FromGraphQl ` so that knows about `CheckConclusionState` `Skipped` and `Stale` 
- Add extra `null` arguments to `MentionableUsers` and `Comments `

### How to test

- Check PR list is showing correctly for https://github.com/AvaloniaUI/Avalonia

### Questions

Which of the `Avalonia` PRs was using the new state and what does it look like now?

Fixes #2472