### PR TITLE
Use PullRequest.timelineItems instead of PullRequest.timeline

### DIFF
--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -306,7 +306,6 @@ namespace GitHub.InlineReviews.Services
         async Task<PullRequestDetailModel> ReadPullRequestDetailWithResolved(HostAddress address, string owner,
             string name, int number, bool refresh)
         {
-
             if (readPullRequestWithResolved == null)
             {
                 readPullRequestWithResolved = new Query()
@@ -384,22 +383,22 @@ namespace GitHub.InlineReviews.Services
                                 AvatarUrl = review.Author.AvatarUrl(null)
                             }
                         }).ToList(),
-                        Timeline = pr.Timeline(null, null, null, null, null).AllPages().Select(item => item.Switch<object>(when =>
-                            when.Commit(commit => new CommitModel
+                        Timeline = pr.TimelineItems(null, null, null, null, null, null, null).AllPages().Select(item => item.Switch<object>(when =>
+                            when.PullRequestCommit(commit => new CommitModel
                             {
-                                AbbreviatedOid = commit.AbbreviatedOid,
+                                AbbreviatedOid = commit.Commit.AbbreviatedOid,
                                 Author = new CommitActorModel
                                 {
-                                    Name = commit.Author.Name,
-                                    Email = commit.Author.Email,
-                                    User = commit.Author.User != null ? new ActorModel
+                                    Name = commit.Commit.Author.Name,
+                                    Email = commit.Commit.Author.Email,
+                                    User = commit.Commit.Author.User != null ? new ActorModel
                                     {
-                                        Login = commit.Author.User.Login,
-                                        AvatarUrl = commit.Author.User.AvatarUrl(null),
+                                        Login = commit.Commit.Author.User.Login,
+                                        AvatarUrl = commit.Commit.Author.User.AvatarUrl(null),
                                     } : null
                                 },
-                                MessageHeadline = commit.MessageHeadline,
-                                Oid = commit.Oid,
+                                MessageHeadline = commit.Commit.MessageHeadline,
+                                Oid = commit.Commit.Oid,
                             }).IssueComment(comment => new CommentModel
                             {
                                 Author = new ActorModel
@@ -563,21 +562,21 @@ namespace GitHub.InlineReviews.Services
                                 Url = comment.Url,
                             }).ToList(),
                         }).ToList(),
-                        Timeline = pr.Timeline(null, null, null, null, null).AllPages().Select(item => item.Switch<object>(when =>
-                            when.Commit(commit => new CommitModel
+                        Timeline = pr.TimelineItems(null, null, null, null, null, null, null).AllPages().Select(item => item.Switch<object>(when =>
+                            when.PullRequestCommit(commit => new CommitModel
                             {
-                                AbbreviatedOid = commit.AbbreviatedOid,
+                                AbbreviatedOid = commit.Commit.AbbreviatedOid,
                                 Author = new CommitActorModel {
-                                    Name = commit.Author.Name,
-                                    Email = commit.Author.Email,
-                                    User = commit.Author.User != null ? new ActorModel
+                                    Name = commit.Commit.Author.Name,
+                                    Email = commit.Commit.Author.Email,
+                                    User = commit.Commit.Author.User != null ? new ActorModel
                                     {
-                                        Login = commit.Author.User.Login,
-                                        AvatarUrl = commit.Author.User.AvatarUrl(null),
+                                        Login = commit.Commit.Author.User.Login,
+                                        AvatarUrl = commit.Commit.Author.User.AvatarUrl(null),
                                     } : null
                                 },
-                                MessageHeadline = commit.MessageHeadline,
-                                Oid = commit.Oid,
+                                MessageHeadline = commit.Commit.MessageHeadline,
+                                Oid = commit.Commit.Oid,
                             }).IssueComment(comment => new CommentModel
                             {
                                 Author = new ActorModel

--- a/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
+++ b/src/GitHub.InlineReviews/Services/PullRequestSessionService.cs
@@ -306,6 +306,8 @@ namespace GitHub.InlineReviews.Services
         async Task<PullRequestDetailModel> ReadPullRequestDetailWithResolved(HostAddress address, string owner,
             string name, int number, bool refresh)
         {
+            var itemTypes = new[] { PullRequestTimelineItemsItemType.IssueComment, PullRequestTimelineItemsItemType.PullRequestCommit };
+
             if (readPullRequestWithResolved == null)
             {
                 readPullRequestWithResolved = new Query()
@@ -383,7 +385,7 @@ namespace GitHub.InlineReviews.Services
                                 AvatarUrl = review.Author.AvatarUrl(null)
                             }
                         }).ToList(),
-                        Timeline = pr.TimelineItems(null, null, null, null, null, null, null).AllPages().Select(item => item.Switch<object>(when =>
+                        Timeline = pr.TimelineItems(null, null, null, null, itemTypes, null, null).AllPages().Select(item => item.Switch<object>(when =>
                             when.PullRequestCommit(commit => new CommitModel
                             {
                                 AbbreviatedOid = commit.Commit.AbbreviatedOid,
@@ -490,6 +492,8 @@ namespace GitHub.InlineReviews.Services
         async Task<PullRequestDetailModel> ReadPullRequestDetailWithoutResolved(HostAddress address, string owner,
             string name, int number, bool refresh)
         {
+            var itemTypes = new[] { PullRequestTimelineItemsItemType.IssueComment, PullRequestTimelineItemsItemType.PullRequestCommit };
+
             if (readPullRequestWithoutResolved == null)
             {
                 readPullRequestWithoutResolved = new Query()
@@ -562,7 +566,7 @@ namespace GitHub.InlineReviews.Services
                                 Url = comment.Url,
                             }).ToList(),
                         }).ToList(),
-                        Timeline = pr.TimelineItems(null, null, null, null, null, null, null).AllPages().Select(item => item.Switch<object>(when =>
+                        Timeline = pr.TimelineItems(null, null, null, null, itemTypes, null, null).AllPages().Select(item => item.Switch<object>(when =>
                             when.PullRequestCommit(commit => new CommitModel
                             {
                                 AbbreviatedOid = commit.Commit.AbbreviatedOid,


### PR DESCRIPTION
The the deprecated `PullRequest.timeline` field is going away soon. When it does, [this](https://github.com/github/VisualStudio/issues/2481) will happen. Convert to using the modern `PullRequest.timelineItems` field.

## Todo

- [x] Only fetch pull request comments and commits.

### How to test

- [x] Open pull request details view
- [x] Open pull request timeline page
- [x] Check that pull request comments and commits appear as expected

Seems to be working...

![image](https://user-images.githubusercontent.com/11719160/76952402-f2a66c00-6904-11ea-8e7d-d3364a586aa0.png)

### Notes

Thanks @parto, @xuorig, @rmosolgo and @nplasterer for the heads up about this!

Fixes #2481