### PR TITLE
Add navigation from GitHub tool window to repository

### DIFF
--- a/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
+++ b/src/GitHub.App/ViewModels/GitHubPane/GitHubPaneViewModel.cs
@@ -160,6 +160,14 @@ namespace GitHub.ViewModels.GitHubPane
                 },
                 currentPage.Select(x => x is IOpenInBrowser));
 
+            BrowseRepository = ReactiveCommand.Create(
+                () =>
+                {
+                    var url = LocalRepository.CloneUrl.ToRepositoryUrl();
+                    if (url != null) browser.OpenUrl(url);
+                },
+                currentPage.Select(x => x is IOpenInBrowser));
+
             help = ReactiveCommand.Create(() => { });
             help.Subscribe(_ =>
             {
@@ -531,5 +539,7 @@ namespace GitHub.ViewModels.GitHubPane
             var routeFormat = "^" + new Regex("(:([a-z]+))\\b").Replace(route, @"(?<$2>[\w_.\-=]+)") + "$";
             return new Regex(routeFormat, RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
         }
+
+        public ReactiveCommand<Unit, Unit> BrowseRepository { get; }
     }
 }

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/GitHubPaneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/GitHubPaneView.xaml
@@ -57,7 +57,7 @@
       <Separator Margin="5,-2,5,0"
                  Foreground="{DynamicResource GitHubPaneTitleBrush}"
                  Style="{StaticResource TitleVerticalSeparator}" />
-            <ghfvs:GitHubActionLink Margin="0,-2,0,0" Command="{Binding BrowseRepository}" Content="{Binding LocalRepository.Name}" />
+            <ghfvs:GitHubActionLink Margin="0,-2.5,0,0" Command="{Binding BrowseRepository}" Content="{Binding LocalRepository.Name}" />
         </StackPanel>
 
     <Separator Margin="0,0,0,2"

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/GitHubPaneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/GitHubPaneView.xaml
@@ -57,7 +57,7 @@
       <Separator Margin="5,-2,5,0"
                  Foreground="{DynamicResource GitHubPaneTitleBrush}"
                  Style="{StaticResource TitleVerticalSeparator}" />
-            <ghfvs:GitHubActionLink Margin="0,-5,0,0" Command="{Binding BrowseRepository}" Content="{Binding LocalRepository.Name}" />
+            <ghfvs:GitHubActionLink Margin="0,-2,0,0" Command="{Binding BrowseRepository}" Content="{Binding LocalRepository.Name}" />
         </StackPanel>
 
     <Separator Margin="0,0,0,2"

--- a/src/GitHub.VisualStudio.UI/Views/GitHubPane/GitHubPaneView.xaml
+++ b/src/GitHub.VisualStudio.UI/Views/GitHubPane/GitHubPaneView.xaml
@@ -57,11 +57,8 @@
       <Separator Margin="5,-2,5,0"
                  Foreground="{DynamicResource GitHubPaneTitleBrush}"
                  Style="{StaticResource TitleVerticalSeparator}" />
-      <TextBlock Margin="0,-5,0,0"
-                 VerticalAlignment="Center"
-                 Foreground="{DynamicResource GitHubVsGrayText}"
-                 Text="{Binding LocalRepository.Name}" />
-    </StackPanel>
+            <ghfvs:GitHubActionLink Margin="0,-5,0,0" Command="{Binding BrowseRepository}" Content="{Binding LocalRepository.Name}" />
+        </StackPanel>
 
     <Separator Margin="0,0,0,2"
                DockPanel.Dock="Top"


### PR DESCRIPTION
Add navigation from GitHub tool window to the active repository. This is an alternative to using the repository link on the `Team Explorer - Home` page.

### Screenshots

After

![image](https://user-images.githubusercontent.com/11719160/76708141-83562f80-66ec-11ea-8fd2-3c2e562f8482.png)

Before

![image](https://user-images.githubusercontent.com/11719160/76707757-f316eb00-66e9-11ea-8592-18db385b5a33.png)

Team Explorer - Home

![image](https://user-images.githubusercontent.com/11719160/76708192-d6c87d80-66ec-11ea-8814-6a08344859ae.png)
