### PR TITLE
Use a default client ID/secret for testing

### DIFF
--- a/src/GitHub.Api/GitHub.Api.csproj
+++ b/src/GitHub.Api/GitHub.Api.csproj
@@ -4,7 +4,14 @@
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  
+   
+  <PropertyGroup>
+    <!-- Use a default client ID/secret for testing -->
+    <!-- https://github.com/organizations/editor-tools/settings/applications/620133 -->
+    <GitHubVS_ClientId Condition="'$(GitHubVS_ClientId)' == ''">2454a3e6102fd41cc212</GitHubVS_ClientId>
+    <GitHubVS_ClientSecret Condition="'$(GitHubVS_ClientSecret)' == ''">2157c138e970165d955d09562230afcfbcda23f2</GitHubVS_ClientSecret>
+  </PropertyGroup>
+   
   <Import Project="$(SolutionDir)\src\common\signing.props" />
 
   <Target Name="AddClientSecret" BeforeTargets="BeforeCompile"


### PR DESCRIPTION
### What this PR does

Include a default client ID / secret. This will be used when building an externally contributed PRs or when the `GitHubVS_ClientId` / `GitHubVS_ClientSecret` env vars haven't been defined.

The following application will be used (this isn't publicly visible):
https://github.com/organizations/editor-tools/settings/applications/620133

### How to test

Building locally

1. Clone https://github.com/github/VisualStudio
2. Build and install the VSIX
3. Open the login dialog and sign in using browser
4. Check the test application is being used
5. Add `GitHubVS_ClientId` / `GitHubVS_ClientSecret` for a different application
6. Build and install the VSIX
7. Check the different application is being used

- [x] tested

GitHub Actions workflow

1. Submit an externally contributed PR
2. Install the VSIX artifact
3. Open the login dialog and sign in using browser
4. Check the test application is being used

- [ ] tested
