### PR TITLE
Always default to GitHub login

### DIFF
--- a/src/GitHub.App/ViewModels/Dialog/LoginCredentialsViewModel.cs
+++ b/src/GitHub.App/ViewModels/Dialog/LoginCredentialsViewModel.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.ComponentModel.Composition;
 using System.Reactive.Linq;
-using GitHub.App;
-using GitHub.Primitives;
 using GitHub.Services;
 using ReactiveUI;
 
@@ -28,8 +26,7 @@ namespace GitHub.ViewModels.Dialog
                 (x, y) => x.Value || y.Value
             ).ToProperty(this, vm => vm.IsLoginInProgress);
 
-            UpdateLoginMode();
-            connectionManager.Connections.CollectionChanged += (_, __) => UpdateLoginMode();
+            LoginMode = LoginMode.DotComOrEnterprise;
 
             Done = Observable.Merge(
                 loginToGitHubViewModel.Login,
@@ -55,21 +52,5 @@ namespace GitHub.ViewModels.Dialog
         public bool IsLoginInProgress { get { return isLoginInProgress.Value; } }
 
         public IObservable<object> Done { get; }
-
-        void UpdateLoginMode()
-        {
-            var result = LoginMode.DotComOrEnterprise;
-
-            foreach (var connection in ConnectionManager.Connections)
-            {
-                if (connection.IsLoggedIn)
-                {
-                    result &= ~((connection.HostAddress == HostAddress.GitHubDotComHostAddress) ?
-                        LoginMode.DotComOnly : LoginMode.EnterpriseOnly);
-                }
-            }
-
-            LoginMode = result;
-        }
     }
 }

--- a/test/GitHub.App.UnitTests/ViewModels/Dialog/LoginCredentialsViewModelTests.cs
+++ b/test/GitHub.App.UnitTests/ViewModels/Dialog/LoginCredentialsViewModelTests.cs
@@ -76,8 +76,10 @@ public class LoginCredentialsViewModelTests
     public class TheLoginModeProperty : TestBaseClass
     {
         [Test]
-        public void LoginModeTracksAvailableConnections()
+        public void LoginModeIgnoresAvailableConnections()
         {
+            // We always want to option to log-in to GitHub or GitHub Enterprise
+
             var connectionManager = Substitute.For<IConnectionManager>();
             var connections = new ObservableCollectionEx<IConnection>();
             var gitHubLogin = Substitute.For<ILoginToGitHubViewModel>();
@@ -96,13 +98,13 @@ public class LoginCredentialsViewModelTests
             Assert.That(LoginMode.DotComOrEnterprise, Is.EqualTo(loginViewModel.LoginMode));
 
             connections.Add(enterpriseConnection);
-            Assert.That(LoginMode.DotComOnly, Is.EqualTo(loginViewModel.LoginMode));
+            Assert.That(LoginMode.DotComOrEnterprise, Is.EqualTo(loginViewModel.LoginMode));
 
             connections.Add(gitHubConnection);
-            Assert.That(LoginMode.None, Is.EqualTo(loginViewModel.LoginMode));
+            Assert.That(LoginMode.DotComOrEnterprise, Is.EqualTo(loginViewModel.LoginMode));
 
             connections.RemoveAt(0);
-            Assert.That(LoginMode.EnterpriseOnly, Is.EqualTo(loginViewModel.LoginMode));
+            Assert.That(LoginMode.DotComOrEnterprise, Is.EqualTo(loginViewModel.LoginMode));
         }
     }
 


### PR DESCRIPTION
Default to GitHub login, even when already authenticated. User might want to authenticate as a different user. Having the default change can be confusing.

- Set default `LoginMode` to `LoginMode.DotComOrEnterprise`

Fixes #2478 