### PR TITLE
Fix detecting GitHub Enterprise Server behind a HAProxy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,8 @@ jobs:
     - name: Run unit tests
       shell: bash
       run: |
-        vstest.console /TestAdapterPath:test /Settings:test/test.runsettings \
+        vstest.console /TestAdapterPath:test /Settings:test/test.runsettings \        
+          test/GitHub.Api.UnitTests/bin/${{ env.config }}/net46/GitHub.Api.UnitTests.dll \
           test/GitHub.App.UnitTests/bin/${{ env.config }}/net46/GitHub.App.UnitTests.dll \
           test/GitHub.Exports.Reactive.UnitTests/bin/${{ env.config }}/net46/GitHub.Exports.Reactive.UnitTests.dll \
           test/GitHub.Exports.UnitTests/bin/${{ env.config }}/net46/GitHub.Exports.UnitTests.dll \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Run unit tests
       shell: bash
       run: |
-        vstest.console /TestAdapterPath:test /Settings:test/test.runsettings \        
+        vstest.console /TestAdapterPath:test /Settings:test/test.runsettings \
           test/GitHub.Api.UnitTests/bin/${{ env.config }}/net46/GitHub.Api.UnitTests.dll \
           test/GitHub.App.UnitTests/bin/${{ env.config }}/net46/GitHub.App.UnitTests.dll \
           test/GitHub.Exports.Reactive.UnitTests/bin/${{ env.config }}/net46/GitHub.Exports.Reactive.UnitTests.dll \

--- a/src/GitHub.Api/LoginManager.cs
+++ b/src/GitHub.Api/LoginManager.cs
@@ -346,9 +346,14 @@ namespace GitHub.Api
             var response = await client.Connection.Get<User>(
                 UserEndpoint, null, null).ConfigureAwait(false);
 
-            if (response.HttpResponse.Headers.ContainsKey(ScopesHeader))
+            var scopes = response.HttpResponse.Headers
+                .Where(h => string.Equals(h.Key, ScopesHeader, StringComparison.OrdinalIgnoreCase))
+                .Select(h => h.Value)
+                .FirstOrDefault();
+
+            if (scopes != null)
             {
-                var returnedScopes = new ScopesCollection(response.HttpResponse.Headers[ScopesHeader]
+                var returnedScopes = new ScopesCollection(scopes
                     .Split(',')
                     .Select(x => x.Trim())
                     .ToArray());

--- a/src/GitHub.Exports/ExceptionExtensions.cs
+++ b/src/GitHub.Exports/ExceptionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Octokit;
 
 namespace GitHub.Extensions
@@ -9,8 +10,7 @@ namespace GitHub.Extensions
         public static bool IsGitHubApiException(this Exception ex)
         {
             var apiex = ex as ApiException;
-            return apiex?.HttpResponse?.Headers.ContainsKey(GithubHeader) ?? false;
+            return apiex?.HttpResponse?.Headers.Keys.Contains(GithubHeader, StringComparer.OrdinalIgnoreCase) ?? false;
         }
     }
-
 }

--- a/test/GitHub.Exports.UnitTests/ApiExceptionExtensionsTests.cs
+++ b/test/GitHub.Exports.UnitTests/ApiExceptionExtensionsTests.cs
@@ -11,6 +11,7 @@ public class ApiExceptionExtensionsTests
     {
         [TestCase("Not-GitHub-Request-Id", false)]
         [TestCase("X-GitHub-Request-Id", true)]
+        [TestCase("x-github-request-id", true)]
         public void NoGitHubRequestId(string key, bool expect)
         {
             var ex = CreateApiException(new Dictionary<string, string> { { key, "ANYTHING" } });

--- a/test/GitHub.Exports.UnitTests/ApiExceptionExtensionsTests.cs
+++ b/test/GitHub.Exports.UnitTests/ApiExceptionExtensionsTests.cs
@@ -20,6 +20,16 @@ public class ApiExceptionExtensionsTests
 
             Assert.That(result, Is.EqualTo(expect));
         }
+        
+        [Test]
+        public void NoResponse()
+        {
+            var ex = new ApiException();
+
+            var result = ApiExceptionExtensions.IsGitHubApiException(ex);
+
+            Assert.That(result, Is.EqualTo(false));
+        }
 
         static ApiException CreateApiException(Dictionary<string, string> headers)
         {

--- a/test/GitHub.Exports.UnitTests/ApiExceptionExtensionsTests.cs
+++ b/test/GitHub.Exports.UnitTests/ApiExceptionExtensionsTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using Octokit;
+using NSubstitute;
+using NUnit.Framework;
+using GitHub.Extensions;
+
+public class ApiExceptionExtensionsTests
+{
+    public class TheIsGitHubApiExceptionMethod
+    {
+        [TestCase("Not-GitHub-Request-Id", false)]
+        [TestCase("X-GitHub-Request-Id", true)]
+        public void NoGitHubRequestId(string key, bool expect)
+        {
+            var ex = CreateApiException(new Dictionary<string, string> { { key, "ANYTHING" } });
+
+            var result = ApiExceptionExtensions.IsGitHubApiException(ex);
+
+            Assert.That(result, Is.EqualTo(expect));
+        }
+
+        static ApiException CreateApiException(Dictionary<string, string> headers)
+        {
+            var response = Substitute.For<IResponse>();
+            response.Headers.Returns(headers.ToImmutableDictionary());
+            var ex = new ApiException(response);
+            return ex;
+        }
+    }
+}


### PR DESCRIPTION
The `X-GitHub-Request-Id` header is used to check whether an error is returned from a GitHub or GitHub Enterprise server instance. If the server is behind a HAProxy, the header will be converted to lower case. We were only checking for a case sensitive `X-GitHub-Request-Id` header and not detecting GHES instances behind a HAProxy proxy.

### What this PR does

- Check any casing of the `X-GitHub-Request-Id` header

### Credits

This bug was discovered and documented by @osmanager in #2560. Thankyou!

### Related

- Handle case insensitive headers when parsing for API rate limiting
octokit/octokit.net#2175

Fixes #2560