### PR TITLE
Direct users to GitHub support rather than issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,45 +1,5 @@
----
-name: Bug report
-about: Create a report to help us improve GitHub Extension for Visual Studio
-labels: 
+Please report GitHub for Visual Studio bugs here:
+https://support.github.com/contact/bug-report?subject=Re:%20GitHub%20for%20Visual%20Studio
 
----
-
-<!-- Hello! Please read the [Contributing Guidelines](https://github.com/github/VisualStudio/blob/master/CONTRIBUTING.md) before submitting an issue regarding the GitHub Extension for Visual Studio. -->
-
-## Versions
- - GitHub Extension for Visual Studio version: ...
- - Visual Studio version: ...
-
-## What happened
-<!--A clear and concise description of what the bug is.-->
-
-### Steps to Reproduce
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
-### Expected behavior
-<!--A clear and concise description of what you expected to happen.-->
-
-### Screenshots
-<!--If applicable, add screenshots to help explain your problem.-->
-
-### Logs
-<!--If applicable, add logs. To include log files:
-  1. Close Visual Studio if it's open
-  2. Open a Developer Command Prompt for VS2015
-  3. Run devenv /log
-  4. Reproduce your issue
-  5. Close VS
-  6. Locate the following files on your system and email them to windows@github.com or create a gist and link it in the issue report:
-   - `%appdata%\Microsoft\VisualStudio\14.0\ActivityLog.xml`
-   - `%localappdata%\temp\extension.log`
-   - `%localappdata%\GitHubVisualStudio\extension.log`
-   - Windows Event Viewer
--->
-
-### Additional context
-<!--Add any other context about the problem here.-->
+Please report Visual Studio bugs here:
+https://developercommunity.visualstudio.com/search


### PR DESCRIPTION
Issues in this repo are no longer being monitored. We should direct users to the most appropriate forum.