### PR TITLE
Make pull request functionality more discoverable outside of Team Explorer

### DIFF
--- a/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
@@ -98,7 +98,7 @@ namespace GitHub.InlineReviews.Services
                 return;
             }
 
-            var viewModel = CreatePullRequestStatusViewModel(session);
+            var viewModel = CreatePullRequestStatusViewModel(repository, session);
             ShowStatus(viewModel);
         }
 
@@ -155,12 +155,14 @@ namespace GitHub.InlineReviews.Services
             return false;
         }
 
-        PullRequestStatusViewModel CreatePullRequestStatusViewModel(IPullRequestSession session)
+        PullRequestStatusViewModel CreatePullRequestStatusViewModel(LocalRepositoryModel repository, IPullRequestSession session)
         {
             var pullRequestStatusViewModel = new PullRequestStatusViewModel(openPullRequestsCommand, showCurrentPullRequestCommand);
             var pullRequest = session?.PullRequest;
             pullRequestStatusViewModel.Number = pullRequest?.Number;
             pullRequestStatusViewModel.Title = pullRequest?.Title;
+            pullRequestStatusViewModel.RepositoryName = repository?.Name;
+            pullRequestStatusViewModel.RepositoryOwner = repository?.Owner;
             return pullRequestStatusViewModel;
         }
 

--- a/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestStatusBarManager.cs
@@ -157,13 +157,13 @@ namespace GitHub.InlineReviews.Services
 
         PullRequestStatusViewModel CreatePullRequestStatusViewModel(LocalRepositoryModel repository, IPullRequestSession session)
         {
-            var pullRequestStatusViewModel = new PullRequestStatusViewModel(openPullRequestsCommand, showCurrentPullRequestCommand);
-            var pullRequest = session?.PullRequest;
-            pullRequestStatusViewModel.Number = pullRequest?.Number;
-            pullRequestStatusViewModel.Title = pullRequest?.Title;
-            pullRequestStatusViewModel.RepositoryName = repository?.Name;
-            pullRequestStatusViewModel.RepositoryOwner = repository?.Owner;
-            return pullRequestStatusViewModel;
+            return new PullRequestStatusViewModel(openPullRequestsCommand, showCurrentPullRequestCommand)
+            {
+                Number = session?.PullRequest?.Number,
+                Title = session?.PullRequest?.Title,
+                RepositoryName = repository?.Name,
+                RepositoryOwner = repository?.Owner,
+            };
         }
 
         PullRequestStatusView ShowStatus(PullRequestStatusViewModel pullRequestStatusViewModel = null)

--- a/src/GitHub.InlineReviews/ViewModels/PullRequestStatusViewModel.cs
+++ b/src/GitHub.InlineReviews/ViewModels/PullRequestStatusViewModel.cs
@@ -8,6 +8,8 @@ namespace GitHub.InlineReviews.ViewModels
     {
         int? number;
         string title;
+        string repositoryName;
+        string repositoryOwner;
 
         public PullRequestStatusViewModel(ICommand openPullRequestsCommand, ICommand showCurrentPullRequestCommand)
         {
@@ -37,6 +39,32 @@ namespace GitHub.InlineReviews.ViewModels
                 {
                     title = value;
                     PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Title)));
+                }
+            }
+        }
+
+        public string RepositoryOwner
+        {
+            get { return repositoryOwner; }
+            set
+            {
+                if (repositoryOwner != value)
+                {
+                    repositoryOwner = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(RepositoryOwner)));
+                }
+            }
+        }
+
+        public string RepositoryName
+        {
+            get { return repositoryName; }
+            set
+            {
+                if (repositoryName != value)
+                {
+                    repositoryName = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(RepositoryName)));
                 }
             }
         }

--- a/src/GitHub.InlineReviews/Views/PullRequestStatusView.xaml
+++ b/src/GitHub.InlineReviews/Views/PullRequestStatusView.xaml
@@ -49,7 +49,10 @@
                         Fill="White"
                         VerticalAlignment="Bottom"
                         Margin="0 0 4 0 "
-                        Icon="git_pull_request" />
+                        Icon="mark_github" />
+                    <TextBlock VerticalAlignment="Center">
+                        <Run Text="{Binding RepositoryOwner}" /> / <Run Text="{Binding RepositoryName}" />
+                    </TextBlock>
                 </StackPanel>
             </Button>
             <Grid.ToolTip>


### PR DESCRIPTION
This PR makes the GitHub tool window more discoverable from outside of Team Explorer.

- Show the `owner` / `name` of GitHub repositories on status bar
- Open `GitHub` tool window when activated

![image](https://user-images.githubusercontent.com/11719160/76568624-24ed3f00-64a9-11ea-9ba4-06772345bf80.png)

